### PR TITLE
#58: Add builder for Instance Configuration 

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -152,7 +152,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
       c.appendLabel(CLOUD_ID_LABEL_KEY, getInstanceId());
 
       // Apply a label that identifies the name of this instance configuration
-      c.appendLabel(CONFIG_LABEL_KEY, c.namePrefix);
+      c.appendLabel(CONFIG_LABEL_KEY, c.getNamePrefix());
     }
     return this;
   }
@@ -344,7 +344,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
   /** Gets {@link InstanceConfiguration} that has the matching Description. */
   public InstanceConfiguration getInstanceConfig(String description) {
     for (InstanceConfiguration c : configurations) {
-      if (c.description.equals(description)) {
+      if (c.getDescription().equals(description)) {
         return c;
       }
     }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -1060,4 +1060,205 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       return FormValidation.ok();
     }
   }
+
+  // For use in Builder only
+  private InstanceConfiguration() {}
+
+  public static class Builder {
+
+    private InstanceConfiguration instanceConfiguration;
+
+    public Builder() {
+      instanceConfiguration = new InstanceConfiguration();
+    }
+
+    public Builder description(String description) {
+      instanceConfiguration.description = description;
+      return this;
+    }
+
+    public Builder namePrefix(String namePrefix) {
+      instanceConfiguration.namePrefix = namePrefix;
+      return this;
+    }
+
+    public Builder region(String region) {
+      instanceConfiguration.region = region;
+      return this;
+    }
+
+    public Builder zone(String zone) {
+      instanceConfiguration.zone = zone;
+      return this;
+    }
+
+    public Builder machineType(String machineType) {
+      instanceConfiguration.machineType = machineType;
+      return this;
+    }
+
+    public Builder numExecutorsStr(String numExecutorsStr) {
+      instanceConfiguration.numExecutors = intOrDefault(numExecutorsStr, DEFAULT_NUM_EXECUTORS);
+      instanceConfiguration.numExecutorsStr = instanceConfiguration.numExecutors.toString();
+      return this;
+    }
+
+    public Builder startupScript(String startupScript) {
+      instanceConfiguration.startupScript = startupScript;
+      return this;
+    }
+
+    public Builder preemptible(boolean preemptible) {
+      instanceConfiguration.preemptible = preemptible;
+      return this;
+    }
+
+    public Builder minCpuPlatform(String minCpuPlatform) {
+      instanceConfiguration.minCpuPlatform = minCpuPlatform;
+      return this;
+    }
+
+    public Builder labels(String labels) {
+      instanceConfiguration.labels = Util.fixNull(labels);
+      return this;
+    }
+
+    public Builder runAsUser(String runAsUser) {
+      instanceConfiguration.runAsUser = runAsUser;
+      return this;
+    }
+
+    public Builder bootDiskType(String bootDiskType) {
+      instanceConfiguration.bootDiskType = bootDiskType;
+      return this;
+    }
+
+    public Builder bootDiskAutoDelete(boolean bootDiskAutoDelete) {
+      instanceConfiguration.bootDiskAutoDelete = bootDiskAutoDelete;
+      return this;
+    }
+
+    public Builder bootDiskSourceImageName(String bootDiskSourceImageName) {
+      instanceConfiguration.bootDiskSourceImageName = bootDiskSourceImageName;
+      return this;
+    }
+
+    public Builder bootDiskSourceImageProject(String bootDiskSourceImageProject) {
+      instanceConfiguration.bootDiskSourceImageProject = bootDiskSourceImageProject;
+      return this;
+    }
+
+    public Builder networkConfiguration(NetworkConfiguration networkConfiguration) {
+      instanceConfiguration.networkConfiguration = networkConfiguration;
+      return this;
+    }
+
+    public Builder externalAddress(boolean externalAddress) {
+      instanceConfiguration.externalAddress = externalAddress;
+      return this;
+    }
+
+    public Builder useInternalAddress(boolean useInternalAddress) {
+      instanceConfiguration.useInternalAddress = useInternalAddress;
+      return this;
+    }
+
+    public Builder networkTags(String networkTags) {
+      instanceConfiguration.networkTags = Util.fixNull(networkTags).trim();
+      return this;
+    }
+
+    public Builder serviceAccountEmail(String serviceAccountEmail) {
+      instanceConfiguration.serviceAccountEmail = serviceAccountEmail;
+      return this;
+    }
+
+    public Builder mode(Node.Mode mode) {
+      instanceConfiguration.mode = mode;
+      return this;
+    }
+
+    public Builder acceleratorConfiguration(AcceleratorConfiguration acceleratorConfiguration) {
+      instanceConfiguration.acceleratorConfiguration = acceleratorConfiguration;
+      return this;
+    }
+
+    public Builder retentionTimeMinutesStr(String retentionTimeMinutesStr) {
+      instanceConfiguration.retentionTimeMinutes =
+          intOrDefault(retentionTimeMinutesStr, DEFAULT_RETENTION_TIME_MINUTES);
+      instanceConfiguration.retentionTimeMinutesStr =
+          instanceConfiguration.retentionTimeMinutes.toString();
+      return this;
+    }
+
+    public Builder launchTimeoutSecondsStr(String launchTimeoutSecondsStr) {
+      instanceConfiguration.launchTimeoutSeconds =
+          intOrDefault(launchTimeoutSecondsStr, DEFAULT_LAUNCH_TIMEOUT_SECONDS);
+      instanceConfiguration.launchTimeoutSecondsStr =
+          instanceConfiguration.launchTimeoutSeconds.toString();
+      return this;
+    }
+
+    public Builder bootDiskSizeGbStr(String bootDiskSizeGbStr) {
+      instanceConfiguration.bootDiskSizeGb =
+          longOrDefault(bootDiskSizeGbStr, DEFAULT_BOOT_DISK_SIZE_GB);
+      instanceConfiguration.bootDiskSizeGbStr = instanceConfiguration.bootDiskSizeGb.toString();
+      return this;
+    }
+
+    public Builder oneShot(boolean oneShot) {
+      instanceConfiguration.oneShot = oneShot;
+      return this;
+    }
+
+    public Builder template(String template) {
+      instanceConfiguration.template = template;
+      return this;
+    }
+
+    public Builder windows(boolean windows) {
+      instanceConfiguration.windows = windows;
+      return this;
+    }
+
+    public Builder windowsPasswordCredentialsId(String windowsPasswordCredentialsId) {
+      instanceConfiguration.windowsPasswordCredentialsId = windowsPasswordCredentialsId;
+      return this;
+    }
+
+    public Builder windowsPrivateKeyCredentialsId(String windowsPrivateKeyCredentialsId) {
+      instanceConfiguration.windowsPrivateKeyCredentialsId = windowsPrivateKeyCredentialsId;
+      return this;
+    }
+
+    public Builder createSnapshot(boolean createSnapshot) {
+      instanceConfiguration.createSnapshot = createSnapshot;
+      return this;
+    }
+
+    public Builder remoteFs(String remoteFs) {
+      instanceConfiguration.remoteFs = remoteFs;
+      return this;
+    }
+
+    public InstanceConfiguration build() {
+      if (instanceConfiguration.windows) {
+        instanceConfiguration.windowsConfig =
+            Optional.of(
+                new WindowsConfiguration(
+                    instanceConfiguration.runAsUser,
+                    instanceConfiguration.windowsPasswordCredentialsId,
+                    instanceConfiguration.windowsPrivateKeyCredentialsId));
+      } else {
+        instanceConfiguration.windowsConfig = Optional.empty();
+      }
+
+      if (!instanceConfiguration.oneShot) {
+        instanceConfiguration.createSnapshot = false;
+      }
+
+      instanceConfiguration.readResolve();
+      return instanceConfiguration;
+    }
+  }
 }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -163,9 +163,9 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     this.setRunAsUser(runAsUser);
     this.setWindowsPasswordCredentialsId(windowsPasswordCredentialsId);
     this.setWindowsPrivateKeyCredentialsId(windowsPrivateKeyCredentialsId);
