### PR TITLE
ci: add temporary pipeline support

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+fly -t jenkins set-pipeline \
+  -c pipeline.yml \
+  -v project_id=$PROJECT_ID \
+  -v service_account_json=$SERVICE_ACCOUNT_JSON \
+  -p compute-engine-plugin-develop

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,38 @@
+jobs:
+  - name: test-unit
+    serial: true
+    plan:
+      - get: plugin-master
+        trigger: true
+      - get: ci
+      - task: test-unit
+        file: ci/ci/tasks/test-unit.yml
+        input_mapping: {plugin: plugin-master}
+
+  - name: test-integration
+    serial: true
+    plan:
+      - get: plugin-master
+        passed: [test-unit]
+        trigger: true
+      - get: ci
+      - task: test-integration
+        file: ci/ci/tasks/test-integration.yml
+        input_mapping: {plugin: plugin-master}
+        params:
+          service_account_json: ((service_account_json))
+          project_id:           ((project_id))
+
+resources:
+- name: plugin-master
+  type: git
+  source:
+    uri: https://github.com/jenkinsci/google-compute-engine-plugin.git
+    branch: master
+- name: ci
+  type: git
+  source:
+    uri: https://github.com/jenkinsci/google-compute-engine-plugin.git
+    branch: master
+    paths:
+        - ci/*

--- a/ci/tasks/test-integration.sh
+++ b/ci/tasks/test-integration.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -u -x
+
+pushd plugin
+  mvn verify
+popd

--- a/ci/tasks/test-integration.yml
+++ b/ci/tasks/test-integration.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: maven
+    tag: '3.6.0-jdk-8-alpine'
+
+inputs:
+- name: plugin
+
+run:
+  path: plugin/ci/tasks/test-integration.sh
+
+params:
+  service_account_json: change-me
+  project_id:           change-me

--- a/ci/tasks/test-unit.sh
+++ b/ci/tasks/test-unit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -u -x
+
+pushd plugin
+  mvn test -e
+popd

--- a/ci/tasks/test-unit.yml
+++ b/ci/tasks/test-unit.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: maven
+    tag: '3.6.0-jdk-8-alpine'
+
+inputs:
+- name: plugin
+
+run:
+  path: plugin/ci/tasks/test-unit.sh


### PR DESCRIPTION
This commit adds temporary support for testing in Concourse. This is a
stop-gap measure until Jenkins infrastructure is in place to perform
similar functionality.