### PR TITLE
Usage -> IAM credentials, have 2nd step copy + pasteable

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -30,10 +30,10 @@ View Google Compute Engine on the plugin site for more information.
 
    ```
    export PROJECT=$(gcloud info --format='value(config.project)') 
-   export SA_EMAIL=$(gcloud iam service-accounts list --filter="name:jenkins-gce"
+   export SA_EMAIL=$(gcloud iam service-accounts list --filter="name:jenkins-gce" \
     --format='value(email)') 
-   gcloud projects add-iam-policy-binding --member serviceAccount:$SA_EMAIL --role
-   roles/compute.instanceAdmin --role roles/iam.serviceAccountUser $PROJECT
+   gcloud projects add-iam-policy-binding --member serviceAccount:$SA_EMAIL --role \
+    roles/compute.instanceAdmin --role roles/iam.serviceAccountUser $PROJECT
    ```
 
 3. Download a JSON Service Account key for your newly created service account. Take note

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -32,8 +32,9 @@ View Google Compute Engine on the plugin site for more information.
    export PROJECT=$(gcloud info --format='value(config.project)') 
    export SA_EMAIL=$(gcloud iam service-accounts list --filter="name:jenkins-gce" \
     --format='value(email)') 
-   gcloud projects add-iam-policy-binding --member serviceAccount:$SA_EMAIL --role \
-    roles/compute.instanceAdmin --role roles/iam.serviceAccountUser $PROJECT
+   gcloud projects add-iam-policy-binding --member serviceAccount:$SA_EMAIL \
+    --role roles/compute.instanceAdmin --role roles/iam.serviceAccountUser \
+    --role roles/compute.networkAdmin $PROJECT
    ```
 
 3. Download a JSON Service Account key for your newly created service account. Take note


### PR DESCRIPTION
Making the commands at the 2nd step of Usage -> IAM credentials without change useable in the local environment

Inspiration is from https://cloud.google.com/solutions/using-jenkins-for-distributed-builds-on-compute-engine - maybe something else is missing?