### PR TITLE
Fixed expired invite link for slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Please file feature requests and bug reports under [issues](https://github.com/j
 
 The GCP Jenkins community uses the **#gcp-jenkins** slack channel on
 [https://googlecloud-community.slack.com](https://googlecloud-community.slack.com)
-to ask questions and share feedback. Invitation link available
-[here](https://join.slack.com/t/googlecloud-community/shared_invite/enQtNDI2NjAyODQ4NzA5LThlOGVhMzUyNDUyNmVmNTQ5YzMxYmYxNDk1YjdmZjU4ZjBiYmU1OGEzYWE2MWY1NWY4NTQ1NjAwOWRlN2ZlN2I).
+to ask questions and share feedback. Invitation link available here:
+[http://bit.ly/gcp-slack](http://bit.ly/gcp-slack).
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
Switched to bitly link to prevent need for future changes.