### PR TITLE
Code cleanup for deprecated methods, imports, and windows integration test

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration.java
@@ -50,7 +50,7 @@ public class AcceleratorConfiguration implements Describable<AcceleratorConfigur
     }
 
     public Descriptor<AcceleratorConfiguration> getDescriptor() {
-        return Jenkins.getInstance().getDescriptor(getClass());
+        return Jenkins.get().getDescriptor(getClass());
     }
 
     @Override

--- a/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
@@ -90,7 +90,7 @@ public class CleanLostNodesWork extends PeriodicWork {
     }
 
     private List<ComputeEngineCloud> getClouds() {
-        return Jenkins.getInstance().clouds
+        return Jenkins.get().clouds
                 .stream()
                 .filter(cloud -> cloud instanceof ComputeEngineCloud)
                 .map(cloud -> (ComputeEngineCloud) cloud)
@@ -98,7 +98,7 @@ public class CleanLostNodesWork extends PeriodicWork {
     }
 
     private Set<String> findLocalInstances(ComputeEngineCloud cloud) {
-        return Jenkins.getInstance()
+        return Jenkins.get()
                 .getNodes()
                 .stream()
                 .filter(node -> node instanceof ComputeEngineInstance)

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -129,7 +129,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
 
     protected Object readResolve() {
         try {
-            ClientFactory clientFactory = new ClientFactory(Jenkins.getInstance(), new ArrayList<DomainRequirement>(),
+            ClientFactory clientFactory = new ClientFactory(Jenkins.get(), new ArrayList<DomainRequirement>(),
                     credentialsId);
             this.client = clientFactory.compute();
         } catch (IOException e) {
@@ -152,7 +152,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
 
     /**
      * Returns unique ID of that cloud instance.
-     * 
+     *
      * This ID allows us to find machines from our cloud in GCP.
      * Current implementation is bit naive and generate ID based on name hashCode.
      *
@@ -165,7 +165,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
 
     /**
      * Returns GCP client for that cloud.
-     * 
+     *
      * @return GCP client object.
      */
     public ComputeClient getClient() {
@@ -174,7 +174,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
 
     /**
      * Returns GCP projectId for that cloud.
-     * 
+     *
      * @return projectId
      */
     public String getProjectId() {
@@ -201,7 +201,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
                 }
 
                 final ComputeEngineInstance node = config.provision(StreamTaskListener.fromStdout());
-                Jenkins.getInstance().addNode(node);
+                Jenkins.get().addNode(node);
                 r.add(new PlannedNode(node.getNodeName(), Computer.threadPoolForRemoting.submit(() -> {
                     long startTime = System.currentTimeMillis();
                     LOGGER.log(Level.INFO, String.format("Waiting %dms for node %s to connect", config.getLaunchTimeoutMillis(), node.getNodeName()));
@@ -319,7 +319,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
         ComputeEngineInstance node = c.provision(StreamTaskListener.fromStdout());
         if (node == null)
             throw HttpResponses.error(SC_BAD_REQUEST, "Could not provision new node.");
-        Jenkins.getInstance().addNode(node);
+        Jenkins.get().addNode(node);
 
         return HttpResponses.redirectViaContextPath("/computer/" + node.getNodeName());
     }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputer.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputer.java
@@ -17,8 +17,6 @@
 package com.google.jenkins.plugins.computeengine;
 
 import com.google.api.services.compute.model.Instance;
-import com.google.api.services.compute.model.Operation;
-import com.google.jenkins.plugins.computeengine.client.ComputeClient;
 import hudson.slaves.AbstractCloudComputer;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.HttpRedirect;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -16,12 +16,15 @@
 
 package com.google.jenkins.plugins.computeengine;
 
-import com.google.api.services.compute.Compute;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
-import hudson.slaves.*;
+import hudson.slaves.AbstractCloudComputer;
+import hudson.slaves.AbstractCloudSlave;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.RetentionStrategy;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
@@ -33,7 +36,7 @@ import java.util.Optional;
 public class ComputeEngineInstance extends AbstractCloudSlave {
     private static final long serialVersionUID = 1;
     private static final Logger LOGGER = Logger.getLogger(ComputeEngineInstance.class.getName());
-    
+
     // TODO: https://issues.jenkins-ci.org/browse/JENKINS-55518
     public final String zone;
     public final String cloudName;
@@ -123,7 +126,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
     }
 
     public ComputeEngineCloud getCloud() throws CloudNotFoundException {
-        ComputeEngineCloud cloud = (ComputeEngineCloud) Jenkins.getInstance().getCloud(cloudName);
+        ComputeEngineCloud cloud = (ComputeEngineCloud) Jenkins.get().getCloud(cloudName);
         if (cloud == null)
             throw new CloudNotFoundException(String.format("Could not find cloud %s in Jenkins configuration", cloudName));
         return cloud;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -16,10 +16,18 @@
 
 package com.google.jenkins.plugins.computeengine;
 
-import com.google.api.services.compute.model.*;
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.NetworkInterface;
+import com.google.api.services.compute.model.Operation;
 import com.google.jenkins.plugins.computeengine.client.ComputeClient;
 import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyPair;
-import com.trilead.ssh2.*;
+import com.trilead.ssh2.Connection;
+import com.trilead.ssh2.HTTPProxyData;
+import com.trilead.ssh2.SCPClient;
+import com.trilead.ssh2.ServerHostKeyVerifier;
+import com.trilead.ssh2.Session;
 import hudson.ProxyConfiguration;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
@@ -113,7 +121,7 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
             SCPClient scp = conn.createSCPClient();
             String tmpDir = "/tmp";
             logInfo(computer, listener, "Copying slave.jar to: " + tmpDir);
-            scp.put(Jenkins.getInstance().getJnlpJars("slave.jar").readFully(), "slave.jar", tmpDir);
+            scp.put(Jenkins.get().getJnlpJars("slave.jar").readFully(), "slave.jar", tmpDir);
 
             // Confirm Java is installed
             if (!testCommand(computer, conn, "java -fullversion", logger, listener)) {
@@ -251,7 +259,7 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
                 logInfo(computer, listener, "Connecting to " + host + " on port " + port + ", with timeout " + SSH_TIMEOUT
                         + ".");
                 Connection conn = new Connection(host, port);
-                ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
+                ProxyConfiguration proxyConfig = Jenkins.get().proxy;
                 Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
                 if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
                     InetSocketAddress address = (InetSocketAddress) proxy.address();

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -120,8 +120,8 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
 
             SCPClient scp = conn.createSCPClient();
             String tmpDir = "/tmp";
-            logInfo(computer, listener, "Copying slave.jar to: " + tmpDir);
-            scp.put(Jenkins.get().getJnlpJars("slave.jar").readFully(), "slave.jar", tmpDir);
+            logInfo(computer, listener, "Copying agent.jar to: " + tmpDir);
+            scp.put(Jenkins.get().getJnlpJars("agent.jar").readFully(), "agent.jar", tmpDir);
 
             // Confirm Java is installed
             if (!testCommand(computer, conn, "java -fullversion", logger, listener)) {
@@ -130,7 +130,7 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
 
 
             //TODO: allow jvmopt configuration
-            String launchString = "java -jar " + tmpDir + "/slave.jar";
+            String launchString = "java -jar " + tmpDir + "/agent.jar";
 
             logInfo(computer, listener, "Launching Jenkins agent via plugin SSH: " + launchString);
             final Session sess = conn.openSession();

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -42,7 +42,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
     private static final Logger LOGGER = Logger.getLogger(ComputeEngineLinuxLauncher.class.getName());
     private static final String TMPDIR = "C:\\";
     //TODO: allow jvmopt configuration
-    private static final String LAUNCHSTRING = "java -jar C:\\slave.jar";
+    private static final String LAUNCHSTRING = "java -jar C:\\agent.jar";
     private static int bootstrapAuthTries = 30;
     private static int bootstrapAuthSleepMs = 15000;
 
@@ -113,8 +113,8 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
 
             SCPClient scp = conn.createSCPClient();
 
-            logInfo(computer, listener, "Copying slave.jar to: " + TMPDIR);
-            scp.put(Jenkins.get().getJnlpJars("slave.jar").readFully(), "slave.jar", TMPDIR);
+            logInfo(computer, listener, "Copying agent.jar to: " + TMPDIR);
+            scp.put(Jenkins.get().getJnlpJars("agent.jar").readFully(), "agent.jar", TMPDIR);
 
             // Confirm Java is installed
             if (!testCommand(computer, conn, "java -fullversion", logger, listener)) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -114,7 +114,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
             SCPClient scp = conn.createSCPClient();
 
             logInfo(computer, listener, "Copying slave.jar to: " + TMPDIR);
-            scp.put(Jenkins.getInstance().getJnlpJars("slave.jar").readFully(), "slave.jar", TMPDIR);
+            scp.put(Jenkins.get().getJnlpJars("slave.jar").readFully(), "slave.jar", TMPDIR);
 
             // Confirm Java is installed
             if (!testCommand(computer, conn, "java -fullversion", logger, listener)) {
@@ -246,7 +246,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
                 logInfo(computer, listener, "Connecting to " + host + " on port " + port + ", with timeout " + SSH_TIMEOUT
                         + ".");
                 Connection conn = new Connection(host, port);
-                ProxyConfiguration proxyConfig = Jenkins.getInstance().proxy;
+                ProxyConfiguration proxyConfig = Jenkins.get().proxy;
                 Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
                 if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
                     InetSocketAddress address = (InetSocketAddress) proxy.address();

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -24,14 +24,35 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-import com.google.api.services.compute.model.*;
+import com.google.api.services.compute.model.AcceleratorConfig;
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.AttachedDisk;
+import com.google.api.services.compute.model.AttachedDiskInitializeParams;
+import com.google.api.services.compute.model.DiskType;
+import com.google.api.services.compute.model.Image;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.InstanceTemplate;
+import com.google.api.services.compute.model.MachineType;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.NetworkInterface;
+import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Region;
+import com.google.api.services.compute.model.Scheduling;
+import com.google.api.services.compute.model.ServiceAccount;
+import com.google.api.services.compute.model.Tags;
+import com.google.api.services.compute.model.Zone;
 import com.google.common.base.Strings;
 import com.google.jenkins.plugins.computeengine.client.ClientFactory;
 import com.google.jenkins.plugins.computeengine.client.ComputeClient;
 import hudson.Extension;
 import hudson.RelativePath;
 import hudson.Util;
-import hudson.model.*;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
 import hudson.security.ACL;
 import hudson.slaves.CloudRetentionStrategy;
@@ -202,7 +223,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
 
         // Remote filesystem location.
         this.remoteFs = remoteFs;
-        
+
         // Network
         this.networkConfiguration = networkConfiguration;
         this.externalAddress = externalAddress;
@@ -253,7 +274,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     }
 
     public Descriptor<InstanceConfiguration> getDescriptor() {
-        return Jenkins.getInstance().getDescriptor(getClass());
+        return Jenkins.get().getDescriptor(getClass());
     }
 
     public String getLabelString() {
@@ -313,15 +334,15 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             ComputeEngineInstance computeEngineInstance = new ComputeEngineInstance(
                     cloud.name,
                     instance.getName(),
-                    instance.getZone(), 
+                    instance.getZone(),
                     instance.getDescription(),
                     runAsUser,
                     targetRemoteFs,
                     windowsConfig,
                     createSnapshot,
                     oneShot,
-                    numExecutors, 
-                    mode, 
+                    numExecutors,
+                    mode,
                     labels,
                     launcher,
                     (oneShot ? new OnceRetentionStrategy(retentionTimeMinutes) : new CloudRetentionStrategy(retentionTimeMinutes)),
@@ -337,7 +358,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
      * Initializes transient properties
      */
     protected Object readResolve() {
-        Jenkins.getInstance().checkPermission(Jenkins.RUN_SCRIPTS);
+        Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
 
         labelSet = Label.parse(labels);
         return this;
@@ -348,7 +369,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         instance.setName(uniqueName());
         instance.setDescription(description);
         instance.setZone(nameFromSelfLink(zone));
-        
+
         if (StringUtils.isNotEmpty(template)) {
             // TODO: JENKINS-55285
             InstanceTemplate instanceTemplate = cloud.client.getTemplate(nameFromSelfLink(cloud.projectId), nameFromSelfLink(template));
@@ -528,7 +549,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         public String getHelpFile(String fieldName) {
             String p = super.getHelpFile(fieldName);
             if (p == null) {
-                Descriptor d = Jenkins.getInstance().getDescriptor(ComputeEngineInstance.class);
+                Descriptor d = Jenkins.get().getDescriptor(ComputeEngineInstance.class);
                 if (d != null)
                     p = d.getHelpFile(fieldName);
             }
@@ -536,7 +557,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         }
 
         public List<NetworkConfiguration.NetworkConfigurationDescriptor> getNetworkConfigurationDescriptors() {
-            List<NetworkConfiguration.NetworkConfigurationDescriptor> d = Jenkins.getInstance().getDescriptorList(NetworkConfiguration.class);
+            List<NetworkConfiguration.NetworkConfigurationDescriptor> d = Jenkins.get().getDescriptorList(NetworkConfiguration.class);
             // No deprecated regions
             Iterator it = d.iterator();
             while (it.hasNext()) {
@@ -606,7 +627,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                 return items;
             }
         }
-        
+
         public ListBoxModel doFillTemplateItems(@AncestorInPath Jenkins context,
                                               @QueryParameter("projectId") @RelativePath("..") final String projectId,
                                               @QueryParameter("credentialsId") @RelativePath("..") final String credentialsId) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkConfiguration.java
@@ -45,7 +45,7 @@ public abstract class NetworkConfiguration implements Describable<NetworkConfigu
     }
 
     public Descriptor<NetworkConfiguration> getDescriptor() {
-        return Jenkins.getInstance().getDescriptor(getClass());
+        return Jenkins.get().getDescriptor(getClass());
     }
 
     @Override

--- a/src/main/java/com/google/jenkins/plugins/computeengine/WindowsConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/WindowsConfiguration.java
@@ -69,7 +69,7 @@ public class WindowsConfiguration {
 
         StandardUsernamePasswordCredentials cred = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class,
-                        Jenkins.getInstance(), ACL.SYSTEM, domainRequirements),
+                        Jenkins.get(), ACL.SYSTEM, domainRequirements),
                 CredentialsMatchers.withId(passwordCredentialsId.get()));
 
         if (cred == null) {
@@ -86,7 +86,7 @@ public class WindowsConfiguration {
     public StandardUsernameCredentials getPrivateKeyCredentials() {
         StandardUsernameCredentials cred = CredentialsMatchers.firstOrNull(
                 new SystemCredentialsProvider.ProviderImpl().getCredentials(BasicSSHUserPrivateKey.class,
-                        Jenkins.getInstance(), ACL.SYSTEM),
+                        Jenkins.get(), ACL.SYSTEM),
                 CredentialsMatchers.withId(privateKeyCredentialsId.get()));
         return cred;
     }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -1,7 +1,10 @@
 package com.google.jenkins.plugins.computeengine;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
-import com.cloudbees.plugins.credentials.*;
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
@@ -20,15 +23,24 @@ import hudson.model.Node;
 import hudson.model.Result;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.NodeProvisioner;
+import hudson.tasks.BatchFile;
 import hudson.tasks.Builder;
-import hudson.tasks.Shell;
+
 import org.awaitility.Awaitility;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -208,7 +220,7 @@ public class ComputeEngineCloudWindowsIT {
         assertEquals(logs(), 1, planned.size());
 
         String name = planned.iterator().next().displayName;
-        
+
         // Wait for the node creation to finish
         planned.iterator().next().future.get();
 
@@ -236,7 +248,7 @@ public class ComputeEngineCloudWindowsIT {
         cloud.addConfiguration(snapshotInstanceConfiguration());
 
         FreeStyleProject project = r.createFreeStyleProject();
-        Builder step = new Shell("exit 1");
+        Builder step = new BatchFile("exit 1");
         project.getBuildersList().add(step);
         project.setAssignedLabel(new LabelAtom(SNAPSHOT_LABEL));
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
@@ -24,7 +24,12 @@ import com.google.jenkins.plugins.credentials.oauth.ServiceAccountConfig;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -69,7 +74,7 @@ public class StringJsonServiceAccountConfig extends ServiceAccountConfig {
 
     @Override
     public com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.DescriptorImpl getDescriptor() {
-        return (com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.DescriptorImpl) Jenkins.getInstance()
+        return (com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.DescriptorImpl) Jenkins.get()
                 .getDescriptorOrDie(com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.class);
     }
 


### PR DESCRIPTION
- Got rid of deprecated method getInstance() from Jenkins class in favor of get().
- Replaced Shell in snapshot integration test for Windows with BatchFile (the proper shell to be running on Windows VM's).
- Cleaned up wildcard imports on changed files.