### PR TITLE
Change Jenkins version to 2.107.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.0.11-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
+        <jenkins.version>2.107.1</jenkins.version>
         <jenkinsRuleTimeout>0</jenkinsRuleTimeout>
         <java.level>8</java.level>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Changing Jenkins version so that we support up to 12 months of Jenkins releases.