### PR TITLE
Add missing license headers and fix existing license headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Changelog
 All notable changes to this project will be documented in this file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2017-2019 Google LLC
+ Copyright 2017 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2017-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # How to contribute
 
 We'd love to accept your patches and contributions to this project. There are

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,14 @@
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 hpi:
 	export MAVEN_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n"
 	mvn -o hpi:run

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Google Compute Engine Plugin for Jenkins
 The Google Compute Engine (GCE) Plugin allows you to use GCE virtual machines (VMs) with Jenkins to execute build tasks. GCE VMs provision quickly, are destroyed by Jenkins when idle, and offer Preemptible VMs that run at a much lower price than regular VMs.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Running Windows VM's
 * To run a VM as an agent, have both SSH and Java installed on the Windows Image. Chocolatey is recommended to install OpenSSH and Java.
 

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 201\d(-20\d\d)? Google LLC$
+^ \* Copyright 20\d\d Google LLC$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 201(8) Google LLC$
+^ \* Copyright 201\d(-20\d\d)? Google LLC$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,11 +1,11 @@
 ^/\*$
-^ \* Copyright 201(8) Google Inc\. All Rights Reserved\.$
+^ \* Copyright 201(8) Google LLC$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);$
 ^ \* you may not use this file except in compliance with the License\.$
 ^ \* You may obtain a copy of the License at$
 ^ \*$
-^ \*     http://www\.apache\.org/licenses/LICENSE-2\.0$
+^ \*     https://www\.apache\.org/licenses/LICENSE-2\.0$
 ^ \*$
 ^ \* Unless required by applicable law or agreed to in writing, software$
 ^ \* distributed under the License is distributed on an \"AS IS\" BASIS,$

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2019 Google LLC
+ Copyright 2017-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2017-2019 Google LLC
+ Copyright 2017 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.google.api.services.compute.model.Network;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/CloudNotFoundException.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/CloudNotFoundException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/CloudNotFoundException.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/CloudNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/CloudNotFoundException.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/CloudNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputer.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputer.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputer.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerListener.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerListener.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerListener.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerListener.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 Google LLC
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2017-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineScopeRequirement.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineScopeRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineScopeRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -1,8 +1,17 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkConfiguration.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NoConfigurationException.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NoConfigurationException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NoConfigurationException.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NoConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NoConfigurationException.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NoConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.google.common.base.Strings;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/WindowsConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/WindowsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/WindowsConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/WindowsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/WindowsConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/WindowsConfiguration.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package com.google.jenkins.plugins.computeengine.client;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ComputeClient.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ComputeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ComputeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ssh/GoogleKeyPair.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ssh/GoogleKeyPair.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ssh/GoogleKeyPair.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ssh/GoogleKeyPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ssh/GoogleKeyPair.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ssh/GoogleKeyPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration/config.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry field="gpuType" title="${%GPU Type}">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/AcceleratorConfiguration/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration/config-detail.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration/config-detail.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration/config-detail.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration/config-detail.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry field="network" title="${%Network}">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration/config-detail.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration/config-detail.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
     <j:if test="${it.hasPermission(it.PROVISION)}">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2017-2019 Google LLC
