### PR TITLE
WIP: Parallelized integration tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
+    <concurrency>10</concurrency>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -204,8 +204,12 @@
           </systemPropertyVariables>
           <excludes>
             <exclude>**/ComputeEngineCloudWindowsIT.java</exclude>
+            <exclude>**/ComputeEngineCloudIT.java</exclude>
+            <exclude>**/ITUtil.java</exclude>
           </excludes>
           <argLine>-Djenkins.test.timeout=${jenkinsRuleTimeout}</argLine>
+          <parallel>methods</parallel>
+          <useUnlimitedThreads>true</useUnlimitedThreads>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -98,11 +98,9 @@ public class ComputeEngineCloudIT {
     private static final String ZONE = "us-west1-a";
     private static final String ZONE_BASE = format("projects/%s/zones/" + ZONE);
     private static final String LABEL = "integration";
-    private static final String MULTIPLE_LABEL = "integration test";
     private static final String SNAPSHOT_LABEL = "snapshot";
     private static final String MACHINE_TYPE = ZONE_BASE + "/machineTypes/n1-standard-1";
     private static final String NUM_EXECUTORS = "1";
-    private static final String MULTIPLE_NUM_EXECUTORS = "2";
     private static final boolean PREEMPTIBLE = false;
     //  TODO: Write a test to see if min cpu platform worked by picking a higher version?
     private static final String MIN_CPU_PLATFORM = "Intel Broadwell";
@@ -224,86 +222,6 @@ public class ComputeEngineCloudIT {
         ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
         Image i = cloud.client.getImage("debian-cloud", "debian-9-stretch-v20180820");
         assertNotNull(i);
-    }
-
-    @Test(timeout = 300000)
-    public void testWorkerCreated() throws Exception {
-        //TODO: each test method should probably have its own handler.
-        logOutput.reset();
-
-        ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-        InstanceConfiguration ic = validInstanceConfiguration();
-        cloud.addConfiguration(ic);
-        // Add a new node
-        Collection<NodeProvisioner.PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 1);
-
-        // There should be a planned node
-        assertEquals(logs(), 1, planned.size());
-
-        String name = planned.iterator().next().displayName;
-
-        // Wait for the node creation to finish
-        planned.iterator().next().future.get();
-
-        // There should be no warning logs
-        assertFalse(logs(), logs().contains("WARNING"));
-
-        Instance i = cloud.client.getInstance(projectId, ZONE, name);
-
-        // The created instance should have 3 labels
-        assertEquals(logs(), 3, i.getLabels().size());
-
-        // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name prefix
-        assertEquals(logs(), ic.namePrefix, i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
-        assertEquals(logs(), cloud.getInstanceId(), i.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));
-    }
-
-    @Test(timeout = 300000)
-    public void test1WorkerCreatedFor2Executors() throws Exception {
-        logOutput.reset();
-
-        ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-        cloud.addConfiguration(validInstanceConfigurationWithExecutors(MULTIPLE_NUM_EXECUTORS));
-        // Add a new node
-        Collection<NodeProvisioner.PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 2);
-
-        // There should be a planned node
-        assertEquals(logs(), 1, planned.size());
-    }
-
-    @Test(timeout = 300000)
-    public void testMultipleLabelsForJob() throws Exception {
-        // For a configuration with multiple labels, test if job label matches one of the configuration's labels
-        logOutput.reset();
-
-        ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-        InstanceConfiguration ic = validInstanceConfigurationWithLabels(MULTIPLE_LABEL);
-        cloud.addConfiguration(ic);
-        // Add a new node
-        Collection<NodeProvisioner.PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 1);
-
-        // There should be a planned node
-        assertEquals(logs(), 1, planned.size());
-    }
-
-    @Test(timeout = 300000)
-    public void testMultipleLabelsInConfig() throws Exception {
-        // For a configuration with multiple labels, test if job label matches one of the configuration's labels
-        logOutput.reset();
-
-        ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-        InstanceConfiguration ic = validInstanceConfigurationWithLabels(MULTIPLE_LABEL);
-        cloud.addConfiguration(ic);
-        // Add a new node
-        Collection<NodeProvisioner.PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 1);
-
-        String name = planned.iterator().next().displayName;
-
-        planned.iterator().next().future.get();
-
-        String provisionedLabels = r.jenkins.getNode(name).getLabelString();
-        // There should be a planned node TODO
-        assertEquals(logs(), MULTIPLE_LABEL, provisionedLabels);
     }
 
     @Test(timeout = 300000, expected = ExecutionException.class)
