### PR TITLE
Fixed null issues with instance labels from template

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -339,12 +339,11 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         if (StringUtils.isNotEmpty(template)) {
             // TODO: JENKINS-55285
             InstanceTemplate instanceTemplate = cloud.client.getTemplate(nameFromSelfLink(cloud.projectId), nameFromSelfLink(template));
-            Map<String, String> templateLabels = instanceTemplate.getProperties().getLabels();
-            Map<String, String> mergedLabels = new HashMap<>(templateLabels);
-            mergedLabels.putAll(googleLabels);
-            instance.setLabels(mergedLabels);
+            if (instanceTemplate.getProperties().getLabels() != null) {
+                Map<String, String> templateLabels = instanceTemplate.getProperties().getLabels();
+                appendLabels(templateLabels);
+            }
         } else {
-            instance.setLabels(googleLabels);
             instance.setMachineType(stripSelfLinkPrefix(machineType));
             instance.setMetadata(metadata());
             instance.setTags(tags());
@@ -359,6 +358,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                 instance.setMinCpuPlatform(minCpuPlatform);
             }
         }
+        instance.setLabels(googleLabels);
         return instance;
     }
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -339,11 +339,14 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         if (StringUtils.isNotEmpty(template)) {
             // TODO: JENKINS-55285
             InstanceTemplate instanceTemplate = cloud.client.getTemplate(nameFromSelfLink(cloud.projectId), nameFromSelfLink(template));
+            Map<String, String> mergedLabels = new HashMap<>(googleLabels);
             if (instanceTemplate.getProperties().getLabels() != null) {
                 Map<String, String> templateLabels = instanceTemplate.getProperties().getLabels();
-                appendLabels(templateLabels);
+                mergedLabels.putAll(templateLabels);
             }
+            instance.setLabels(mergedLabels);
         } else {
+            instance.setLabels(googleLabels);
             instance.setMachineType(stripSelfLinkPrefix(machineType));
             instance.setMetadata(metadata());
             instance.setTags(tags());
@@ -358,7 +361,6 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                 instance.setMinCpuPlatform(minCpuPlatform);
             }
         }
-        instance.setLabels(googleLabels);
         return instance;
     }
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -314,31 +314,7 @@ public class ComputeEngineCloudIT {
         ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
         cloud.addConfiguration(validInstanceConfigurationWithTemplate(TEMPLATE));
         try {
-            InstanceTemplate instanceTemplate = new InstanceTemplate();
-            instanceTemplate.setName(nameFromSelfLink(TEMPLATE));
-            InstanceProperties instanceProperties = new InstanceProperties();
-            instanceProperties.setMachineType(nameFromSelfLink(MACHINE_TYPE));
-            instanceProperties.setLabels(ImmutableMap.of("test-label", "label-value"));
-            AttachedDisk boot = new AttachedDisk();
-            boot.setBoot(true);
-            boot.setAutoDelete(BOOT_DISK_AUTODELETE);
-            boot.setInitializeParams(new AttachedDiskInitializeParams()
-                    .setDiskSizeGb(Long.parseLong(BOOT_DISK_SIZE_GB_STR))
-                    .setDiskType(nameFromSelfLink(BOOT_DISK_TYPE))
-                    .setSourceImage(BOOT_DISK_IMAGE_NAME)
-            );
-            instanceProperties.setDisks(of(boot));
-            instanceProperties.setTags(new Tags().setItems(of(NETWORK_TAGS)));
-            instanceProperties.setMetadata(new Metadata().setItems(of(new Metadata.Items()
-                    .setKey(METADATA_LINUX_STARTUP_SCRIPT_KEY).setValue(DEB_JAVA_STARTUP_SCRIPT))));
-            instanceProperties.setNetworkInterfaces(of(new NetworkInterface()
-                    .setName(NETWORK_NAME)
-                    .setAccessConfigs(of(new AccessConfig()
-                            .setType(NAT_TYPE)
-                            .setName(NAT_NAME)
-                    ))
-            ));
-            instanceTemplate.setProperties(instanceProperties);
+            InstanceTemplate instanceTemplate = createTemplate(ImmutableMap.of("test-label", "label-value"));
             client.insertTemplate(cloud.projectId, instanceTemplate);
 
             // Add a new node
@@ -365,6 +341,55 @@ public class ComputeEngineCloudIT {
         }
     }
 
+    @Test(timeout = 300000)
+    public void testTemplateNoGoogleLabels() throws Exception {
+        ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
+        cloud.addConfiguration(validInstanceConfigurationWithTemplate(TEMPLATE));
+        try {
+            InstanceTemplate instanceTemplate = createTemplate(null);
+            client.insertTemplate(cloud.projectId, instanceTemplate);
+
+            // Add a new node
+            Collection<NodeProvisioner.PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 1);
+
+            // There should be a successful planned node even without google labels
+            assertEquals(logs(), 1, planned.size());
+        } finally {
+            try {
+                client.deleteTemplate(cloud.projectId, nameFromSelfLink(TEMPLATE));
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    private static InstanceTemplate createTemplate(Map<String, String> googleLabels) {
+        InstanceTemplate instanceTemplate = new InstanceTemplate();
+        instanceTemplate.setName(nameFromSelfLink(TEMPLATE));
+        InstanceProperties instanceProperties = new InstanceProperties();
+        instanceProperties.setMachineType(nameFromSelfLink(MACHINE_TYPE));
+        instanceProperties.setLabels(googleLabels);
+        AttachedDisk boot = new AttachedDisk();
+        boot.setBoot(true);
+        boot.setAutoDelete(BOOT_DISK_AUTODELETE);
+        boot.setInitializeParams(new AttachedDiskInitializeParams()
+                .setDiskSizeGb(Long.parseLong(BOOT_DISK_SIZE_GB_STR))
+                .setDiskType(nameFromSelfLink(BOOT_DISK_TYPE))
+                .setSourceImage(BOOT_DISK_IMAGE_NAME)
+        );
+        instanceProperties.setDisks(of(boot));
+        instanceProperties.setTags(new Tags().setItems(of(NETWORK_TAGS)));
+        instanceProperties.setMetadata(new Metadata().setItems(of(new Metadata.Items()
+                .setKey(METADATA_LINUX_STARTUP_SCRIPT_KEY).setValue(DEB_JAVA_STARTUP_SCRIPT))));
+        instanceProperties.setNetworkInterfaces(of(new NetworkInterface()
+                .setName(NETWORK_NAME)
+                .setAccessConfigs(of(new AccessConfig()
+                        .setType(NAT_TYPE)
+                        .setName(NAT_NAME)
+                ))
+        ));
+        instanceTemplate.setProperties(instanceProperties);
+        return instanceTemplate;
+    }
 
     private static InstanceConfiguration validInstanceConfiguration() {
         return instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, NUM_EXECUTORS, LABEL, NULL_TEMPLATE);


### PR DESCRIPTION
When testing https://github.com/jenkinsci/google-compute-engine-plugin/pull/12/ via the UI with an instance template I created, got nullPointerException when no label is provided by template.

Made a fix so that label is optional.

Testing
- tested with templates on both linux and windows with no labels in UI
- ran mvn verify, passed unit and integration tests