### PR TITLE
Combining one-shot with snapshot creation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.0.11-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
+        <jenkins.version>2.107.1</jenkins.version>
         <jenkinsRuleTimeout>0</jenkinsRuleTimeout>
         <java.level>8</java.level>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.0.11-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.107.1</jenkins.version>
+        <jenkins.version>2.7.3</jenkins.version>
         <jenkinsRuleTimeout>0</jenkinsRuleTimeout>
         <java.level>8</java.level>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputer.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputer.java
@@ -125,12 +125,6 @@ public class ComputeEngineComputer extends AbstractCloudComputer<ComputeEngineIn
             try {
                 ComputeEngineCloud cloud = getCloud();
 
-                // Checks for failed jobs for this computer's node
-                if (cloud != null && node.isCreateSnapshot() && !this.getBuilds().failureOnly().isEmpty()) {
-                    LOGGER.log(Level.INFO, "Creating snapshot for node ... " + node.getNodeName());
-                    cloud.getClient().createSnapshot(cloud.projectId, node.zone, node.getNodeName());
-                }
-
                 node.terminate();
             } catch (InterruptedException ie) {
                 // Termination Exception

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -293,6 +293,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             // TODO: JENKINS-55285
             Operation operation = cloud.client.insertInstance(cloud.projectId, template, instance);
             logger.println("Sent insert request");
+            logger.println("oneshot is " + this.oneShot);
             String targetRemoteFs = this.remoteFs;
             ComputeEngineComputerLauncher launcher = null;
             if (this.windows) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -177,7 +177,12 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         this.windowsPasswordCredentialsId = windowsPasswordCredentialsId;
         this.windowsPrivateKeyCredentialsId = windowsPrivateKeyCredentialsId;
 
-        this.createSnapshot = createSnapshot;
+        // We only create snapshots for one-shot instances
+        if (oneShot) {
+            this.createSnapshot = createSnapshot;
+        } else {
+            this.createSnapshot = false;
+        }
         this.minCpuPlatform = minCpuPlatform;
         this.numExecutors = intOrDefault(numExecutorsStr, DEFAULT_NUM_EXECUTORS);
         this.oneShot = oneShot;
@@ -852,6 +857,15 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                                                                     @QueryParameter("windowsPasswordCredentialsId") String windowsPasswordCredentialsId) {
             if (windows && (Strings.isNullOrEmpty(value) && Strings.isNullOrEmpty(windowsPasswordCredentialsId))) {
                 return FormValidation.error("A password or private key credential is required");
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckCreateSnapshot(@AncestorInPath Jenkins context,
+                                                                             @QueryParameter boolean value,
+                                                                             @QueryParameter("oneShot") boolean oneShot) {
+            if (!oneShot && value) {
+                return FormValidation.error("One-shot must be enabled to create snapshots");
             }
             return FormValidation.ok();
         }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -293,7 +293,6 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             // TODO: JENKINS-55285
             Operation operation = cloud.client.insertInstance(cloud.projectId, template, instance);
             logger.println("Sent insert request");
-            logger.println("oneshot is " + this.oneShot);
             String targetRemoteFs = this.remoteFs;
             ComputeEngineComputerLauncher launcher = null;
             if (this.windows) {
@@ -316,6 +315,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                     targetRemoteFs,
                     windowsConfig,
                     createSnapshot,
+                    oneShot,
                     numExecutors, 
                     mode, 
                     labels,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -865,7 +865,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                                                                              @QueryParameter boolean value,
                                                                              @QueryParameter("oneShot") boolean oneShot) {
             if (!oneShot && value) {
-                return FormValidation.error("One-shot must be enabled to create snapshots");
+                return FormValidation.error(Messages.InstanceConfiguration_SnapshotConfigError());
             }
             return FormValidation.ok();
         }

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -40,16 +40,13 @@
             <f:entry field="windowsPrivateKeyCredentialsId" title="${%Windows SSH Private Key Credentials}">
                 <c:select/>
             </f:entry>
-            <f:entry field="createSnapshot" title="${%Create Snapshot?}">
-                <f:checkbox/>
-            </f:entry>
         </f:section>
 
         <f:section title="One-Shot">
-            <f:entry title="${%Enabled}" field="oneShot">
+            <f:entry field="oneShot" title="${%Enabled}">
                 <f:checkbox/>
             </f:entry>
-            <f:entry field="${%createSnapshot?}" title="${%Create snapshot?}">
+            <f:entry field="createSnapshot" title="${%Create snapshot?}">
                 <f:checkbox/>
             </f:entry>
         </f:section>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -15,9 +15,6 @@
             <f:entry title="${%Node Retention Time (minutes)}" field="retentionTimeMinutesStr">
                 <f:textbox default="${descriptor.defaultRetentionTimeMinutes()}"/>
             </f:entry>
-            <f:entry title="${%One shot node?}" field="oneShot">
-                <f:checkbox/>
-            </f:entry>
             <f:slave-mode name="mode" node="${instance}"/>
             <f:entry title="${%Labels}" field="labelString">
                 <f:textbox/>
@@ -44,6 +41,15 @@
                 <c:select/>
             </f:entry>
             <f:entry field="createSnapshot" title="${%Create Snapshot?}">
+                <f:checkbox/>
+            </f:entry>
+        </f:section>
+
+        <f:section title="One-Shot">
+            <f:entry title="${%Enabled}" field="oneShot">
+                <f:checkbox/>
+            </f:entry>
+            <f:entry field="${%createSnapshot?}" title="${%Create snapshot?}">
                 <f:checkbox/>
             </f:entry>
         </f:section>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-createSnapshot.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-createSnapshot.html
@@ -1,5 +1,5 @@
 <div>
-    By checking this option, before your instance is deleted, a snapshot will be created if there were any failed
+    By checking this option, before your one-shot instance is deleted, a snapshot will be created if there were any failed
     builds on the instance.
     <p>
         See the <a href="https://cloud.google.com/compute/docs/disks/create-snapshots">Creating Snapshots</a>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-oneShot.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-oneShot.html
@@ -1,4 +1,4 @@
 <div>
-    Create One Shot instance.
-    Instances like that will be created before each request and deleted after each one.
+    <a href="https://wiki.jenkins.io/display/JENKINS/One-Shot+Executor">One-Shot</a> executors create nodes dedicated
+    to a single build. Upon completion of the build the node is terminated.
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
@@ -1,2 +1,3 @@
 ComputeEngineCloud.DisplayName=Google Compute Engine
 ComputeEngineAgent.DisplayName=Google Compute Engine
+InstanceConfiguration.SnapshotConfigError=One-shot must be enabled to create snapshots

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -135,6 +135,7 @@ public class ComputeEngineCloudIT {
     private static final String SERVICE_ACCOUNT_EMAIL = "";
     private static final String RETENTION_TIME_MINUTES_STR = "";
     private static final String LAUNCH_TIMEOUT_SECONDS_STR = "";
+    private static final int SNAPSHOT_TEST_TIMEOUT = 120;
 
     private static Logger cloudLogger;
     private static Logger clientLogger;
@@ -423,7 +424,7 @@ public class ComputeEngineCloudIT {
         Node worker = build.getBuiltOn();
 
         // Need time for one-shot instance to terminate and create the snapshot
-        Awaitility.await().timeout(60, TimeUnit.SECONDS).until(() -> r.jenkins.getNode(worker.getNodeName()) == null);
+        Awaitility.await().timeout(SNAPSHOT_TEST_TIMEOUT, TimeUnit.SECONDS).until(() -> r.jenkins.getNode(worker.getNodeName()) == null);
 
         assertNull(logs(), client.getSnapshot(projectId, worker.getNodeName()));
     }
@@ -446,7 +447,7 @@ public class ComputeEngineCloudIT {
 
         try {
             // Need time for one-shot instance to terminate and create the snapshot
-            Awaitility.await().timeout(60, TimeUnit.SECONDS).until(() -> r.jenkins.getNode(worker.getNodeName()) == null);
+            Awaitility.await().timeout(SNAPSHOT_TEST_TIMEOUT, TimeUnit.SECONDS).until(() -> r.jenkins.getNode(worker.getNodeName()) == null);
 
             Snapshot createdSnapshot = client.getSnapshot(projectId, worker.getNodeName());
             assertNotNull(logs(), createdSnapshot);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -9,7 +9,6 @@ import com.google.api.services.compute.model.Image;
 import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Snapshot;
-import com.google.common.base.Strings;
 import com.google.jenkins.plugins.computeengine.client.ClientFactory;
 import com.google.jenkins.plugins.computeengine.client.ComputeClient;
 import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyPair;
@@ -38,7 +37,6 @@ import java.util.logging.StreamHandler;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Integration test for launching windows VM. Tests that agents can be created properly.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -9,6 +9,7 @@ import com.google.api.services.compute.model.Image;
 import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Snapshot;
+import com.google.common.base.Strings;
 import com.google.jenkins.plugins.computeengine.client.ClientFactory;
 import com.google.jenkins.plugins.computeengine.client.ComputeClient;
 import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyPair;
@@ -22,12 +23,14 @@ import hudson.model.labels.LabelAtom;
 import hudson.slaves.NodeProvisioner;
 import hudson.tasks.Builder;
 import hudson.tasks.Shell;
+import org.awaitility.Awaitility;
 import org.junit.*;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
@@ -35,6 +38,7 @@ import java.util.logging.StreamHandler;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Integration test for launching windows VM. Tests that agents can be created properly.
@@ -197,7 +201,7 @@ public class ComputeEngineCloudWindowsIT {
         //TODO: each test method should probably have its own handler.
         logOutput.reset();
 
-        InstanceConfiguration ic = validInstanceConfiguration1(LABEL, false);
+        InstanceConfiguration ic = validInstanceConfiguration1(LABEL, false, false);
         ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
         cloud.addConfiguration(ic);
 
@@ -227,7 +231,7 @@ public class ComputeEngineCloudWindowsIT {
     }
 
     // Tests snapshot is created when we have failure builds for given node
-    // Snapshot creation is longer for windows vm's.
+    // Snapshot creation is longer for windows one-shot vm's.
     @Test(timeout = 0)
     public void testSnapshotCreated() throws Exception {
         logOutput.reset();
@@ -242,8 +246,10 @@ public class ComputeEngineCloudWindowsIT {
 
         FreeStyleBuild build = r.assertBuildStatus(Result.FAILURE, project.scheduleBuild2(0));
         Node worker = build.getBuiltOn();
+
         try {
-            r.jenkins.getNode(worker.getNodeName()).toComputer().doDoDelete();
+            // Need time for one-shot instance to terminate and create the snapshot
+            Awaitility.await().timeout(15, TimeUnit.MINUTES).until(() -> r.jenkins.getNode(worker.getNodeName()) == null);            // Assert that there is 0 nodes after job finished
 
             Snapshot createdSnapshot = client.getSnapshot(projectId, worker.getNodeName());
             assertNotNull(logs(), createdSnapshot);
@@ -263,7 +269,7 @@ public class ComputeEngineCloudWindowsIT {
      * @return InstanceConfiguration proper instance configuration to test snapshot creation.
      */
     private static InstanceConfiguration snapshotInstanceConfiguration() {
-        return validInstanceConfiguration1(SNAPSHOT_LABEL, true);
+        return validInstanceConfiguration1(SNAPSHOT_LABEL, true, true);
     }
 
     /**
@@ -273,7 +279,7 @@ public class ComputeEngineCloudWindowsIT {
      * @param createSnapshot Whether or not to create a snapshot for the provisioned instance upon deletion.
      * @return InstanceConfiguration working instance configuration to provision an instance.
      */
-    private static InstanceConfiguration validInstanceConfiguration1(String labels, boolean createSnapshot) {
+    private static InstanceConfiguration validInstanceConfiguration1(String labels, boolean createSnapshot, boolean oneShot) {
 
         String startupScript = "Stop-Service sshd\n" +
                 "$ConfiguredPublicKey = " + "\"" + publicKey + "\"\n" +
@@ -318,7 +324,7 @@ public class ComputeEngineCloudWindowsIT {
                 NODE_MODE,
                 new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT),
                 RUN_AS_USER,
-                false,
+                oneShot,
                 null);
         ic.appendLabels(INTEGRATION_LABEL);
         return ic;


### PR DESCRIPTION
As discussed, we should only allow snapshot creation when one-shot is enabled.
The changes involved have 2 portions.

UI
* One-shot has own section with two checkboxes: Enabled and Create snapshot?

Backend
* Because the OnceRetentionStrategy terminates the One-shot instance via _terminate in ComputeEngineInstance, had to remove the snapshot logic from ComputeEngineComputer to ComputeEngineInstance.
* Above point breaks integration tests. Fixed them by polling for node removal, which will guarantee snapshot was created (given that there are not errors).