### PR TITLE
Windows Compatibility and overall stability improvements for integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,4 +276,18 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>Windows</family>
+        </os>
+      </activation>
+      <properties>
+        <concurrency>4</concurrency>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
@@ -19,11 +19,8 @@ package com.google.jenkins.plugins.computeengine;
 import com.google.api.client.json.jackson.JacksonFactory;
 import com.google.api.client.util.PemReader;
 import com.google.jenkins.plugins.credentials.oauth.JsonKey;
-import com.google.jenkins.plugins.credentials.oauth.KeyUtils;
 import com.google.jenkins.plugins.credentials.oauth.ServiceAccountConfig;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -38,13 +35,22 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+/**
+ * A {@link ServiceAccountConfig} depending solely on a secret String. Only used
+ * for integration tests.
+ *
+ * @deprecated To be replaced by {@link
+ *     com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig} when upgrading the
+ *     google-oauth-plugin to 0.8.
+ */
+@Deprecated
 public class StringJsonServiceAccountConfig extends ServiceAccountConfig {
   private static final long serialVersionUID = 6818111194672325387L;
   private static final Logger LOGGER =
       Logger.getLogger(
           com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.class
               .getSimpleName());
-  private String jsonKeyFile;
+
   private transient JsonKey jsonKey;
 
   @DataBoundConstructor
@@ -52,24 +58,11 @@ public class StringJsonServiceAccountConfig extends ServiceAccountConfig {
     if (jsonKeyString != null) {
       InputStream stream = new ByteArrayInputStream(jsonKeyString.getBytes(StandardCharsets.UTF_8));
       try {
-        JsonKey jsonKey = JsonKey.load(new JacksonFactory(), stream);
-        if (jsonKey.getClientEmail() != null && jsonKey.getPrivateKey() != null) {
-          try {
-            this.jsonKeyFile = writeJsonKeyToFile(jsonKey);
-          } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "Failed to write json key to file", e);
-          }
-        }
+        jsonKey = JsonKey.load(new JacksonFactory(), stream);
       } catch (IOException e) {
         LOGGER.log(Level.SEVERE, "Failed to read json key from file", e);
       }
     }
-  }
-
-  private String writeJsonKeyToFile(JsonKey jsonKey) throws IOException {
-    File jsonKeyFile = KeyUtils.createKeyFile("key", ".json");
-    KeyUtils.writeKeyToFileEncoded(jsonKey.toPrettyString(), jsonKeyFile);
-    return jsonKeyFile.getAbsolutePath();
   }
 
   @Override
@@ -81,13 +74,8 @@ public class StringJsonServiceAccountConfig extends ServiceAccountConfig {
                 com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.class);
   }
 