-    this.windowsConfig =
+    this.setWindowsConfig(
         makeWindowsConfiguration(
-            windows, runAsUser, windowsPasswordCredentialsId, windowsPrivateKeyCredentialsId);
+            windows, runAsUser, windowsPasswordCredentialsId, windowsPrivateKeyCredentialsId));
     readResolve();
   }
 
@@ -324,6 +324,11 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   // Provided through constructor
   public void setWindowsPrivateKeyCredentialsId(String windowsPrivateKeyCredentialsId) {
     this.windowsPrivateKeyCredentialsId = windowsPrivateKeyCredentialsId;
+  }
+
+  // Generated in constructor
+  public void setWindowsConfig(Optional<WindowsConfiguration> windowsConfig) {
+    this.windowsConfig = windowsConfig;
   }
 
   @DataBoundSetter
@@ -1327,12 +1332,12 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     }
 
     public InstanceConfiguration build() {
-      instanceConfiguration.windowsConfig =
+      instanceConfiguration.setWindowsConfig(
           makeWindowsConfiguration(
               instanceConfiguration.windows,
               instanceConfiguration.runAsUser,
               instanceConfiguration.windowsPasswordCredentialsId,
-              instanceConfiguration.windowsPrivateKeyCredentialsId);
+              instanceConfiguration.windowsPrivateKeyCredentialsId));
       instanceConfiguration.readResolve();
       return instanceConfiguration;
     }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -108,39 +108,39 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
               add("windows-sql-cloud");
             }
           });
