### PR TITLE
Added integration test for multiple labels and removed labels string as argument.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -156,7 +156,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
                     break;
                 }
 
-                final ComputeEngineInstance node = config.provision(StreamTaskListener.fromStdout(), config.getLabelString());
+                final ComputeEngineInstance node = config.provision(StreamTaskListener.fromStdout());
                 Jenkins.getInstance().addNode(node);
                 r.add(new PlannedNode(node.getNodeName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
                     public Node call() throws Exception {
@@ -223,14 +223,6 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
         }
     }
 
-    private synchronized ComputeEngineInstance getAnAgent(InstanceConfiguration config, String labels) {
-        try {
-            return config.provision(StreamTaskListener.fromStdout(), labels);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
     @Override
     public boolean canProvision(Label label) {
         try {
@@ -285,7 +277,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
             throw HttpResponses.error(SC_BAD_REQUEST, "No such Instance Configuration: " + configuration);
         }
 
-        ComputeEngineInstance node = c.provision(StreamTaskListener.fromStdout(), null);
+        ComputeEngineInstance node = c.provision(StreamTaskListener.fromStdout());
         if (node == null)
             throw HttpResponses.error(SC_BAD_REQUEST, "Could not provision new node.");
         Jenkins.getInstance().addNode(node);

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -156,7 +156,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
                     break;
                 }
 
-                final ComputeEngineInstance node = config.provision(StreamTaskListener.fromStdout(), label);
+                final ComputeEngineInstance node = config.provision(StreamTaskListener.fromStdout(), config.getLabelString());
                 Jenkins.getInstance().addNode(node);
                 r.add(new PlannedNode(node.getNodeName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
                     public Node call() throws Exception {
@@ -223,9 +223,9 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
         }
     }
 
-    private synchronized ComputeEngineInstance getAnAgent(InstanceConfiguration config, Label requiredLabel) {
+    private synchronized ComputeEngineInstance getAnAgent(InstanceConfiguration config, String labels) {
         try {
-            return config.provision(StreamTaskListener.fromStdout(), requiredLabel);
+            return config.provision(StreamTaskListener.fromStdout(), labels);
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -273,7 +273,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         googleLabels.put(key, value);
     }
 
-    public ComputeEngineInstance provision(TaskListener listener, Label requiredLabel) throws IOException {
+    public ComputeEngineInstance provision(TaskListener listener, String labels) throws IOException {
         PrintStream logger = listener.getLogger();
         try {
             Instance i = instance();
@@ -302,7 +302,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                     windowsConfig,
                     numExecutors, 
                     mode, 
-                    requiredLabel == null ? "" : requiredLabel.getName(),
+                    labels,
                     launcher,
                     new CloudRetentionStrategy(retentionTimeMinutes), 
                     getLaunchTimeoutMillis());

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -28,6 +28,7 @@ import com.google.api.services.compute.model.*;
 import com.google.common.base.Strings;
 import com.google.jenkins.plugins.computeengine.client.ClientFactory;
 import com.google.jenkins.plugins.computeengine.client.ComputeClient;
+import com.google.common.collect.ImmutableList;
 import hudson.Extension;
 import hudson.RelativePath;
 import hudson.Util;
@@ -273,7 +274,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         googleLabels.put(key, value);
     }
 
-    public ComputeEngineInstance provision(TaskListener listener, String labels) throws IOException {
+    public ComputeEngineInstance provision(TaskListener listener) throws IOException {
         PrintStream logger = listener.getLogger();
         try {
             Instance i = instance();

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -28,7 +28,6 @@ import com.google.api.services.compute.model.*;
 import com.google.common.base.Strings;
 import com.google.jenkins.plugins.computeengine.client.ClientFactory;
 import com.google.jenkins.plugins.computeengine.client.ComputeClient;
-import com.google.common.collect.ImmutableList;
 import hudson.Extension;
 import hudson.RelativePath;
 import hudson.Util;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -233,7 +233,7 @@ public class ComputeEngineCloudIT {
     }
 
     @Test(timeout = 300000)
-    public void testMultipleLabels() throws Exception {
+    public void testMultipleLabelsForJob() throws Exception {
         // For a configuration with multiple labels, test if job label matches one of the configuration's labels
         logOutput.reset();
 
@@ -245,6 +245,22 @@ public class ComputeEngineCloudIT {
 
         // There should be a planned node
         assertEquals(logs(), 1, planned.size());
+    }
+
+    @Test(timeout = 300000)
+    public void testMultipleLabelsInConfig() throws Exception {
+        // For a configuration with multiple labels, test if job label matches one of the configuration's labels
+        logOutput.reset();
+
+        ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
+        InstanceConfiguration ic = instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, NUM_EXECUTORS, MULTIPLE_LABEL);
+        cloud.addConfiguration(ic);
+        // Add a new node
+        Collection<NodeProvisioner.PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 1);
+
+        String provisionedLabels = planned.iterator().next().future.get().getLabelString();
+        // There should be a planned node TODO
+        assertEquals(logs(), MULTIPLE_LABEL, provisionedLabels);
     }
 
     @Test(timeout = 300000)

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -65,6 +65,7 @@ public class ComputeEngineCloudIT {
     private static final String ZONE = "us-west1-a";
     private static final String ZONE_BASE = format("projects/%s/zones/" + ZONE);
     private static final String LABEL = "integration";
+    private static final String MULTIPLE_LABEL = "integration test";
     private static final String MACHINE_TYPE = ZONE_BASE + "/machineTypes/n1-standard-1";
     private static final String NUM_EXECUTORS = "1";
     private static final String MULTIPLE_NUM_EXECUTORS = "2";
@@ -232,6 +233,21 @@ public class ComputeEngineCloudIT {
     }
 
     @Test(timeout = 300000)
+    public void testMultipleLabels() throws Exception {
+        // For a configuration with multiple labels, test if job label matches one of the configuration's labels
+        logOutput.reset();
+
+        ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
+        InstanceConfiguration ic = instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, NUM_EXECUTORS, MULTIPLE_LABEL);
+        cloud.addConfiguration(ic);
+        // Add a new node
+        Collection<NodeProvisioner.PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 1);
+
+        // There should be a planned node
+        assertEquals(logs(), 1, planned.size());
+    }
+
+    @Test(timeout = 300000)
     public void testWorkerFailed() throws Exception {
         //TODO: each test method should probably have its own handler.
         logOutput.reset();
@@ -253,7 +269,7 @@ public class ComputeEngineCloudIT {
     }
 
     private static InstanceConfiguration validInstanceConfiguration1(String numExecutors) {
-        return instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, numExecutors);
+        return instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, numExecutors, LABEL);
     }
 
     /**
@@ -262,10 +278,10 @@ public class ComputeEngineCloudIT {
      * @return
      */
     private static InstanceConfiguration invalidInstanceConfiguration1() {
-        return instanceConfiguration("", NUM_EXECUTORS);
+        return instanceConfiguration("", NUM_EXECUTORS, LABEL);
     }
 
-    private static InstanceConfiguration instanceConfiguration(String startupScript, String numExecutors) {
+    private static InstanceConfiguration instanceConfiguration(String startupScript, String numExecutors, String labels) {
         InstanceConfiguration ic = new InstanceConfiguration(
                 NAME_PREFIX,
                 REGION,
@@ -275,7 +291,7 @@ public class ComputeEngineCloudIT {
                 startupScript,
                 PREEMPTIBLE,
                 MIN_CPU_PLATFORM,
-                LABEL,
+                labels,
                 CONFIG_DESC,
                 BOOT_DISK_TYPE,
                 BOOT_DISK_AUTODELETE,


### PR DESCRIPTION
Referencing https://github.com/jenkinsci/google-compute-engine-plugin/pull/3.

Changes:
- Labels do not need to be passed to InstanceConfiguration since it already has labels it needs to pass to ComputeEngineInstance.
- Removed getAnAgent since it is never called.
- Added an integration test to test if an instance with multiple labels still matched a job with only one of its labels.

Testing: 
Ran unit and integration tests. Passed.