### PR TITLE
Increase test timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
-        <jenkinsRuleTimeout>-Djenkins.test.timeout=480</jenkinsRuleTimeout>
+        <jenkinsRuleTimeout>480</jenkinsRuleTimeout>
         <java.level>8</java.level>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -137,7 +137,7 @@
                     <excludes>
                         <exclude>**/ComputeEngineCloudWindowsIT.java</exclude>
                     </excludes>
-                    <argLine>${jenkinsRuleTimeout}</argLine>
+                    <argLine>-Djenkins.test.timeout=${jenkinsRuleTimeout}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
+        <jenkinsRuleTimeout>-Djenkins.test.timeout=480</jenkinsRuleTimeout>
         <java.level>8</java.level>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -114,9 +115,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.20.1</version>
-                    <configuration>
-                        <argLine>-Djenkins.test.timeout=480</argLine>
-                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -139,6 +137,7 @@
                     <excludes>
                         <exclude>**/ComputeEngineCloudWindowsIT.java</exclude>
                     </excludes>
+                    <argLine>${jenkinsRuleTimeout}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.20.1</version>
+                    <configuration>
+                        <argLine>-Djenkins.test.timeout=480</argLine>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Currently, JenkinsRule in integration tests automatically times out at 180 seconds. This was not enough time to run our integration tests since we provision a good number of nodes.
I have made a change to the pom file that feeds in an argument to specify timeout.
I've set a timeout at twice the length it takes me to run both unit and integration tests.

Ran mvn verify and build success.