-  public String getJsonKeyFile() {
-    return jsonKeyFile;
-  }
-
   @Override
   public String getAccountId() {
-    JsonKey jsonKey = getJsonKey();
     if (jsonKey != null) {
       return jsonKey.getClientEmail();
     }
@@ -96,7 +84,6 @@ public class StringJsonServiceAccountConfig extends ServiceAccountConfig {
 
   @Override
   public PrivateKey getPrivateKey() {
-    JsonKey jsonKey = getJsonKey();
     if (jsonKey != null) {
       String privateKey = jsonKey.getPrivateKey();
       if (privateKey != null && !privateKey.isEmpty()) {
@@ -105,29 +92,11 @@ public class StringJsonServiceAccountConfig extends ServiceAccountConfig {
           PemReader.Section section = pemReader.readNextSection();
           PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(section.getBase64DecodedBytes());
           return KeyFactory.getInstance("RSA").generatePrivate(keySpec);
-        } catch (IOException e) {
-          LOGGER.log(Level.SEVERE, "Failed to read private key", e);
-        } catch (InvalidKeySpecException e) {
-          LOGGER.log(Level.SEVERE, "Failed to read private key", e);
-        } catch (NoSuchAlgorithmException e) {
+        } catch (IOException | InvalidKeySpecException | NoSuchAlgorithmException e) {
           LOGGER.log(Level.SEVERE, "Failed to read private key", e);
         }
       }
     }
     return null;
-  }
-
-  private JsonKey getJsonKey() {
-    if (jsonKey == null && jsonKeyFile != null && !jsonKeyFile.isEmpty()) {
-      try {
-        jsonKey = JsonKey.load(new JacksonFactory(), new FileInputStream(jsonKeyFile));
-        File jsonKeyFileObject = new File(jsonKeyFile);
-        KeyUtils.updatePermissions(jsonKeyFileObject);
-        KeyUtils.writeKeyToFileEncoded(jsonKey.toPrettyString(), jsonKeyFileObject);
-        return jsonKey;
-      } catch (IOException ignored) {
-      }
-    }
-    return jsonKey;
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/StringJsonServiceAccountConfig.java
@@ -20,11 +20,8 @@ import com.google.api.client.json.jackson.JacksonFactory;
 import com.google.api.client.util.PemReader;
 import com.google.jenkins.plugins.credentials.oauth.JsonKey;
 import com.google.jenkins.plugins.credentials.oauth.ServiceAccountConfig;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -33,11 +30,12 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
+import org.apache.tools.ant.filters.StringInputStream;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * A {@link ServiceAccountConfig} depending solely on a secret String. Only used
- * for integration tests.
+ * A {@link ServiceAccountConfig} depending solely on a secret String. Only used for integration
+ * tests.
  *
  * @deprecated To be replaced by {@link
  *     com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig} when upgrading the
@@ -56,9 +54,8 @@ public class StringJsonServiceAccountConfig extends ServiceAccountConfig {
   @DataBoundConstructor
   public StringJsonServiceAccountConfig(String jsonKeyString) {
     if (jsonKeyString != null) {
-      InputStream stream = new ByteArrayInputStream(jsonKeyString.getBytes(StandardCharsets.UTF_8));
       try {
-        jsonKey = JsonKey.load(new JacksonFactory(), stream);
+        jsonKey = JsonKey.load(new JacksonFactory(), new StringInputStream(jsonKeyString));
       } catch (IOException e) {
         LOGGER.log(Level.SEVERE, "Failed to read json key from file", e);
       }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -20,6 +20,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.DEB_JA
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
@@ -57,7 +58,9 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
 
   private static final String MULTIPLE_NUM_EXECUTORS = "2";
 
-  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -57,7 +57,7 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
 
   private static final String MULTIPLE_NUM_EXECUTORS = "2";
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -21,6 +21,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
@@ -58,7 +59,9 @@ public class ComputeEngineCloudMultipleLabelsIT {
 
   private static final String MULTIPLE_LABEL = "integration test";
 
-  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -58,7 +58,7 @@ public class ComputeEngineCloudMultipleLabelsIT {
 
   private static final String MULTIPLE_LABEL = "integration test";
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
@@ -62,7 +62,7 @@ public class ComputeEngineCloudNoSnapshotCreatedIT {
   private static Logger log =
       Logger.getLogger(ComputeEngineCloudNoSnapshotCreatedIT.class.getName());
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(15, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
@@ -21,13 +21,13 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_T
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.SNAPSHOT_LABEL;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -62,7 +62,9 @@ public class ComputeEngineCloudNoSnapshotCreatedIT {
   private static Logger log =
       Logger.getLogger(ComputeEngineCloudNoSnapshotCreatedIT.class.getName());
 
-  @ClassRule public static Timeout timeout = new Timeout(15, TimeUnit.MINUTES);
+  @ClassRule
+  public static Timeout timeout = new Timeout(7 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;
@@ -110,7 +112,6 @@ public class ComputeEngineCloudNoSnapshotCreatedIT {
   /** Makes sure that the instance is being stopped after completing the job. */
   @Test
   public void testNoSnapshotCreatedInstanceStopping() throws IOException {
-    assertEquals("RUNNING", client.getInstance(PROJECT_ID, ZONE, name).getStatus());
     Awaitility.await()
         .timeout(1, TimeUnit.MINUTES)
         .until(() -> "STOPPING".equals(client.getInstance(PROJECT_ID, ZONE, name).getStatus()));
@@ -122,6 +123,7 @@ public class ComputeEngineCloudNoSnapshotCreatedIT {
     // Wait for one-shot instance to terminate and create the snapshot
     Awaitility.await()
         .timeout(2, TimeUnit.MINUTES)
+        .pollInterval(10, TimeUnit.SECONDS)
         .until(() -> jenkinsRule.jenkins.getNode(name) == null);
     assertNull(client.getSnapshot(PROJECT_ID, name));
   }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudOneShotInstanceIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudOneShotInstanceIT.java
@@ -56,7 +56,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ComputeEngineCloudOneShotInstanceIT {
   private static Logger log = Logger.getLogger(ComputeEngineCloudOneShotInstanceIT.class.getName());
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudOneShotInstanceIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudOneShotInstanceIT.java
@@ -110,6 +110,7 @@ public class ComputeEngineCloudOneShotInstanceIT {
   public void testOneShotInstanceDeletedFromGCP() {
     Awaitility.await()
         .timeout(1, TimeUnit.MINUTES)
+        .pollInterval(10, TimeUnit.SECONDS)
         .until(() -> client.getInstancesWithLabel(PROJECT_ID, label).isEmpty());
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
@@ -21,6 +21,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_T
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.SNAPSHOT_LABEL;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
@@ -64,7 +65,9 @@ public class ComputeEngineCloudSnapshotCreatedIT {
 
   private static final int SNAPSHOT_TEST_TIMEOUT = 120;
 
-  @ClassRule public static Timeout timeout = new Timeout(20, TimeUnit.MINUTES);
+  @ClassRule
+  public static Timeout timeout = new Timeout(10 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;
@@ -104,6 +107,7 @@ public class ComputeEngineCloudSnapshotCreatedIT {
     // Need time for one-shot instance to terminate and create the snapshot
     Awaitility.await()
         .timeout(SNAPSHOT_TEST_TIMEOUT, TimeUnit.SECONDS)
+        .pollInterval(10, TimeUnit.SECONDS)
         .until(() -> jenkinsRule.jenkins.getNode(worker.getNodeName()) == null);
 
     createdSnapshot = client.getSnapshot(PROJECT_ID, worker.getNodeName());

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
@@ -64,7 +64,7 @@ public class ComputeEngineCloudSnapshotCreatedIT {
 
   private static final int SNAPSHOT_TEST_TIMEOUT = 120;
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(20, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateIT.java
@@ -21,6 +21,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.DEB_JA
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.createTemplate;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.format;
@@ -64,7 +65,9 @@ public class ComputeEngineCloudTemplateIT {
   private static final String GOOGLE_LABEL_KEY = "test-label";
   private static final String GOOGLE_LABEL_VALUE = "test-value";
 
-  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateIT.java
@@ -64,7 +64,7 @@ public class ComputeEngineCloudTemplateIT {
   private static final String GOOGLE_LABEL_KEY = "test-label";
   private static final String GOOGLE_LABEL_VALUE = "test-value";
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateNoGoogleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateNoGoogleLabelsIT.java
@@ -21,6 +21,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.DEB_JA
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.createTemplate;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.format;
@@ -63,7 +64,9 @@ public class ComputeEngineCloudTemplateNoGoogleLabelsIT {
   private static final String TEMPLATE =
       format("projects/%s/global/instanceTemplates/test-template-no-labels");
 
-  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateNoGoogleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateNoGoogleLabelsIT.java
@@ -63,7 +63,7 @@ public class ComputeEngineCloudTemplateNoGoogleLabelsIT {
   private static final String TEMPLATE =
       format("projects/%s/global/instanceTemplates/test-template-no-labels");
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -56,7 +56,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ComputeEngineCloudWorkerCreatedIT {
   private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerCreatedIT.class.getName());
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -21,6 +21,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
@@ -56,7 +57,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ComputeEngineCloudWorkerCreatedIT {
   private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerCreatedIT.class.getName());
 
-  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
@@ -51,7 +51,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ComputeEngineCloudWorkerFailedIT {
   private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerFailedIT.class.getName());
 
-  @ClassRule public static Timeout timeout = new Timeout(5, TimeUnit.MINUTES);
+  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
@@ -19,6 +19,7 @@ package com.google.jenkins.plugins.computeengine.integration;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
@@ -51,7 +52,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ComputeEngineCloudWorkerFailedIT {
   private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerFailedIT.class.getName());
 
-  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
+  @ClassRule
+  public static Timeout timeout = new Timeout(7 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeTestIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeTestIT.java
@@ -18,18 +18,21 @@ import io.jenkins.plugins.casc.ConfigurationAsCode;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ConfigAsCodeTestIT {
   private static Logger log = Logger.getLogger(ConfigAsCodeTestIT.class.getName());
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   private static ComputeClient client;
-  private static Map<String, String> label = getLabel(ComputeEngineCloudMultipleLabelsIT.class);
+  private static Map<String, String> label = getLabel(ConfigAsCodeTestIT.class);
 
   @BeforeClass
   public static void init() throws Exception {
@@ -43,7 +46,7 @@ public class ConfigAsCodeTestIT {
     teardownResources(client, label, log);
   }
 
-  @Test(timeout = 300000)
+  @Test
   public void testWorkerCreated() throws Exception {
     ConfigurationAsCode.get()
         .configure(this.getClass().getResource("configuration-as-code-it.yml").toString());

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeTestIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeTestIT.java
@@ -1,6 +1,7 @@
 package com.google.jenkins.plugins.computeengine.integration;
 
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
@@ -30,7 +31,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ConfigAsCodeTestIT {
   private static Logger log = Logger.getLogger(ConfigAsCodeTestIT.class.getName());
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
-  @ClassRule public static Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
+
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
   private static ComputeClient client;
   private static Map<String, String> label = getLabel(ConfigAsCodeTestIT.class);
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -130,7 +130,7 @@ class ITUtil {
     }
     assertFalse(
         "GOOGLE_CREDENTIALS or GOOGLE_CREDENTIALS_FILE env vars must be set",
-        Strings.isNullOrEmpty(CREDENTIALS));
+        Strings.isNullOrEmpty(creds));
     return creds;
   }
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.apache.commons.lang.SystemUtils;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /** Common logic and constants used throughout the integration tests. */
@@ -106,6 +107,7 @@ class ITUtil {
   private static final String SERVICE_ACCOUNT_EMAIL = "";
   private static final String RETENTION_TIME_MINUTES_STR = "";
   private static final String LAUNCH_TIMEOUT_SECONDS_STR = "";
+  static final int TEST_TIMEOUT_MULTIPLIER = SystemUtils.IS_OS_WINDOWS ? 3 : 1;
 
   static String format(String s) {
     assertNotNull("GOOGLE_PROJECT_ID env var must be set", PROJECT_ID);


### PR DESCRIPTION
From #54:

"Here are the problems that I've addressed while testing this and will submit a PR for separately after a bit of polishing:

1.The way the 0.6 release of the oauth plugin interacts with files is not compatible with Windows, and this was emulated in "StringJsonServiceAccount.java". I was able to resolve the AccountIdNotSetExceptions by ultimately removing the use of files and just using the string and json key directly for integration tests.

2. There is a limit to the number of characters that can be provided for an environment variable on windows. I got around this by changing the credentials to be loaded from a file path stored in the environment variable, rather than setting the environment variable to include the file contents.

3. The tests are taking much longer than they did on my personal machine, so even though the current timeout of 5 minutes was thought to give enough cushion, I've increased the timeouts to be compatible.

4. One result of the original issue is that the ComputeClient objects used in the tests for managing instances outside of what Jenkins itself handles were set to null, and currently the teardownResources method doesn't account for this so we also got NPEs with every test. I've made ITUtil more failure tolerant to reduce noise when debugging the tests."

In addition made the tests fail faster if proper credentials aren't provided. Missing/empty credentials now fail during class initialization, even before the "init" method is ever reached. 