-  public final String description;
-  public final String namePrefix;
-  public final String region;
-  public final String zone;
-  public final String machineType;
-  public final String numExecutorsStr;
-  public final String startupScript;
-  public final boolean preemptible;
-  public final String minCpuPlatform;
-  public final String labels;
-  public final String runAsUser;
-  public final String bootDiskType;
-  public final boolean bootDiskAutoDelete;
-  public final String bootDiskSourceImageName;
-  public final String bootDiskSourceImageProject;
-  public final NetworkConfiguration networkConfiguration;
-  public final boolean externalAddress;
-  public final boolean useInternalAddress;
-  public final String networkTags;
-  public final String serviceAccountEmail;
-  public final Node.Mode mode;
-  public final AcceleratorConfiguration acceleratorConfiguration;
-  public final String retentionTimeMinutesStr;
-  public final String launchTimeoutSecondsStr;
-  public final String bootDiskSizeGbStr;
-  public final boolean oneShot;
-  public final String template;
-  public final boolean windows;
-  public final String windowsPasswordCredentialsId;
-  public final String windowsPrivateKeyCredentialsId;
-  public final Optional<WindowsConfiguration> windowsConfig;
-  public final boolean createSnapshot;
-  public final String remoteFs;
+  private String description;
+  private String namePrefix;
+  private String region;
+  private String zone;
+  private String machineType;
+  private String numExecutorsStr;
+  private String startupScript;
+  private boolean preemptible;
+  private String minCpuPlatform;
+  private String labels;
+  private String runAsUser;
+  private String bootDiskType;
+  private boolean bootDiskAutoDelete;
+  private String bootDiskSourceImageName;
+  private String bootDiskSourceImageProject;
+  private NetworkConfiguration networkConfiguration;
+  private boolean externalAddress;
+  private boolean useInternalAddress;
+  private String networkTags;
+  private String serviceAccountEmail;
+  private Node.Mode mode;
+  private AcceleratorConfiguration acceleratorConfiguration;
+  private String retentionTimeMinutesStr;
+  private String launchTimeoutSecondsStr;
+  private String bootDiskSizeGbStr;
+  private boolean oneShot;
+  private String template;
+  private boolean windows;
+  private String windowsPasswordCredentialsId;
+  private String windowsPrivateKeyCredentialsId;
+  private Optional<WindowsConfiguration> windowsConfig;
+  private boolean createSnapshot;
+  private String remoteFs;
   public Map<String, String> googleLabels;
   public Integer numExecutors;
   public Integer retentionTimeMinutes;
