### PR TITLE
Removed windows user and used run as user as windows username

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -140,7 +140,6 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                                  String bootDiskSourceImageProject,
                                  String bootDiskSizeGbStr,
                                  boolean windows,
-                                 String windowsUsername,
                                  String windowsPasswordCredentialsId,
                                  String windowsPrivateKeyCredentialsId,
                                  boolean createSnapshot,
@@ -167,7 +166,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
 
         this.windows = windows;
         if (windows) {
-            this.windowsConfig = Optional.of(new WindowsConfiguration(windowsUsername, windowsPasswordCredentialsId,
+            this.windowsConfig = Optional.of(new WindowsConfiguration(runAsUser, windowsPasswordCredentialsId,
                     windowsPrivateKeyCredentialsId));
         } else {
             this.windowsConfig = Optional.empty();

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -31,9 +31,6 @@
             <f:entry field="windows" title="${%Windows?}">
                 <f:checkbox/>
             </f:entry>
-            <f:entry field="windowsUsername" title="${%Windows Username}">
-                <f:textbox default="Build"/>
-            </f:entry>
             <f:entry field="windowsPasswordCredentialsId" title="${%Windows Account Credentials}">
                 <c:select/>
             </f:entry>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windows.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windows.html
@@ -2,11 +2,11 @@
     Enable this option if the launched machine is a Windows VM. The Windows VM must have the OpenSSH server feature
     installed on it, Java installed on it, and you must have configured an administrative user with a username and password.
     <p>
-        The configured username and password should be set in the "Windows Username" and "Windows Password" fields.
+        The configured username and password should be set in the "Run as user" and "Windows account credentials" fields.
     </p>
     <p>
         If you do not have the aforementioned pre-installed, you can use the following startup script to automatically set up the minimum requirements.
-        In this example the Windows username is "Build" and the password is "P@ssword2". <br/>
+        In this example the Windows username is "jenkins" and the password is "P@ssword2". <br/>
         See the help file below for Windows private SSH key if you wish to authenticate SSH via keys.
     </p>
     <p>
@@ -17,7 +17,7 @@
             choco install -y openssh -params '"/SSHServerFeature"'<br/>
             choco install -y jre8<br/>
             <br/>
-            $username = "Build"<br/>
+            $username = "jenkins"<br/>
             $password = ConvertTo-SecureString "P@ssword2" -AsPlainText -Force<br/>
             $cred = New-Object System.Management.Automation.PSCredential -ArgumentList $username,$password<br/>
             Start-Process cmd /c -WindowStyle Hidden -Credential $cred -ErrorAction SilentlyContinue<br/>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -546,7 +546,6 @@ public class ComputeEngineCloudIT {
                 false,
                 "",
                 "",
-                "",
                 createSnapshot,
                 null,
                 new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -62,7 +62,7 @@ public class ComputeEngineCloudWindowsIT {
     private static final Node.Mode NODE_MODE = Node.Mode.EXCLUSIVE;
     private static final String ACCELERATOR_NAME = "";
     private static final String ACCELERATOR_COUNT = "";
-    private static final String RUN_AS_USER = "jenkins";
+    private static final String RUN_AS_USER = "Build";
 
     private static Map<String, String> INTEGRATION_LABEL;
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -62,7 +62,7 @@ public class ComputeEngineCloudWindowsIT {
     private static final Node.Mode NODE_MODE = Node.Mode.EXCLUSIVE;
     private static final String ACCELERATOR_NAME = "";
     private static final String ACCELERATOR_COUNT = "";
-    private static final String RUN_AS_USER = "Build";
+    private static final String RUN_AS_USER = "jenkins";
 
     private static Map<String, String> INTEGRATION_LABEL;
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -64,8 +64,6 @@ public class ComputeEngineCloudWindowsIT {
     private static final String ACCELERATOR_COUNT = "";
     private static final String RUN_AS_USER = "jenkins";
 
-    private static final String WINDOWS_USER = "Build";
-
     private static Map<String, String> INTEGRATION_LABEL;
 
     static {
@@ -135,7 +133,7 @@ public class ComputeEngineCloudWindowsIT {
         // Have to reformat since GoogleKeyPair's format is for metadata server and not typical public key format
         publicKey = kp.getPublicKey().trim().substring(1);
 
-        StandardUsernameCredentials windowsPrivateKeyCredential = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, null, WINDOWS_USER,
+        StandardUsernameCredentials windowsPrivateKeyCredential = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, null, RUN_AS_USER,
                 new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(kp.getPrivateKey()), null,
                 "integration test private key for windows");
         store.addCredentials(Domain.global(), windowsPrivateKeyCredential);
@@ -307,7 +305,6 @@ public class ComputeEngineCloudWindowsIT {
                 bootDiskProjectId,
                 BOOT_DISK_SIZE_GB_STR,
                 true,
-                WINDOWS_USER,
                 "",
                 windowsPrivateKeyCredentialId,
                 createSnapshot,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -235,7 +235,6 @@ public class InstanceConfigurationTest {
                 WINDOWS,
                 "",
                 "",
-                "",
                 false,
                 null,
                 new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),

--- a/windows-image-install.ps1
+++ b/windows-image-install.ps1
@@ -22,7 +22,7 @@ choco install -y jre8
 
 # No need to add a user if you've already configured one.
 Write-Output "Adding build user..."
-$username = "Build"
+$username = "jenkins"
 $password = ConvertTo-SecureString "P4ssword1" -AsPlainText -Force
 
 New-LocalUser -Name $username -Password $password

--- a/windows-it-install.ps1
+++ b/windows-it-install.ps1
@@ -22,7 +22,7 @@ choco install -y jre8
 
 # Following Step is needed for the startup script in the integration test to work, even if you already configured your own user.
 Write-Output "Adding build user..."
-$username = "Build"
+$username = "jenkins"
 $password = ConvertTo-SecureString "P4ssword1" -AsPlainText -Force
 New-LocalUser -Name $username -Password $password
 Add-LocalGroupMember -Group "Administrators" -Member "$username"


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-55509

Removed second (windows) username field cause its not needed, and in current form needs to be entered with every config save..