+ Copyright 2017 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2017-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/config.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:f="/lib/form" xmlns:c="/lib/credentials">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-credentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-credentialsId.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-credentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-credentialsId.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     The credential must be of kind `Google Service Account from private key`.
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-credentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-credentialsId.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-projectId.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2017-2019 Google LLC
+ Copyright 2017 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-projectId.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2017-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-projectId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/help-projectId.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     The project ID is a unique identifier for a Google Cloud Platform project.
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineComputer/configure.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineComputer/configure.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineComputer/configure.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineComputer/configure.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <!--We want to override the form in configuring the node-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineComputer/configure.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineComputer/configure.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:f="/lib/form" xmlns:c="/lib/credentials">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskAutoDelete.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskAutoDelete.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskAutoDelete.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskAutoDelete.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     If true, a node's boot disk will be deleted when the node is terminated by Jenkins.
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskAutoDelete.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskAutoDelete.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-createSnapshot.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-createSnapshot.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     By checking this option, before your one-shot instance is deleted, a snapshot will be created if there were any failed
     builds on the instance.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-description.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-description.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-description.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-description.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     The description uniquely identifies this template. It is also applied to any Compute Engine instances created by the
     plugin.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-description.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-description.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-externalAddress.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-externalAddress.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     Dictates whether the instance should receive an <strong>external routable IP</strong> address. In GCE, you will need to have either an <em>external IP</em> or a <a href="https://cloud.google.com/vpc/docs/special-configurations#multiple-natgateways">NAT gateway</a> setup in order to download anything from the internet.
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-launchTimeoutSecondsStr.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-launchTimeoutSecondsStr.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-launchTimeoutSecondsStr.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-launchTimeoutSecondsStr.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     The number of <strong>seconds</strong> a new node has to provision and come online.
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-launchTimeoutSecondsStr.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-launchTimeoutSecondsStr.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-minCpuPlatform.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-minCpuPlatform.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-minCpuPlatform.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-minCpuPlatform.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
    Google datacenters offer varied CPU Platforms. Each CPU platform supports incremental features like AVX-2, AVX-512, and so on.
     Systems-related features like clock speed and memory access seek time can vary across CPU platforms. Different zones support multiple CPU

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-minCpuPlatform.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-minCpuPlatform.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-namePrefix.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-namePrefix.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-namePrefix.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-namePrefix.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     This prefix will be used to create a unique name for each Compute Engine instance launched by the plugin.
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-namePrefix.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-namePrefix.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkConfiguration.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkConfiguration.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkConfiguration.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkConfiguration.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     Choose an available network and subnetwork from your selected project, or manually enter values to use a <a href="https://cloud.google.com/vpc/docs/shared-vpc">shared VPC</a>
     <p>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkConfiguration.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkConfiguration.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkTags.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkTags.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkTags.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkTags.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     A <strong>space-delimited</strong> list of network tags to apply to the VM.
     <p>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkTags.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkTags.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-oneShot.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-oneShot.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     <a href="https://wiki.jenkins.io/display/JENKINS/One-Shot+Executor">One-Shot</a> executors create nodes dedicated
     to a single build. Upon completion of the build the node is terminated.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-preemptible.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-preemptible.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-preemptible.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-preemptible.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     A preemptible VM is an instance that you can create and run at a much lower price than normal instances. However,
     Compute Engine might terminate (preempt) these instances if it requires access to those resources for other tasks.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-preemptible.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-preemptible.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-remoteFs.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-remoteFs.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-remoteFs.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-remoteFs.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     The location to store the Jenkins workspace on the instance. If this isn't specified, it defaults
     to <code>C:\JenkinsSlave</code> on Windows and <code>./.jenkins-slave</code> on Linux.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-remoteFs.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-remoteFs.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-retentionTimeMinutesStr.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-retentionTimeMinutesStr.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-retentionTimeMinutesStr.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-retentionTimeMinutesStr.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     The number of <strong>minutes</strong> after which an inactive node will be terminated. This value should be
     at least as the launch timeout configured above.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-retentionTimeMinutesStr.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-retentionTimeMinutesStr.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-runAsUser.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-runAsUser.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-runAsUser.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-runAsUser.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     The local user that the Jenkins agent process will run as. Default is <em>jenkins</em>
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-runAsUser.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-runAsUser.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-serviceAccountEmail.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-serviceAccountEmail.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-serviceAccountEmail.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-serviceAccountEmail.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     The name of an <strong>existing</strong> service account that will be associated with the node.
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-serviceAccountEmail.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-serviceAccountEmail.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-template.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-template.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-template.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-template.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     Use instance template for creating instances.
     <p>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-template.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-template.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-useInternalAddress.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-useInternalAddress.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-useInternalAddress.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-useInternalAddress.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     Use an agent's internal IP address for communication even if <em>External IP?</em> is selected.
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-useInternalAddress.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-useInternalAddress.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windows.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windows.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windows.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windows.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     Enable this option if the launched machine is a Windows VM. The Windows VM must have the OpenSSH server feature
     installed on it, Java installed on it, and you must have configured an administrative user with a username and password.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windows.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windows.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPasswordCredentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPasswordCredentialsId.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPasswordCredentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPasswordCredentialsId.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     <p>
         Create an Username with password credential with Global scope. This should be the username and password to

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPasswordCredentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPasswordCredentialsId.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPrivateKeyCredentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPrivateKeyCredentialsId.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPrivateKeyCredentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPrivateKeyCredentialsId.html
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <div>
     <p>
     Download the SSH Credentials Plugin. Then create an SSH Username with private key credential with Global scope.<br/>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPrivateKeyCredentialsId.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-windowsPrivateKeyCredentialsId.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2017-2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