@@ -281,6 +281,134 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       return s.substring(s.indexOf("/projects/") + 1, s.length());
     }
     return s;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getNamePrefix() {
+    return namePrefix;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public String getZone() {
+    return zone;
+  }
+
+  public String getMachineType() {
+    return machineType;
+  }
+
+  public String getNumExecutorsStr() {
+    return numExecutorsStr;
+  }
+
+  public String getStartupScript() {
+    return startupScript;
+  }
+
+  public boolean isPreemptible() {
+    return preemptible;
+  }
+
+  public String getMinCpuPlatform() {
+    return minCpuPlatform;
+  }
+
+  public String getLabels() {
+    return labels;
+  }
+
+  public String getRunAsUser() {
+    return runAsUser;
+  }
+
+  public String getBootDiskType() {
+    return bootDiskType;
+  }
+
+  public boolean isBootDiskAutoDelete() {
+    return bootDiskAutoDelete;
+  }
+
+  public String getBootDiskSourceImageName() {
+    return bootDiskSourceImageName;
+  }
+
+  public String getBootDiskSourceImageProject() {
+    return bootDiskSourceImageProject;
+  }
+
+  public NetworkConfiguration getNetworkConfiguration() {
+    return networkConfiguration;
+  }
+
+  public boolean isExternalAddress() {
+    return externalAddress;
+  }
+
+  public boolean isUseInternalAddress() {
+    return useInternalAddress;
+  }
+
+  public String getNetworkTags() {
+    return networkTags;
+  }
+
+  public String getServiceAccountEmail() {
+    return serviceAccountEmail;
+  }
+
+  public AcceleratorConfiguration getAcceleratorConfiguration() {
+    return acceleratorConfiguration;
+  }
+
+  public String getRetentionTimeMinutesStr() {
+    return retentionTimeMinutesStr;
+  }
+
+  public String getLaunchTimeoutSecondsStr() {
+    return launchTimeoutSecondsStr;
+  }
+
+  public String getBootDiskSizeGbStr() {
+    return bootDiskSizeGbStr;
+  }
+
+  public boolean isOneShot() {
+    return oneShot;
+  }
+
+  public String getTemplate() {
+    return template;
+  }
+
+  public boolean isWindows() {
+    return windows;
+  }
+
+  public String getWindowsPasswordCredentialsId() {
+    return windowsPasswordCredentialsId;
+  }
+
+  public String getWindowsPrivateKeyCredentialsId() {
+    return windowsPrivateKeyCredentialsId;
+  }
+
+  public Optional<WindowsConfiguration> getWindowsConfig() {
+    return windowsConfig;
+  }
+
+  public boolean isCreateSnapshot() {
+    return createSnapshot;
+  }
+
+  public String getRemoteFs() {
+    return remoteFs;
   }
 
   public Descriptor<InstanceConfiguration> getDescriptor() {

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -262,7 +262,8 @@ public class ComputeEngineCloudIT {
 
     // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name
     // prefix
-    assertEquals(logs(), ic.namePrefix, i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
+    assertEquals(
+        logs(), ic.getNamePrefix(), i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
     assertEquals(
         logs(), cloud.getInstanceId(), i.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));
   }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudIT.java
@@ -561,39 +561,41 @@ public class ComputeEngineCloudIT {
       boolean oneShot,
       String template) {
     InstanceConfiguration ic =
-        new InstanceConfiguration(
-            NAME_PREFIX,
-            REGION,
-            ZONE,
-            MACHINE_TYPE,
-            numExecutors,
-            startupScript,
-            PREEMPTIBLE,
-            MIN_CPU_PLATFORM,
-            labels,
-            CONFIG_DESC,
-            BOOT_DISK_TYPE,
-            BOOT_DISK_AUTODELETE,
-            BOOT_DISK_IMAGE_NAME,
-            BOOT_DISK_PROJECT_ID,
-            BOOT_DISK_SIZE_GB_STR,
-            false,
-            "",
-            "",
-            createSnapshot,
-            null,
-            new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),
-            EXTERNAL_ADDR,
-            false,
-            NETWORK_TAGS,
-            SERVICE_ACCOUNT_EMAIL,
-            RETENTION_TIME_MINUTES_STR,
-            LAUNCH_TIMEOUT_SECONDS_STR,
-            NODE_MODE,
-            new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT),
-            RUN_AS_USER,
-            oneShot,
-            template);
+        new InstanceConfiguration.Builder()
+            .namePrefix(NAME_PREFIX)
+            .region(REGION)
+            .zone(ZONE)
+            .machineType(MACHINE_TYPE)
+            .numExecutorsStr(numExecutors)
+            .startupScript(startupScript)
+            .preemptible(PREEMPTIBLE)
+            .minCpuPlatform(MIN_CPU_PLATFORM)
+            .labels(labels)
+            .description(CONFIG_DESC)
+            .bootDiskType(BOOT_DISK_TYPE)
+            .bootDiskAutoDelete(BOOT_DISK_AUTODELETE)
+            .bootDiskSourceImageName(BOOT_DISK_IMAGE_NAME)
+            .bootDiskSourceImageProject(BOOT_DISK_PROJECT_ID)
+            .bootDiskSizeGbStr(BOOT_DISK_SIZE_GB_STR)
+            .windows(false)
+            .windowsPasswordCredentialsId("")
+            .windowsPrivateKeyCredentialsId("")
+            .createSnapshot(createSnapshot)
+            .remoteFs(null)
+            .networkConfiguration(new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME))
+            .externalAddress(EXTERNAL_ADDR)
+            .useInternalAddress(false)
+            .networkTags(NETWORK_TAGS)
+            .serviceAccountEmail(SERVICE_ACCOUNT_EMAIL)
+            .retentionTimeMinutesStr(RETENTION_TIME_MINUTES_STR)
+            .launchTimeoutSecondsStr(LAUNCH_TIMEOUT_SECONDS_STR)
+            .mode(NODE_MODE)
+            .acceleratorConfiguration(
+                new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
+            .runAsUser(RUN_AS_USER)
+            .oneShot(oneShot)
+            .template(template)
+            .build();
     ic.appendLabels(INTEGRATION_LABEL);
     return ic;
   }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -134,7 +134,7 @@ public class ComputeEngineCloudTest {
     Assert.assertEquals(ics.get(0), cloud.getInstanceConfig(l));
 
     // Configuration for description should match
-    Assert.assertEquals(ics.get(0), cloud.getInstanceConfig(ics.get(0).description));
+    Assert.assertEquals(ics.get(0), cloud.getInstanceConfig(ics.get(0).getDescription()));
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -339,39 +339,42 @@ public class ComputeEngineCloudWindowsIT {
             + "Restart-Service sshd";
 
     InstanceConfiguration ic =
-        new InstanceConfiguration(
-            NAME_PREFIX,
-            REGION,
-            ZONE,
-            MACHINE_TYPE,
-            NUM_EXECUTORS,
-            startupScript,
-            PREEMPTIBLE,
-            MIN_CPU_PLATFORM,
-            labels,
-            CONFIG_DESC,
-            BOOT_DISK_TYPE,
-            BOOT_DISK_AUTODELETE,
-            "projects/" + bootDiskProjectId + "/global/images/" + bootDiskImageName,
-            bootDiskProjectId,
-            BOOT_DISK_SIZE_GB_STR,
-            true,
-            "",
-            windowsPrivateKeyCredentialId,
-            createSnapshot,
-            null,
-            new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),
-            EXTERNAL_ADDR,
-            false,
-            NETWORK_TAGS,
-            SERVICE_ACCOUNT_EMAIL,
-            RETENTION_TIME_MINUTES_STR,
-            LAUNCH_TIMEOUT_SECONDS_STR,
-            NODE_MODE,
-            new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT),
-            RUN_AS_USER,
-            oneShot,
-            null);
+        new InstanceConfiguration.Builder()
+            .namePrefix(NAME_PREFIX)
+            .region(REGION)
+            .zone(ZONE)
+            .machineType(MACHINE_TYPE)
+            .numExecutorsStr(NUM_EXECUTORS)
+            .startupScript(startupScript)
+            .preemptible(PREEMPTIBLE)
+            .minCpuPlatform(MIN_CPU_PLATFORM)
+            .labels(labels)
+            .description(CONFIG_DESC)
+            .bootDiskType(BOOT_DISK_TYPE)
+            .bootDiskAutoDelete(BOOT_DISK_AUTODELETE)
+            .bootDiskSourceImageName(
+                "projects/" + bootDiskProjectId + "/global/images/" + bootDiskImageName)
+            .bootDiskSourceImageProject(bootDiskProjectId)
+            .bootDiskSizeGbStr(BOOT_DISK_SIZE_GB_STR)
+            .windows(true)
+            .windowsPasswordCredentialsId("")
+            .windowsPrivateKeyCredentialsId(windowsPrivateKeyCredentialId)
+            .createSnapshot(createSnapshot)
+            .remoteFs(null)
+            .networkConfiguration(new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME))
+            .externalAddress(EXTERNAL_ADDR)
+            .useInternalAddress(false)
+            .networkTags(NETWORK_TAGS)
+            .serviceAccountEmail(SERVICE_ACCOUNT_EMAIL)
+            .retentionTimeMinutesStr(RETENTION_TIME_MINUTES_STR)
+            .launchTimeoutSecondsStr(LAUNCH_TIMEOUT_SECONDS_STR)
+            .mode(NODE_MODE)
+            .acceleratorConfiguration(
+                new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
+            .runAsUser(RUN_AS_USER)
+            .oneShot(oneShot)
+            .template(null)
+            .build();
     ic.appendLabels(INTEGRATION_LABEL);
     return ic;
   }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudWindowsIT.java