@@ -492,18 +410,6 @@ public class ComputeEngineCloudIT {
     private static InstanceConfiguration snapshotInstanceConfiguration() {
         // Snapshot label needed since the freestyle project could use a previously provisioned node instead of this configuration's.
         return instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, NUM_EXECUTORS, SNAPSHOT_LABEL, true, true, NULL_TEMPLATE);
-    }
-
-    private static InstanceConfiguration validInstanceConfiguration() {
-        return instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, NUM_EXECUTORS, LABEL, false, false, NULL_TEMPLATE);
-    }
-
-    private static InstanceConfiguration validInstanceConfigurationWithLabels(String labels) {
-        return instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, NUM_EXECUTORS, labels, false, false, NULL_TEMPLATE);
-    }
-
-    private static InstanceConfiguration validInstanceConfigurationWithExecutors(String numExecutors) {
-        return instanceConfiguration(DEB_JAVA_STARTUP_SCRIPT, numExecutors, LABEL, false, false, NULL_TEMPLATE);
     }
 
     private static InstanceConfiguration validInstanceConfigurationWithTemplate(String template) {

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -44,6 +44,7 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
 
   private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
   private static StreamHandler sh;
+  private static ComputeEngineCloud cloud;
   private static ComputeClient client;
   private static Map<String, String> label =
       ITUtil.getLabel(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class);
@@ -52,7 +53,7 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
   public static void init() throws Exception {
     log.info("init");
     ITUtil.initCredentials(r);
-    ITUtil.initCloud(r);
+    cloud = ITUtil.initCloud(r);
     sh = ITUtil.initLogging(logOutput);
     client = ITUtil.initClient(r, label, log);
   }
@@ -64,7 +65,6 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
 
   @Test(timeout = 300000)
   public void test1WorkerCreatedFor2Executors() {
-    ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
     cloud.addConfiguration(
         ITUtil.instanceConfiguration(
             ITUtil.DEB_JAVA_STARTUP_SCRIPT,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -1,0 +1,61 @@
+package com.google.jenkins.plugins.computeengine.integration;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import com.google.jenkins.plugins.computeengine.client.ComputeClient;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
+  private static Logger log = Logger.getLogger(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class.getName());
+
+  private static final String MULTIPLE_NUM_EXECUTORS = "2";
+
+  @ClassRule
+  public static JenkinsRule r = new JenkinsRule();
+
+  private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
+  private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
+  private static ComputeClient client;
+  private static Map<String, String> label = ITUtil.getLabel(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class);
+
+  @BeforeClass
+  public static void init() throws Exception {
+    client = ITUtil.init(r, sh, label, log);
+  }
+
+  @AfterClass
+  public static void teardown() throws IOException {
+    ITUtil.teardown(sh, logOutput, client, label, log);
+  }
+
+
+  @Test(timeout = 300000)
+  public void test1WorkerCreatedFor2Executors() {
+    ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
+    cloud.addConfiguration(validInstanceConfigurationWithExecutors(MULTIPLE_NUM_EXECUTORS));
+    // Add a new node
+    Collection<PlannedNode> planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 2);
+
+    // There should be a planned node
+    assertEquals(ITUtil.logs(sh, logOutput), 1, planned.size());
+  }
+
+  private static InstanceConfiguration validInstanceConfigurationWithExecutors(String numExecutors) {
+    return ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, numExecutors, ITUtil.LABEL, label, false, false, ITUtil.NULL_TEMPLATE);
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -44,14 +43,18 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
   @ClassRule public static JenkinsRule r = new JenkinsRule();
 
   private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
-  private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
+  private static StreamHandler sh;
   private static ComputeClient client;
   private static Map<String, String> label =
       ITUtil.getLabel(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class);
 
   @BeforeClass
   public static void init() throws Exception {
-    client = ITUtil.init(r, sh, label, log);
+    log.info("init");
+    ITUtil.initCredentials(r);
+    ITUtil.initCloud(r);
+    sh = ITUtil.initLogging(logOutput);
+    client = ITUtil.initClient(r, label, log);
   }
 
   @AfterClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -36,17 +36,18 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
-  private static Logger log = Logger.getLogger(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class.getName());
+  private static Logger log =
+      Logger.getLogger(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class.getName());
 
   private static final String MULTIPLE_NUM_EXECUTORS = "2";
 
-  @ClassRule
-  public static JenkinsRule r = new JenkinsRule();
+  @ClassRule public static JenkinsRule r = new JenkinsRule();
 
   private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
   private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
   private static ComputeClient client;
-  private static Map<String, String> label = ITUtil.getLabel(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class);
+  private static Map<String, String> label =
+      ITUtil.getLabel(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class);
 
   @BeforeClass
   public static void init() throws Exception {
@@ -58,11 +59,18 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
     ITUtil.teardown(sh, logOutput, client, label, log);
   }
 
-
   @Test(timeout = 300000)
   public void test1WorkerCreatedFor2Executors() {
     ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-    cloud.addConfiguration(ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, MULTIPLE_NUM_EXECUTORS, ITUtil.LABEL, label, false, false, ITUtil.NULL_TEMPLATE));
+    cloud.addConfiguration(
+        ITUtil.instanceConfiguration(
+            ITUtil.DEB_JAVA_STARTUP_SCRIPT,
+            MULTIPLE_NUM_EXECUTORS,
+            ITUtil.LABEL,
+            label,
+            false,
+            false,
+            ITUtil.NULL_TEMPLATE));
     // Add a new node
     Collection<PlannedNode> planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 2);
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.computeengine.integration;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -19,7 +19,6 @@ package com.google.jenkins.plugins.computeengine.integration;
 import static org.junit.Assert.assertEquals;
 
 import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
-import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
 import com.google.jenkins.plugins.computeengine.client.ComputeClient;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.NodeProvisioner.PlannedNode;
@@ -63,15 +62,11 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
   @Test(timeout = 300000)
   public void test1WorkerCreatedFor2Executors() {
     ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-    cloud.addConfiguration(validInstanceConfigurationWithExecutors(MULTIPLE_NUM_EXECUTORS));
+    cloud.addConfiguration(ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, MULTIPLE_NUM_EXECUTORS, ITUtil.LABEL, label, false, false, ITUtil.NULL_TEMPLATE));
     // Add a new node
     Collection<PlannedNode> planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 2);
 
     // There should be a planned node
     assertEquals(ITUtil.logs(sh, logOutput), 1, planned.size());
-  }
-
-  private static InstanceConfiguration validInstanceConfigurationWithExecutors(String numExecutors) {
-    return ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, numExecutors, ITUtil.LABEL, label, false, false, ITUtil.NULL_TEMPLATE);
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -69,6 +69,7 @@ public class ComputeEngineCloudMultipleLabelsIT {
     cloud.addConfiguration(ic);
     // Add a new node
     planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 1);
+    planned.iterator().next().future.get();
   }
 
   @AfterClass