@@ -1,4 +1,4 @@
-# Copyright 2017-2019 Google LLC
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 ComputeEngineCloud.DisplayName=Google Compute Engine
 ComputeEngineAgent.DisplayName=Google Compute Engine
 InstanceConfiguration.SnapshotConfigError=One-shot must be enabled to create snapshots

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkConfiguration/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkConfiguration/config.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
     <st:include page="config-detail.jelly" optional="false" class="${descriptor.clazz}"/>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkConfiguration/config.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration/config-detail.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration/config-detail.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2018-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration/config-detail.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration/config-detail.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry field="projectId" title="${%Host project ID}">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration/config-detail.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfiguration/config-detail.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018-2019 Google LLC
+ Copyright 2018 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/client/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/client/Messages.properties
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/client/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/client/Messages.properties
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 ClientFactory.CredentialsIdRequired=credentialsId must be specified
 ClientFactory.FailedToInitializeHTTPTransport=Failed to initialize HTTP transport: {0}
 ClientFactory.FailedToRetrieveCredentials=Could not retrieve credentials: {0}

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/client/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/client/Messages.properties
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2018-2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2017-2019 Google LLC
+ Copyright 2017 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,5 +1,5 @@
 <!--
- Copyright 2019 Google LLC
+ Copyright 2017-2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,8 +1,11 @@
 <!--
- Copyright 2017 Google Inc.
+ Copyright 2019 Google LLC
+
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at
-     https://www.apache.org/licenses/LICENSE-2.0
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
  Unless required by applicable law or agreed to in writing, software distributed under the License
  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
  implied. See the License for the specific language governing permissions and limitations under the

--- a/src/test/java/com/google/jenkins/plugins/computeengine/AcceleratorConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/AcceleratorConfigurationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/AcceleratorConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/AcceleratorConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/AcceleratorConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/AcceleratorConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWorkTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWorkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWorkTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWorkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWorkTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWorkTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.google.api.services.compute.model.Instance;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.cloudbees.plugins.credentials.Credentials;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncherTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/GoogleKeyPairTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/GoogleKeyPairTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/GoogleKeyPairTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/GoogleKeyPairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/GoogleKeyPairTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/GoogleKeyPairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfigurationTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/SharedVpcNetworkConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/client/ClientFactoryTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/client/ClientFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/client/ClientFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/client/ComputeClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/client/ComputeClientTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.google.jenkins.plugins.computeengine.client;
 
 import com.google.api.services.compute.Compute;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/client/ComputeClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/client/ComputeClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2018-2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/client/ComputeClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/client/ComputeClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/windows-image-install.ps1
+++ b/windows-image-install.ps1
@@ -1,3 +1,15 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
+#
 # Following script works with the Windows 2016 image provided by GCE.
 # If running a different version of Windows/Powershell, changes may be needed.
 # We are in the first phase where we need to configure PowerShell, install Chocolately, install the OpenSSH Server.

--- a/windows-image-install.ps1
+++ b/windows-image-install.ps1
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at

--- a/windows-image-install.ps1
+++ b/windows-image-install.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2018-2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at

--- a/windows-it-install.ps1
+++ b/windows-it-install.ps1
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at

--- a/windows-it-install.ps1
+++ b/windows-it-install.ps1
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2018-2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at

--- a/windows-it-install.ps1
+++ b/windows-it-install.ps1
@@ -1,3 +1,15 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
+#
 # Following script works with the Windows 2016 image provided by GCE.
 # Script may not work for other images/versions of Powershell.
 # We are in the first phase where we need to configure PowerShell, install Chocolately, install the OpenSSH Server and the restart the VM.


### PR DESCRIPTION
Apart from adding the header to the files that were missing it, I'm changing the existing headers to match the apache header listed in the open source releasing guide, available externally [here](https://opensource.google.com/docs/releasing/preparing/#Apache-header)