@@ -256,7 +256,8 @@ public class ComputeEngineCloudWindowsIT {
 
     // Instance should have a label with key CONFIG_LABEL_KEY and value equal to the config's name
     // prefix
-    assertEquals(logs(), ic.namePrefix, i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
+    assertEquals(
+        logs(), ic.getNamePrefix(), i.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
     // proper id label to properly count instances
     assertEquals(
         logs(), cloud.getInstanceId(), i.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -252,39 +252,40 @@ public class InstanceConfigurationTest {
   }
 
   public static InstanceConfiguration instanceConfiguration(String minCpuPlatform) {
-    return new InstanceConfiguration(
-        NAME_PREFIX,
-        REGION,
-        ZONE,
-        MACHINE_TYPE,
-        NUM_EXECUTORS,
-        STARTUP_SCRIPT,
-        PREEMPTIBLE,
-        minCpuPlatform,
-        LABEL,
-        CONFIG_DESC,
-        BOOT_DISK_TYPE,
-        BOOT_DISK_AUTODELETE,
-        BOOT_DISK_IMAGE_NAME,
-        BOOT_DISK_PROJECT_ID,
-        BOOT_DISK_SIZE_GB_STR,
-        WINDOWS,
-        "",
-        "",
-        false,
-        null,
-        new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME),
-        EXTERNAL_ADDR,
-        false,
-        NETWORK_TAGS,
-        SERVICE_ACCOUNT_EMAIL,
-        RETENTION_TIME_MINUTES_STR,
-        LAUNCH_TIMEOUT_SECONDS_STR,
-        NODE_MODE,
-        new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT),
-        RUN_AS_USER,
-        false,
-        null);
+    return new InstanceConfiguration.Builder()
+        .namePrefix(NAME_PREFIX)
+        .region(REGION)
+        .zone(ZONE)
+        .machineType(MACHINE_TYPE)
+        .numExecutorsStr(NUM_EXECUTORS)
+        .startupScript(STARTUP_SCRIPT)
+        .preemptible(PREEMPTIBLE)
+        .minCpuPlatform(minCpuPlatform)
+        .labels(LABEL)
+        .description(CONFIG_DESC)
+        .bootDiskType(BOOT_DISK_TYPE)
+        .bootDiskAutoDelete(BOOT_DISK_AUTODELETE)
+        .bootDiskSourceImageName(BOOT_DISK_IMAGE_NAME)
+        .bootDiskSourceImageProject(BOOT_DISK_PROJECT_ID)
+        .bootDiskSizeGbStr(BOOT_DISK_SIZE_GB_STR)
+        .windows(WINDOWS)
+        .windowsPasswordCredentialsId("")
+        .windowsPrivateKeyCredentialsId("")
+        .createSnapshot(false)
+        .remoteFs(null)
+        .networkConfiguration(new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME))
+        .externalAddress(EXTERNAL_ADDR)
+        .useInternalAddress(false)
+        .networkTags(NETWORK_TAGS)
+        .serviceAccountEmail(SERVICE_ACCOUNT_EMAIL)
+        .retentionTimeMinutesStr(RETENTION_TIME_MINUTES_STR)
+        .launchTimeoutSecondsStr(LAUNCH_TIMEOUT_SECONDS_STR)
+        .mode(NODE_MODE)
+        .acceleratorConfiguration(new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
+        .runAsUser(RUN_AS_USER)
+        .oneShot(false)
+        .template(null)
+        .build();
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -243,7 +243,7 @@ public class InstanceConfigurationTest {
         .equals(BOOT_DISK_IMAGE_NAME));
 
     InstanceConfiguration instanceConfiguration = instanceConfiguration();
-    assert (instanceConfiguration.useInternalAddress == false);
+    assert (!instanceConfiguration.isUseInternalAddress());
     assert (instanceConfiguration.instance().getMinCpuPlatform() == null);
   }
 


### PR DESCRIPTION
See #58 and #65. Until a consensus is reached I'm avoiding lombok.

I removed the final keyword from the fields and made them private instead, with getters to access them. Most of the getters aren't used anywhere but are required by stapler for the UI to work. This allowed me to create and modify an initially empty InstanceConfiguration in the builder rather than defining fields for each constructor parameter on the builder itself and calling the constructor from the build() method.

For now, this does not include the work to reduce the constructor size in favor of databound setters, but I acknowledge that the logic from the constructor that was added to the individual builder fields would be better to move to a setter and call the setters from the builder instead of assigning fields directly. I need more context on which Instance Configuration fields are essential before I can make that change.