@@ -91,7 +92,6 @@ public class ComputeEngineCloudMultipleLabelsIT {
     // configuration's labels
 
     String name = planned.iterator().next().displayName;
-    planned.iterator().next().future.get();
     String provisionedLabels = r.jenkins.getNode(name).getLabelString();
     // There should be the proper labels provisioned
     assertEquals(ITUtil.logs(sh, logOutput), MULTIPLE_LABEL, provisionedLabels);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -44,7 +43,7 @@ public class ComputeEngineCloudMultipleLabelsIT {
   @ClassRule public static JenkinsRule r = new JenkinsRule();
 
   private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
-  private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
+  private static StreamHandler sh;
   private static ComputeClient client;
   private static Map<String, String> label =
       ITUtil.getLabel(ComputeEngineCloudMultipleLabelsIT.class);
@@ -52,9 +51,12 @@ public class ComputeEngineCloudMultipleLabelsIT {
 
   @BeforeClass
   public static void init() throws Exception {
-    client = ITUtil.init(r, sh, label, log);
+    log.info("init");
+    ITUtil.initCredentials(r);
+    ComputeEngineCloud cloud = ITUtil.initCloud(r);
+    sh = ITUtil.initLogging(logOutput);
+    client = ITUtil.initClient(r, label, log);
 
-    ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
     InstanceConfiguration ic =
         ITUtil.instanceConfiguration(
             ITUtil.DEB_JAVA_STARTUP_SCRIPT,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -41,13 +41,13 @@ public class ComputeEngineCloudMultipleLabelsIT {
 
   private static final String MULTIPLE_LABEL = "integration test";
 
-  @ClassRule
-  public static JenkinsRule r = new JenkinsRule();
+  @ClassRule public static JenkinsRule r = new JenkinsRule();
 
   private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
   private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
   private static ComputeClient client;
-  private static Map<String, String> label = ITUtil.getLabel(ComputeEngineCloudMultipleLabelsIT.class);
+  private static Map<String, String> label =
+      ITUtil.getLabel(ComputeEngineCloudMultipleLabelsIT.class);
   private static Collection<PlannedNode> planned;
 
   @BeforeClass
@@ -55,7 +55,15 @@ public class ComputeEngineCloudMultipleLabelsIT {
     client = ITUtil.init(r, sh, label, log);
 
     ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-    InstanceConfiguration ic = ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, ITUtil.NUM_EXECUTORS, MULTIPLE_LABEL, label, false, false, ITUtil.NULL_TEMPLATE);
+    InstanceConfiguration ic =
+        ITUtil.instanceConfiguration(
+            ITUtil.DEB_JAVA_STARTUP_SCRIPT,
+            ITUtil.NUM_EXECUTORS,
+            MULTIPLE_LABEL,
+            label,
+            false,
+            false,
+            ITUtil.NULL_TEMPLATE);
     cloud.addConfiguration(ic);
     // Add a new node
     planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 1);
@@ -66,10 +74,10 @@ public class ComputeEngineCloudMultipleLabelsIT {
     ITUtil.teardown(sh, logOutput, client, label, log);
   }
 
-
   @Test(timeout = 300000)
   public void testMultipleLabelsForJob() {
-    // For a configuration with multiple labels, test if job label matches one of the configuration's labels
+    // For a configuration with multiple labels, test if job label matches one of the
+    // configuration's labels
 
     // There should be a planned node
     assertEquals(ITUtil.logs(sh, logOutput), 1, planned.size());
@@ -77,7 +85,8 @@ public class ComputeEngineCloudMultipleLabelsIT {
 
   @Test(timeout = 300000)
   public void testMultipleLabelsInConfig() throws Exception {
-    // For a configuration with multiple labels, test if job label matches one of the configuration's labels
+    // For a configuration with multiple labels, test if job label matches one of the
+    // configuration's labels
 
     String name = planned.iterator().next().displayName;
     planned.iterator().next().future.get();

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -1,0 +1,76 @@
+package com.google.jenkins.plugins.computeengine.integration;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import com.google.jenkins.plugins.computeengine.client.ComputeClient;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ComputeEngineCloudMultipleLabelsIT {
+  private static Logger log = Logger.getLogger(ComputeEngineCloudMultipleLabelsIT.class.getName());
+
+  private static final String MULTIPLE_LABEL = "integration test";
+
+  @ClassRule
+  public static JenkinsRule r = new JenkinsRule();
+
+  private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
+  private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
+  private static ComputeClient client;
+  private static Map<String, String> label = ITUtil.getLabel(ComputeEngineCloudMultipleLabelsIT.class);
+  private static Collection<PlannedNode> planned;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    client = ITUtil.init(r, sh, label, log);
+
+    ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
+    InstanceConfiguration ic = validInstanceConfigurationWithLabels(MULTIPLE_LABEL);
+    cloud.addConfiguration(ic);
+    // Add a new node
+    planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 1);
+  }
+
+  @AfterClass
+  public static void teardown() throws IOException {
+    ITUtil.teardown(sh, logOutput, client, label, log);
+  }
+
+
+  @Test(timeout = 300000)
+  public void testMultipleLabelsForJob() {
+    // For a configuration with multiple labels, test if job label matches one of the configuration's labels
+
+    // There should be a planned node
+    assertEquals(ITUtil.logs(sh, logOutput), 1, planned.size());
+  }
+
+  @Test(timeout = 300000)
+  public void testMultipleLabelsInConfig() throws Exception {
+    // For a configuration with multiple labels, test if job label matches one of the configuration's labels
+
+    String name = planned.iterator().next().displayName;
+    planned.iterator().next().future.get();
+    String provisionedLabels = r.jenkins.getNode(name).getLabelString();
+    // There should be the proper labels provisioned
+    assertEquals(ITUtil.logs(sh, logOutput), MULTIPLE_LABEL, provisionedLabels);
+  }
+
+  private static InstanceConfiguration validInstanceConfigurationWithLabels(String labels) {
+    return ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, ITUtil.NUM_EXECUTORS, labels, label, false, false, ITUtil.NULL_TEMPLATE);
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -77,7 +77,7 @@ public class ComputeEngineCloudMultipleLabelsIT {
     ITUtil.teardown(sh, logOutput, client, label, log);
   }
 
-  @Test(timeout = 300000)
+  @Test
   public void testMultipleLabelsForJob() {
     // For a configuration with multiple labels, test if job label matches one of the
     // configuration's labels
@@ -86,7 +86,7 @@ public class ComputeEngineCloudMultipleLabelsIT {
     assertEquals(ITUtil.logs(sh, logOutput), 1, planned.size());
   }
 
-  @Test(timeout = 300000)
+  @Test
   public void testMultipleLabelsInConfig() throws Exception {
     // For a configuration with multiple labels, test if job label matches one of the
     // configuration's labels

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.computeengine.integration;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -55,7 +55,7 @@ public class ComputeEngineCloudMultipleLabelsIT {
     client = ITUtil.init(r, sh, label, log);
 
     ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-    InstanceConfiguration ic = validInstanceConfigurationWithLabels(MULTIPLE_LABEL);
+    InstanceConfiguration ic = ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, ITUtil.NUM_EXECUTORS, MULTIPLE_LABEL, label, false, false, ITUtil.NULL_TEMPLATE);
     cloud.addConfiguration(ic);
     // Add a new node
     planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 1);
@@ -84,9 +84,5 @@ public class ComputeEngineCloudMultipleLabelsIT {
     String provisionedLabels = r.jenkins.getNode(name).getLabelString();
     // There should be the proper labels provisioned
     assertEquals(ITUtil.logs(sh, logOutput), MULTIPLE_LABEL, provisionedLabels);
-  }
-
-  private static InstanceConfiguration validInstanceConfigurationWithLabels(String labels) {
-    return ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, ITUtil.NUM_EXECUTORS, labels, label, false, false, ITUtil.NULL_TEMPLATE);
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -62,7 +62,7 @@ public class ComputeEngineCloudWorkerCreatedIT {
   @Test(timeout = 300000)
   public void testWorkerCreated() throws Exception {
     ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-    InstanceConfiguration ic = validInstanceConfiguration();
+    InstanceConfiguration ic = ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, ITUtil.NUM_EXECUTORS, ITUtil.LABEL, label, false, false, ITUtil.NULL_TEMPLATE);
     cloud.addConfiguration(ic);
     // Add a new node
     Collection<PlannedNode> planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 1);
@@ -86,9 +86,5 @@ public class ComputeEngineCloudWorkerCreatedIT {
     // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name prefix
     assertEquals(ITUtil.logs(sh, logOutput), ic.namePrefix, i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
     assertEquals(ITUtil.logs(sh, logOutput), cloud.getInstanceId(), i.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));
-  }
-
-  private static InstanceConfiguration validInstanceConfiguration() {
-    return ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, ITUtil.NUM_EXECUTORS, ITUtil.LABEL, label, false, false, ITUtil.NULL_TEMPLATE);
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
 import java.util.logging.StreamHandler;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -44,14 +43,18 @@ public class ComputeEngineCloudWorkerCreatedIT {
   @ClassRule public static JenkinsRule r = new JenkinsRule();
 
   private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
-  private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
+  private static StreamHandler sh;
   private static ComputeClient client;
   private static Map<String, String> label =
       ITUtil.getLabel(ComputeEngineCloudWorkerCreatedIT.class);
 
   @BeforeClass
   public static void init() throws Exception {
-    client = ITUtil.init(r, sh, label, log);
+    log.info("init");
+    ITUtil.initCredentials(r);
+    ITUtil.initCloud(r);
+    sh = ITUtil.initLogging(logOutput);
+    client = ITUtil.initClient(r, label, log);
   }
 
   @AfterClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -1,5 +1,20 @@
-package com.google.jenkins.plugins.computeengine.integration;
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package com.google.jenkins.plugins.computeengine.integration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -1,0 +1,79 @@
+package com.google.jenkins.plugins.computeengine.integration;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.google.api.services.compute.model.Instance;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import com.google.jenkins.plugins.computeengine.client.ComputeClient;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ComputeEngineCloudWorkerCreatedIT {
+  private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerCreatedIT.class.getName());
+
+  @ClassRule
+  public static JenkinsRule r = new JenkinsRule();
+
+  private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
+  private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
+  private static ComputeClient client;
+  private static Map<String, String> label = ITUtil.getLabel(ComputeEngineCloudWorkerCreatedIT.class);
+
+  @BeforeClass
+  public static void init() throws Exception {
+     client = ITUtil.init(r, sh, label, log);
+  }
+
+  @AfterClass
+  public static void teardown() throws IOException {
+    ITUtil.teardown(sh, logOutput, client, label, log);
+  }
+
+  @Test(timeout = 300000)
+  public void testWorkerCreated() throws Exception {
+    ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
+    InstanceConfiguration ic = validInstanceConfiguration();
+    cloud.addConfiguration(ic);
+    // Add a new node
+    Collection<PlannedNode> planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 1);
+
+    // There should be a planned node
+    assertEquals(ITUtil.logs(sh, logOutput), 1, planned.size());
+
+    String name = planned.iterator().next().displayName;
+
+    // Wait for the node creation to finish
+    planned.iterator().next().future.get();
+
+    // There should be no warning logs
+    assertFalse(ITUtil.logs(sh, logOutput), ITUtil.logs(sh, logOutput).contains("WARNING"));
+
+    Instance i = cloud.getClient().getInstance(ITUtil.projectId, ITUtil.ZONE, name);
+
+    // The created instance should have 3 labels
+    assertEquals(ITUtil.logs(sh, logOutput), 3, i.getLabels().size());
+
+    // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name prefix
+    assertEquals(ITUtil.logs(sh, logOutput), ic.namePrefix, i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
+    assertEquals(ITUtil.logs(sh, logOutput), cloud.getInstanceId(), i.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));
+  }
+
+  private static InstanceConfiguration validInstanceConfiguration() {
+    return ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, ITUtil.NUM_EXECUTORS, ITUtil.LABEL, label, false, false, ITUtil.NULL_TEMPLATE);
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -100,7 +100,7 @@ public class ComputeEngineCloudWorkerCreatedIT {
   }
 
   @Test
-  public void testWorkerCreatedConfigLabelLabelKeyAndValue() {
+  public void testWorkerCreatedConfigLabelKeyAndValue() {
     // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name
     // prefix
     assertEquals(

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -41,17 +41,17 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ComputeEngineCloudWorkerCreatedIT {
   private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerCreatedIT.class.getName());
 
-  @ClassRule
-  public static JenkinsRule r = new JenkinsRule();
+  @ClassRule public static JenkinsRule r = new JenkinsRule();
 
   private static ByteArrayOutputStream logOutput = new ByteArrayOutputStream();
   private static StreamHandler sh = new StreamHandler(logOutput, new SimpleFormatter());
   private static ComputeClient client;
-  private static Map<String, String> label = ITUtil.getLabel(ComputeEngineCloudWorkerCreatedIT.class);
+  private static Map<String, String> label =
+      ITUtil.getLabel(ComputeEngineCloudWorkerCreatedIT.class);
 
   @BeforeClass
   public static void init() throws Exception {
-     client = ITUtil.init(r, sh, label, log);
+    client = ITUtil.init(r, sh, label, log);
   }
 
   @AfterClass
@@ -62,7 +62,15 @@ public class ComputeEngineCloudWorkerCreatedIT {
   @Test(timeout = 300000)
   public void testWorkerCreated() throws Exception {
     ComputeEngineCloud cloud = (ComputeEngineCloud) r.jenkins.clouds.get(0);
-    InstanceConfiguration ic = ITUtil.instanceConfiguration(ITUtil.DEB_JAVA_STARTUP_SCRIPT, ITUtil.NUM_EXECUTORS, ITUtil.LABEL, label, false, false, ITUtil.NULL_TEMPLATE);
+    InstanceConfiguration ic =
+        ITUtil.instanceConfiguration(
+            ITUtil.DEB_JAVA_STARTUP_SCRIPT,
+            ITUtil.NUM_EXECUTORS,
+            ITUtil.LABEL,
+            label,
+            false,
+            false,
+            ITUtil.NULL_TEMPLATE);
     cloud.addConfiguration(ic);
     // Add a new node
     Collection<PlannedNode> planned = cloud.provision(new LabelAtom(ITUtil.LABEL), 1);
@@ -83,8 +91,15 @@ public class ComputeEngineCloudWorkerCreatedIT {
     // The created instance should have 3 labels
     assertEquals(ITUtil.logs(sh, logOutput), 3, i.getLabels().size());
 
-    // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name prefix
-    assertEquals(ITUtil.logs(sh, logOutput), ic.namePrefix, i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
-    assertEquals(ITUtil.logs(sh, logOutput), cloud.getInstanceId(), i.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));
+    // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name
+    // prefix
+    assertEquals(
+        ITUtil.logs(sh, logOutput),
+        ic.namePrefix,
+        i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
+    assertEquals(
+        ITUtil.logs(sh, logOutput),
+        cloud.getInstanceId(),
+        i.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -100,13 +100,18 @@ public class ComputeEngineCloudWorkerCreatedIT {
   }
 
   @Test
-  public void testWorkerCreatedLabelKeyAndValue() {
+  public void testWorkerCreatedConfigLabelLabelKeyAndValue() {
     // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name
     // prefix
     assertEquals(
         ITUtil.logs(sh, logOutput),
         ic.namePrefix,
         i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
+  }
+
+  @Test
+  public void testWorkerCreatedCloudIdKeyAndValue() {
+    // Instance should have a label with key CLOUD_ID_LABEL_KEY and value equal to the instance ID
     assertEquals(
         ITUtil.logs(sh, logOutput),
         cloud.getInstanceId(),

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -86,7 +86,7 @@ public class ComputeEngineCloudWorkerCreatedIT {
     // There should be no warning logs
     assertFalse(ITUtil.logs(sh, logOutput), ITUtil.logs(sh, logOutput).contains("WARNING"));
 
-    Instance i = cloud.getClient().getInstance(ITUtil.projectId, ITUtil.ZONE, name);
+    Instance i = cloud.getClient().getInstance(ITUtil.PROJECT_ID, ITUtil.ZONE, name);
 
     // The created instance should have 3 labels
     assertEquals(ITUtil.logs(sh, logOutput), 3, i.getLabels().size());

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -182,14 +182,14 @@ class ITUtil {
             BOOT_DISK_IMAGE_NAME,
             BOOT_DISK_PROJECT_ID,
             BOOT_DISK_SIZE_GB_STR,
-            false,
-            "",
-            "",
+            false, /* windows */
+            "", /* windowsPasswordCredentialsId */
+            "", /* windowsPrivateKeyCredentialsId */
             createSnapshot,
-            null,
+            null, /* remoteFs */
             new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),
             EXTERNAL_ADDR,
-            false,
+            false, /*useInternalAddress */
             NETWORK_TAGS,
             SERVICE_ACCOUNT_EMAIL,
             RETENTION_TIME_MINUTES_STR,
@@ -205,6 +205,7 @@ class ITUtil {
 
   static Map<String, String> getLabel(Class testClass) {
     // GCE labels can only be lower case letters, numbers, or dashes
+    // Used to label the nodes created in a given testClass for deletion
     return ImmutableMap.of(testClass.getSimpleName().toLowerCase(), "delete");
   }
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -48,14 +48,15 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 class ITUtil {
 
-  static final String DEB_JAVA_STARTUP_SCRIPT = "#!/bin/bash\n" +
-      "/etc/init.d/ssh stop\n" +
-      "echo \"deb http://http.debian.net/debian stretch-backports main\" | \\\n" +
-      "      sudo tee --append /etc/apt/sources.list > /dev/null\n" +
-      "apt-get -y update\n" +
-      "apt-get -y install -t stretch-backports openjdk-8-jdk\n" +
-      "update-java-alternatives -s java-1.8.0-openjdk-amd64\n" +
-      "/etc/init.d/ssh start";
+  static final String DEB_JAVA_STARTUP_SCRIPT =
+      "#!/bin/bash\n"
+          + "/etc/init.d/ssh stop\n"
+          + "echo \"deb http://http.debian.net/debian stretch-backports main\" | \\\n"
+          + "      sudo tee --append /etc/apt/sources.list > /dev/null\n"
+          + "apt-get -y update\n"
+          + "apt-get -y install -t stretch-backports openjdk-8-jdk\n"
+          + "update-java-alternatives -s java-1.8.0-openjdk-amd64\n"
+          + "/etc/init.d/ssh start";
 
   private static final String CLOUD_NAME = "integration";
   private static final String NAME_PREFIX = "integration";
@@ -72,7 +73,8 @@ class ITUtil {
   private static final String BOOT_DISK_TYPE = ZONE_BASE + "/diskTypes/pd-ssd";
   private static final boolean BOOT_DISK_AUTODELETE = true;
   private static final String BOOT_DISK_PROJECT_ID = "debian-cloud";
-  private static final String BOOT_DISK_IMAGE_NAME = "projects/debian-cloud/global/images/family/debian-9";
+  private static final String BOOT_DISK_IMAGE_NAME =
+      "projects/debian-cloud/global/images/family/debian-9";
   private static final String BOOT_DISK_SIZE_GB_STR = "10";
   private static final Node.Mode NODE_MODE = Node.Mode.EXCLUSIVE;
   private static final String ACCELERATOR_NAME = "";
@@ -97,7 +99,8 @@ class ITUtil {
     return String.format(s, projectId);
   }
 
-  static ComputeClient init(JenkinsRule r, StreamHandler sh, Map<String, String> label, Logger log) throws Exception {
+  static ComputeClient init(JenkinsRule r, StreamHandler sh, Map<String, String> label, Logger log)
+      throws Exception {
     log.info("init");
 
     assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
@@ -116,7 +119,9 @@ class ITUtil {
     ComputeEngineCloud gcp = new ComputeEngineCloud(null, CLOUD_NAME, projectId, projectId, "10", null);
 
     // Capture log output to make sense of most failures
-    Logger cloudLogger = LogManager.getLogManager().getLogger("com.google.jenkins.plugins.computeengine.ComputeEngineCloud");
+    Logger cloudLogger =
+        LogManager.getLogManager()
+            .getLogger("com.google.jenkins.plugins.computeengine.ComputeEngineCloud");
     if (cloudLogger != null) {
       cloudLogger.addHandler(sh);
     }
@@ -131,7 +136,9 @@ class ITUtil {
     assertNotNull("ComputeClient can not be null", client);
 
     // Other logging
-    Logger clientLogger = LogManager.getLogManager().getLogger("com.google.jenkins.plugins.computeengine.ComputeClient");
+    Logger clientLogger =
+        LogManager.getLogManager()
+            .getLogger("com.google.jenkins.plugins.computeengine.ComputeClient");
     if (clientLogger != null) {
       clientLogger.addHandler(sh);
     }
@@ -140,49 +147,61 @@ class ITUtil {
     return client;
   }
 
-  static void teardown(StreamHandler sh, ByteArrayOutputStream logOutput, ComputeClient client, Map<String, String> label, Logger log) throws IOException {
+  static void teardown(
+      StreamHandler sh,
+      ByteArrayOutputStream logOutput,
+      ComputeClient client,
+      Map<String, String> label,
+      Logger log)
+      throws IOException {
     log.info("teardown");
     deleteIntegrationInstances(false, client, label, log);
     sh.close();
     log.info(logOutput.toString());
   }
 
-  static InstanceConfiguration instanceConfiguration(String startupScript, String numExecutors, String jenkinsLabels, Map<String, String> label,
-      boolean createSnapshot, boolean oneShot, String template) {
-    InstanceConfiguration ic = new InstanceConfiguration(
-        NAME_PREFIX,
-        REGION,
-        ZONE,
-        MACHINE_TYPE,
-        numExecutors,
-        startupScript,
-        PREEMPTIBLE,
-        MIN_CPU_PLATFORM,
-        jenkinsLabels,
-        CONFIG_DESC,
-        BOOT_DISK_TYPE,
-        BOOT_DISK_AUTODELETE,
-        BOOT_DISK_IMAGE_NAME,
-        BOOT_DISK_PROJECT_ID,
-        BOOT_DISK_SIZE_GB_STR,
-        false,
-        "",
-        "",
-        createSnapshot,
-        null,
-        new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),
-        EXTERNAL_ADDR,
-        false,
-        NETWORK_TAGS,
-        SERVICE_ACCOUNT_EMAIL,
-        RETENTION_TIME_MINUTES_STR,
-        LAUNCH_TIMEOUT_SECONDS_STR,
-        NODE_MODE,
-        new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT),
-        RUN_AS_USER,
-        oneShot,
-        template
-    );
+  static InstanceConfiguration instanceConfiguration(
+      String startupScript,
+      String numExecutors,
+      String jenkinsLabels,
+      Map<String, String> label,
+      boolean createSnapshot,
+      boolean oneShot,
+      String template) {
+    InstanceConfiguration ic =
+        new InstanceConfiguration(
+            NAME_PREFIX,
+            REGION,
+            ZONE,
+            MACHINE_TYPE,
+            numExecutors,
+            startupScript,
+            PREEMPTIBLE,
+            MIN_CPU_PLATFORM,
+            jenkinsLabels,
+            CONFIG_DESC,
+            BOOT_DISK_TYPE,
+            BOOT_DISK_AUTODELETE,
+            BOOT_DISK_IMAGE_NAME,
+            BOOT_DISK_PROJECT_ID,
+            BOOT_DISK_SIZE_GB_STR,
+            false,
+            "",
+            "",
+            createSnapshot,
+            null,
+            new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),
+            EXTERNAL_ADDR,
+            false,
+            NETWORK_TAGS,
+            SERVICE_ACCOUNT_EMAIL,
+            RETENTION_TIME_MINUTES_STR,
+            LAUNCH_TIMEOUT_SECONDS_STR,
+            NODE_MODE,
+            new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT),
+            RUN_AS_USER,
+            oneShot,
+            template);
     ic.appendLabels(label);
     return ic;
   }
@@ -192,14 +211,17 @@ class ITUtil {
     return ImmutableMap.of(testClass.getSimpleName().toLowerCase(), "delete");
   }
 
-  private static void deleteIntegrationInstances(boolean waitForCompletion, ComputeClient client, Map<String, String> label, Logger log) throws IOException {
+  private static void deleteIntegrationInstances(
+      boolean waitForCompletion, ComputeClient client, Map<String, String> label, Logger log)
+      throws IOException {
     List<Instance> instances = client.getInstancesWithLabel(projectId, label);
     for (Instance i : instances) {
       safeDelete(i.getName(), waitForCompletion, client, log);
     }
   }
 
-  private static void safeDelete(String instanceId, boolean waitForCompletion, ComputeClient client, Logger log) {
+  private static void safeDelete(
+      String instanceId, boolean waitForCompletion, ComputeClient client, Logger log) {
     try {
       Operation op = client.terminateInstance(projectId, ZONE, instanceId);
       if (waitForCompletion)

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.computeengine.integration;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -1,0 +1,200 @@
+package com.google.jenkins.plugins.computeengine.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Operation;
+import com.google.common.collect.ImmutableMap;
+import com.google.jenkins.plugins.computeengine.AcceleratorConfiguration;
+import com.google.jenkins.plugins.computeengine.AutofilledNetworkConfiguration;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import com.google.jenkins.plugins.computeengine.StringJsonServiceAccountConfig;
+import com.google.jenkins.plugins.computeengine.client.ClientFactory;
+import com.google.jenkins.plugins.computeengine.client.ComputeClient;
+import com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials;
+import com.google.jenkins.plugins.credentials.oauth.ServiceAccountConfig;
+import hudson.model.Node;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+import org.jvnet.hudson.test.JenkinsRule;
+
+class ITUtil {
+
+  static final String DEB_JAVA_STARTUP_SCRIPT = "#!/bin/bash\n" +
+      "/etc/init.d/ssh stop\n" +
+      "echo \"deb http://http.debian.net/debian stretch-backports main\" | \\\n" +
+      "      sudo tee --append /etc/apt/sources.list > /dev/null\n" +
+      "apt-get -y update\n" +
+      "apt-get -y install -t stretch-backports openjdk-8-jdk\n" +
+      "update-java-alternatives -s java-1.8.0-openjdk-amd64\n" +
+      "/etc/init.d/ssh start";
+
+  private static final String CLOUD_NAME = "integration";
+  private static final String NAME_PREFIX = "integration";
+  private static final String REGION = format("projects/%s/regions/us-west1");
+  static final String ZONE = "us-west1-a";
+  private static final String ZONE_BASE = format("projects/%s/zones/" + ZONE);
+  static final String LABEL = "integration";
+  private static final String MACHINE_TYPE = ZONE_BASE + "/machineTypes/n1-standard-1";
+  static final String NUM_EXECUTORS = "1";
+  private static final boolean PREEMPTIBLE = false;
+  //  TODO: Write a test to see if min cpu platform worked by picking a higher version?
+  private static final String MIN_CPU_PLATFORM = "Intel Broadwell";
+  private static final String CONFIG_DESC = "integration";
+  private static final String BOOT_DISK_TYPE = ZONE_BASE + "/diskTypes/pd-ssd";
+  private static final boolean BOOT_DISK_AUTODELETE = true;
+  private static final String BOOT_DISK_PROJECT_ID = "debian-cloud";
+  private static final String BOOT_DISK_IMAGE_NAME = "projects/debian-cloud/global/images/family/debian-9";
+  private static final String BOOT_DISK_SIZE_GB_STR = "10";
+  private static final Node.Mode NODE_MODE = Node.Mode.EXCLUSIVE;
+  private static final String ACCELERATOR_NAME = "";
+  private static final String ACCELERATOR_COUNT = "";
+  private static final String RUN_AS_USER = "jenkins";
+  static final String NULL_TEMPLATE = null;
+  private static final String NETWORK_NAME = format("projects/%s/global/networks/default");
+  private static final String SUBNETWORK_NAME = "default";
+  private static final boolean EXTERNAL_ADDR = true;
+  private static final String NETWORK_TAGS = "ssh";
+  private static final String SERVICE_ACCOUNT_EMAIL = "";
+  private static final String RETENTION_TIME_MINUTES_STR = "";
+  private static final String LAUNCH_TIMEOUT_SECONDS_STR = "";
+
+  static String projectId = format("%s");
+
+  private static String format(String s) {
+    String projectId = System.getenv("GOOGLE_PROJECT_ID");
+    if (projectId == null) {
+      throw new RuntimeException("GOOGLE_PROJECT_ID env var must be set");
+    }
+    return String.format(s, projectId);
+  }
+
+  static ComputeClient init(JenkinsRule r, StreamHandler sh, Map<String, String> label, Logger log) throws Exception {
+    log.info("init");
+
+    assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
+
+    String serviceAccountKeyJson = System.getenv("GOOGLE_CREDENTIALS");
+    assertNotNull("GOOGLE_CREDENTIALS env var must be set", serviceAccountKeyJson);
+
+    ServiceAccountConfig sac = new StringJsonServiceAccountConfig(serviceAccountKeyJson);
+    Credentials c = new GoogleRobotPrivateKeyCredentials(projectId, sac, null);
+
+    CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
+    assertNotNull("Credentials store can not be null", store);
+    store.addCredentials(Domain.global(), c);
+
+    // Add Cloud plugin
+    ComputeEngineCloud gcp = new ComputeEngineCloud(null, CLOUD_NAME, projectId, projectId, "10", null);
+
+    // Capture log output to make sense of most failures
+    Logger cloudLogger = LogManager.getLogManager().getLogger("com.google.jenkins.plugins.computeengine.ComputeEngineCloud");
+    if (cloudLogger != null) {
+      cloudLogger.addHandler(sh);
+    }
+
+    assertEquals(0, r.jenkins.clouds.size());
+    r.jenkins.clouds.add(gcp);
+    assertEquals(1, r.jenkins.clouds.size());
+
+    // Get a compute client for out-of-band calls to GCE
+    ClientFactory clientFactory = new ClientFactory(r.jenkins, new ArrayList<>(), projectId);
+    ComputeClient client = clientFactory.compute();
+    assertNotNull("ComputeClient can not be null", client);
+
+    // Other logging
+    Logger clientLogger = LogManager.getLogManager().getLogger("com.google.jenkins.plugins.computeengine.ComputeClient");
+    if (clientLogger != null) {
+      clientLogger.addHandler(sh);
+    }
+
+    deleteIntegrationInstances(true, client, label, log);
+    return client;
+  }
+
+  static void teardown(StreamHandler sh, ByteArrayOutputStream logOutput, ComputeClient client, Map<String, String> label, Logger log) throws IOException {
+    log.info("teardown");
+    deleteIntegrationInstances(false, client, label, log);
+    sh.close();
+    log.info(logOutput.toString());
+  }
+
+  static InstanceConfiguration instanceConfiguration(String startupScript, String numExecutors, String jenkinsLabels, Map<String, String> label,
+      boolean createSnapshot, boolean oneShot, String template) {
+    InstanceConfiguration ic = new InstanceConfiguration(
+        NAME_PREFIX,
+        REGION,
+        ZONE,
+        MACHINE_TYPE,
+        numExecutors,
+        startupScript,
+        PREEMPTIBLE,
+        MIN_CPU_PLATFORM,
+        jenkinsLabels,
+        CONFIG_DESC,
+        BOOT_DISK_TYPE,
+        BOOT_DISK_AUTODELETE,
+        BOOT_DISK_IMAGE_NAME,
+        BOOT_DISK_PROJECT_ID,
+        BOOT_DISK_SIZE_GB_STR,
+        false,
+        "",
+        "",
+        createSnapshot,
+        null,
+        new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),
+        EXTERNAL_ADDR,
+        false,
+        NETWORK_TAGS,
+        SERVICE_ACCOUNT_EMAIL,
+        RETENTION_TIME_MINUTES_STR,
+        LAUNCH_TIMEOUT_SECONDS_STR,
+        NODE_MODE,
+        new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT),
+        RUN_AS_USER,
+        oneShot,
+        template
+    );
+    ic.appendLabels(label);
+    return ic;
+  }
+
+  static Map<String, String> getLabel(Class testClass) {
+    // GCE labels can only be lower case letters, numbers, or dashes
+    return ImmutableMap.of(testClass.getSimpleName().toLowerCase(), "delete");
+  }
+
+  private static void deleteIntegrationInstances(boolean waitForCompletion, ComputeClient client, Map<String, String> label, Logger log) throws IOException {
+    List<Instance> instances = client.getInstancesWithLabel(projectId, label);
+    for (Instance i : instances) {
+      safeDelete(i.getName(), waitForCompletion, client, log);
+    }
+  }
+
+  private static void safeDelete(String instanceId, boolean waitForCompletion, ComputeClient client, Logger log) {
+    try {
+      Operation op = client.terminateInstance(projectId, ZONE, instanceId);
+      if (waitForCompletion)
+        client.waitForOperationCompletion(projectId, op.getName(), op.getZone(), 3 * 60 * 1000);
+    } catch (Exception e) {
+      log.warning(String.format("Error deleting instance %s: %s", instanceId, e.getMessage()));
+    }
+  }
+
+  static String logs(StreamHandler sh, ByteArrayOutputStream logOutput) {
+    sh.flush();
+    return logOutput.toString();
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -126,12 +126,14 @@ class ITUtil {
     if (cloudLogger != null) {
       cloudLogger.addHandler(sh);
     }
+
     Logger clientLogger =
         LogManager.getLogManager()
             .getLogger("com.google.jenkins.plugins.computeengine.ComputeClient");
     if (clientLogger != null) {
       clientLogger.addHandler(sh);
     }
+
     return sh;
   }
 


### PR DESCRIPTION
This is a proof of concept for parallelized integration tests. It turns out that Jenkins has some concurrency built into the parent pom.xml. This is enabled by increasing the concurrency property in the pom file, which comes from the parent jenkins testing [pom.xml](https://github.com/jenkinsci/jenkins/blob/d3301258cb8b90b2e2c0671ec71e5f7b333fa65d/test-pom/pom.xml#L41).

As a side effect we get class-level concurrency for the unit tests as well. For the integration test I've also enabled parallel methods, so within the class that contains 2 methods with a very similar setup, those test methods run in parallel. On my machine this set of tests takes just under 2 minutes to run with concurrency enabled, and about three and a half minutes with it disabled. When I add more tests I only expect time to increase by the additional amount of time needed for the longest integration test.

I've pulled in much of the shared code/constants from `ComputeEngineCloudIT` into `ITUtil`, and tried to change as little as possible. The new tests are very similar to their old counterparts with variables passed around that replace the shared objects from earlier.

Submitting this here as WIP for early feedback before I do something similar for the remaining tests.