### PR TITLE
In case of multiple matching labels use them in round robin fashion

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -275,6 +275,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
           break;
         }
 
+        // Get next config in round robin fashion
         InstanceConfiguration config = configs.get(i % configs.size());
 
         final ComputeEngineInstance node = config.provision(StreamTaskListener.fromStdout());

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -52,12 +52,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
@@ -250,21 +252,21 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
 
   @Override
   public Collection<PlannedNode> provision(Label label, int excessWorkload) {
-    List<PlannedNode> r = new ArrayList<>();
+    List<PlannedNode> result = new ArrayList<>();
     try {
-      // TODO: retrieve and iterate a list of InstanceConfiguration that match label
-      final InstanceConfiguration config = getInstanceConfig(label);
+      List<InstanceConfiguration> configs = getInstanceConfigurations(label);
       LOGGER.log(
           Level.INFO,
-          "Provisioning node from config "
-              + config
+          "Provisioning node from configs "
+              + configs
               + " for excess workload of "
               + excessWorkload
               + " units of label '"
               + label
               + "'");
+      int availableCapacity = availableNodeCapacity();
+      int i = 0;
       while (excessWorkload > 0) {
-        Integer availableCapacity = availableNodeCapacity();
         if (availableCapacity <= 0) {
           LOGGER.warning(
               String.format(
@@ -273,45 +275,14 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
           break;
         }
 
+        InstanceConfiguration config = configs.get(i % configs.size());
+
         final ComputeEngineInstance node = config.provision(StreamTaskListener.fromStdout());
         Jenkins.get().addNode(node);
-        r.add(
-            new PlannedNode(
-                node.getNodeName(),
-                Computer.threadPoolForRemoting.submit(
-                    () -> {
-                      long startTime = System.currentTimeMillis();
-                      LOGGER.log(
-                          Level.INFO,
-                          String.format(
-                              "Waiting %dms for node %s to connect",
-                              config.getLaunchTimeoutMillis(), node.getNodeName()));
-                      try {
-                        Computer c = node.toComputer();
-                        if (c != null) {
-                          c.connect(false)
-                              .get(config.getLaunchTimeoutMillis(), TimeUnit.MILLISECONDS);
-                          LOGGER.log(
-                              Level.INFO,
-                              String.format(
-                                  "%dms elapsed waiting for node %s to connect",
-                                  System.currentTimeMillis() - startTime, node.getNodeName()));
-                        } else {
-                          LOGGER.log(
-                              Level.WARNING,
-                              String.format("No computer for node %s found", node.getNodeName()));
-                        }
-                      } catch (TimeoutException e) {
-                        LOGGER.log(
-                            Level.WARNING,
-                            String.format(
-                                "Timeout waiting for node %s to connect", node.getNodeName()),
-                            e);
-                      }
-                      return null;
-                    }),
-                node.getNumExecutors()));
+        result.add(createPlannedNode(config, node));
         excessWorkload -= node.getNumExecutors();
+        availableCapacity -= node.getNumExecutors();
+        i++;
       }
     } catch (IOException ioe) {
       LOGGER.log(Level.WARNING, "Error provisioning node", ioe);
@@ -323,7 +294,46 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
               label.getName()),
           nce.getMessage());
     }
-    return r;
+    return result;
+  }
+
+  private PlannedNode createPlannedNode(InstanceConfiguration config, ComputeEngineInstance node) {
+    return new PlannedNode(
+        node.getNodeName(), getPlannedNodeFuture(config, node), node.getNumExecutors());
+  }
+
+  private Future<Node> getPlannedNodeFuture(
+      InstanceConfiguration config, ComputeEngineInstance node) {
+    return Computer.threadPoolForRemoting.submit(
+        () -> {
+          long startTime = System.currentTimeMillis();
+          LOGGER.log(
+              Level.INFO,
+              String.format(
+                  "Waiting %dms for node %s to connect",
+                  config.getLaunchTimeoutMillis(), node.getNodeName()));
+          try {
+            Computer c = node.toComputer();
+            if (c != null) {
+              c.connect(false).get(config.getLaunchTimeoutMillis(), TimeUnit.MILLISECONDS);
+              LOGGER.log(
+                  Level.INFO,
+                  String.format(
+                      "%dms elapsed waiting for node %s to connect",
+                      System.currentTimeMillis() - startTime, node.getNodeName()));
+            } else {
+              LOGGER.log(
+                  Level.WARNING,
+                  String.format("No computer for node %s found", node.getNodeName()));
+            }
+          } catch (TimeoutException e) {
+            LOGGER.log(
+                Level.WARNING,
+                String.format("Timeout waiting for node %s to connect", node.getNodeName()),
+                e);
+          }
+          return null;
+        });
   }
 
   /**
@@ -365,39 +375,46 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
   @Override
   public boolean canProvision(Label label) {
     try {
-      getInstanceConfig(label);
+      getInstanceConfigurations(label);
       return true;
     } catch (NoConfigurationException nce) {
       return false;
     }
   }
 
-  /** Gets {@link InstanceConfiguration} that has the matching {@link Label}. */
-  public InstanceConfiguration getInstanceConfig(Label label) throws NoConfigurationException {
+  /** Gets all instances of {@link InstanceConfiguration} that has the matching {@link Label}. */
+  public List<InstanceConfiguration> getInstanceConfigurations(Label label)
+      throws NoConfigurationException {
     if (configurations == null) {
       throw new NoConfigurationException(
           String.format(
               "Cloud %s does not have any defined instance configurations.", this.getCloudName()));
     }
 
-    for (InstanceConfiguration configuration : configurations) {
-      if (configuration.getMode() == Node.Mode.NORMAL) {
-        if (label == null || label.matches(configuration.getLabelSet())) {
-          return configuration;
-        }
-      } else if (configuration.getMode() == Node.Mode.EXCLUSIVE) {
-        if (label != null && label.matches(configuration.getLabelSet())) {
-          return configuration;
-        }
-      }
+    List<InstanceConfiguration> configurations =
+        this.configurations.stream()
+            .filter(configuration -> matchesLabel(configuration, label))
+            .collect(Collectors.toList());
+
+    if (configurations.isEmpty()) {
+      throw new NoConfigurationException(
+          String.format(
+              "Cloud %s does not have any matching instance configurations.", this.getCloudName()));
     }
-    throw new NoConfigurationException(
-        String.format(
-            "Cloud %s does not have any matching instance configurations.", this.getCloudName()));
+    return configurations;
+  }
+
+  private boolean matchesLabel(InstanceConfiguration configuration, Label label) {
+    if (configuration.getMode() == Node.Mode.NORMAL) {
+      return label == null || label.matches(configuration.getLabelSet());
+    } else if (configuration.getMode() == Node.Mode.EXCLUSIVE) {
+      return label != null && label.matches(configuration.getLabelSet());
+    }
+    return false;
   }
 
   /** Gets {@link InstanceConfiguration} that has the matching Description. */
-  public InstanceConfiguration getInstanceConfig(String description) {
+  public InstanceConfiguration getInstanceConfigurationByDescription(String description) {
     for (InstanceConfiguration c : configurations) {
       if (c.getDescription().equals(description)) {
         return c;
@@ -412,7 +429,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
     if (configuration == null) {
       throw HttpResponses.error(SC_BAD_REQUEST, "The 'configuration' query parameter is missing");
     }
-    InstanceConfiguration c = getInstanceConfig(configuration);
+    InstanceConfiguration c = getInstanceConfigurationByDescription(configuration);
     if (c == null) {
       throw HttpResponses.error(SC_BAD_REQUEST, "No such Instance Configuration: " + configuration);
     }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -559,7 +559,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       Instance instance = instance();
       // TODO: JENKINS-55285
       Operation operation = cloud.getClient().insertInstance(cloud.projectId, template, instance);
-      logger.println("Sent insert request");
+      logger.println("Sent insert request for instance configuration [" + description + "]");
       String targetRemoteFs = this.remoteFs;
       ComputeEngineComputerLauncher launcher = null;
       if (this.windows) {

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -14,6 +14,7 @@
 
 package com.google.jenkins.plugins.computeengine;
 
+import static com.google.jenkins.plugins.computeengine.InstanceConfigurationTest.instanceConfiguration;
 import static com.google.jenkins.plugins.computeengine.client.ClientFactoryTest.ACCOUNT_ID;
 import static com.google.jenkins.plugins.computeengine.client.ClientFactoryTest.PRIVATE_KEY;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -23,6 +24,7 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
+import com.google.common.collect.Lists;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials;
 import com.google.jenkins.plugins.credentials.oauth.ServiceAccountConfig;
 import hudson.model.Label;
@@ -69,8 +71,8 @@ public class ComputeEngineCloudTest {
 
     // Add a few InstanceConfigurations
     List<InstanceConfiguration> ics = new ArrayList<>();
-    ics.add(InstanceConfigurationTest.instanceConfiguration());
-    ics.add(InstanceConfigurationTest.instanceConfiguration());
+    ics.add(instanceConfiguration());
+    ics.add(instanceConfiguration());
     ComputeEngineCloud cloud =
         new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
     cloud.setInstanceId(INSTANCE_ID);
@@ -93,7 +95,7 @@ public class ComputeEngineCloudTest {
     }
 
     // Add another InstanceConfiguration and ensure properties are initialized
-    cloud.addConfiguration(InstanceConfigurationTest.instanceConfiguration());
+    cloud.addConfiguration(instanceConfiguration());
     for (InstanceConfiguration ic : ics) {
       Assert.assertEquals(
           "Cloud reference was not set on child InstanceConfiguration", ic.cloud, cloud);
@@ -113,43 +115,42 @@ public class ComputeEngineCloudTest {
   @Test
   public void getConfigurationsByLabelSimple() throws Exception {
     // Add a few InstanceConfigurations
-    List<InstanceConfiguration> ics = new ArrayList<>();
-    ics.add(InstanceConfigurationTest.instanceConfiguration());
+    List<InstanceConfiguration> ics = Lists.newArrayList(instanceConfiguration());
     ComputeEngineCloud cloud =
-            new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
+        new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
     cloud.setConfigurations(ics);
 
     // Configuration for description should match
-    Assert.assertEquals(ics.get(0), cloud.getInstanceConfigurationByDescription(ics.get(0).getDescription()));
+    Assert.assertEquals(
+        ics.get(0), cloud.getInstanceConfigurationByDescription(ics.get(0).getDescription()));
 
     // Should be able to provision a label
-    Label l = new LabelAtom(InstanceConfigurationTest.A_LABEL);
+    Label label = new LabelAtom(InstanceConfigurationTest.A_LABEL);
     Assert.assertTrue(
-            "Should be able to provision for label " + InstanceConfigurationTest.A_LABEL,
-            cloud.canProvision(l));
+        "Should be able to provision for label " + InstanceConfigurationTest.A_LABEL,
+        cloud.canProvision(label));
 
     // Configuration for label should match
-    Assert.assertEquals(ics, cloud.getInstanceConfigurations(l));
+    Assert.assertEquals(ics, cloud.getInstanceConfigurations(label));
   }
 
   @Test
   public void getConfigurationsByLabelMulti() throws Exception {
     // Add a few InstanceConfigurations
-    List<InstanceConfiguration> ics = new ArrayList<>();
-    ics.add(InstanceConfigurationTest.instanceConfiguration());
-    ics.add(InstanceConfigurationTest.instanceConfiguration());
+    List<InstanceConfiguration> ics =
+        Lists.newArrayList(instanceConfiguration(), instanceConfiguration());
     ComputeEngineCloud cloud =
         new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
     cloud.setConfigurations(ics);
-    
+
     // Should be able to provision a label
-    Label l = new LabelAtom(InstanceConfigurationTest.A_LABEL);
+    Label label = new LabelAtom(InstanceConfigurationTest.A_LABEL);
     Assert.assertTrue(
         "Should be able to provision for label " + InstanceConfigurationTest.A_LABEL,
-        cloud.canProvision(l));
+        cloud.canProvision(label));
 
     // Configuration for label should match
-    Assert.assertEquals(ics, cloud.getInstanceConfigurations(l));
+    Assert.assertEquals(ics, cloud.getInstanceConfigurations(label));
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -111,20 +111,37 @@ public class ComputeEngineCloudTest {
   }
 
   @Test
-  public void labels() throws Exception {
-    // Create a credential
-    Credentials c =
-        (Credentials) new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
-    CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
-    store.addCredentials(Domain.global(), c);
-
+  public void getConfigurationsByLabelSimple() throws Exception {
     // Add a few InstanceConfigurations
     List<InstanceConfiguration> ics = new ArrayList<>();
     ics.add(InstanceConfigurationTest.instanceConfiguration());
     ComputeEngineCloud cloud =
-        new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
+            new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
     cloud.setConfigurations(ics);
 
+    // Configuration for description should match
+    Assert.assertEquals(ics.get(0), cloud.getInstanceConfigurationByDescription(ics.get(0).getDescription()));
+
+    // Should be able to provision a label
+    Label l = new LabelAtom(InstanceConfigurationTest.A_LABEL);
+    Assert.assertTrue(
+            "Should be able to provision for label " + InstanceConfigurationTest.A_LABEL,
+            cloud.canProvision(l));
+
+    // Configuration for label should match
+    Assert.assertEquals(ics, cloud.getInstanceConfigurations(l));
+  }
+
+  @Test
+  public void getConfigurationsByLabelMulti() throws Exception {
+    // Add a few InstanceConfigurations
+    List<InstanceConfiguration> ics = new ArrayList<>();
+    ics.add(InstanceConfigurationTest.instanceConfiguration());
+    ics.add(InstanceConfigurationTest.instanceConfiguration());
+    ComputeEngineCloud cloud =
+        new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
+    cloud.setConfigurations(ics);
+    
     // Should be able to provision a label
     Label l = new LabelAtom(InstanceConfigurationTest.A_LABEL);
     Assert.assertTrue(
@@ -132,10 +149,7 @@ public class ComputeEngineCloudTest {
         cloud.canProvision(l));
 
     // Configuration for label should match
-    Assert.assertEquals(ics.get(0), cloud.getInstanceConfig(l));
-
-    // Configuration for description should match
-    Assert.assertEquals(ics.get(0), cloud.getInstanceConfig(ics.get(0).getDescription()));
+    Assert.assertEquals(ics, cloud.getInstanceConfigurations(l));
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -177,7 +177,7 @@ public class InstanceConfigurationTest {
     final HtmlPage configure = r.createWebClient().goTo("configure");
     r.submit(configure.getFormByName("config"));
     InstanceConfiguration got =
-        ((ComputeEngineCloud) r.jenkins.clouds.iterator().next()).getInstanceConfig(CONFIG_DESC);
+        ((ComputeEngineCloud) r.jenkins.clouds.iterator().next()).getInstanceConfigurationByDescription(CONFIG_DESC);
     r.assertEqualBeans(
         want,
         got,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -177,7 +177,8 @@ public class InstanceConfigurationTest {
     final HtmlPage configure = r.createWebClient().goTo("configure");
     r.submit(configure.getFormByName("config"));
     InstanceConfiguration got =
-        ((ComputeEngineCloud) r.jenkins.clouds.iterator().next()).getInstanceConfigurationByDescription(CONFIG_DESC);
+        ((ComputeEngineCloud) r.jenkins.clouds.iterator().next())
+            .getInstanceConfigurationByDescription(CONFIG_DESC);
     r.assertEqualBeans(
         want,
         got,

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipeMatchingConfigurationsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipeMatchingConfigurationsIT.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine.integration;
+
+import com.google.common.collect.Lists;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import com.google.jenkins.plugins.computeengine.client.ComputeClient;
+import hudson.model.Node;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProvisioner;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.DEB_JAVA_STARTUP_SCRIPT;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfiguration;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration test suite for {@link ComputeEngineCloud}. Verifies that instances can be created
+ * with multiple matching {@link InstanceConfiguration} and that these instances are properly provisioned.
+ */
+public class ComputeEngineCloudMultipeMatchingConfigurationsIT {
+  private static Logger log = Logger.getLogger(ComputeEngineCloudMultipeMatchingConfigurationsIT.class.getName());
+
+  private static final String DESC_1 = "type_1";
+  private static final String DESC_2 = "type_2";
+
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
+  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+  private static ComputeClient client;
+  private static Map<String, String> label = getLabel(ComputeEngineCloudMultipeMatchingConfigurationsIT.class);
+  private static Collection<PlannedNode> planned;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    log.info("init");
+    initCredentials(jenkinsRule);
+    ComputeEngineCloud cloud = initCloud(jenkinsRule);
+    client = initClient(jenkinsRule, label, log);
+
+    InstanceConfiguration.Builder builder1 = new InstanceConfiguration.Builder()
+            .startupScript(DEB_JAVA_STARTUP_SCRIPT)
+            .numExecutorsStr(NUM_EXECUTORS)
+            .labels(LABEL)
+            .template(NULL_TEMPLATE);
+
+    InstanceConfiguration configuration1 = instanceConfiguration(builder1, label);
+    configuration1.setDescription(DESC_1);
+
+    InstanceConfiguration.Builder builder2 = new InstanceConfiguration.Builder()
+            .startupScript(DEB_JAVA_STARTUP_SCRIPT)
+            .numExecutorsStr(NUM_EXECUTORS)
+            .labels(LABEL)
+            .template(NULL_TEMPLATE);
+
+    InstanceConfiguration configuration2 = instanceConfiguration(builder2, label);
+    configuration2.setDescription(DESC_2);
+    cloud.setConfigurations(
+            Lists.newArrayList(
+                    configuration1,
+                    configuration2
+            ));
+    
+    planned = cloud.provision(new LabelAtom(LABEL), 2);
+  }
+
+  @AfterClass
+  public static void teardown() throws IOException {
+    teardownResources(client, label, log);
+  }
+
+  @Test
+  public void testMultipleLabelsProvisionedWithLabels() throws Exception {
+    assertEquals(2, planned.size());
+
+    final Iterator<PlannedNode> iterator = planned.iterator();
+    PlannedNode plannedNode = iterator.next();
+    checkOneNode(plannedNode, DESC_1);
+    plannedNode = iterator.next();
+    checkOneNode(plannedNode, DESC_2);
+  }
+
+  private void checkOneNode(PlannedNode plannedNode, String desc) throws InterruptedException, java.util.concurrent.ExecutionException {
+    String name = plannedNode.displayName;
+    plannedNode.future.get();
+    Node node = jenkinsRule.jenkins.getNode(name);
+    assertEquals(desc, node.getNodeDescription());
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipeMatchingConfigurationsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipeMatchingConfigurationsIT.java
@@ -16,28 +16,6 @@
 
 package com.google.jenkins.plugins.computeengine.integration;
 
-import com.google.common.collect.Lists;
-import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
-import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
-import com.google.jenkins.plugins.computeengine.client.ComputeClient;
-import hudson.model.Node;
-import hudson.model.labels.LabelAtom;
-import hudson.slaves.NodeProvisioner;
-import hudson.slaves.NodeProvisioner.PlannedNode;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.jvnet.hudson.test.JenkinsRule;
-
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
-
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.DEB_JAVA_STARTUP_SCRIPT;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
@@ -51,12 +29,34 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instan
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.Lists;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import com.google.jenkins.plugins.computeengine.client.ComputeClient;
+import hudson.model.Node;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.JenkinsRule;
+
 /**
  * Integration test suite for {@link ComputeEngineCloud}. Verifies that instances can be created
- * with multiple matching {@link InstanceConfiguration} and that these instances are properly provisioned.
+ * with multiple matching {@link InstanceConfiguration} and that these instances are properly
+ * provisioned.
  */
 public class ComputeEngineCloudMultipeMatchingConfigurationsIT {
-  private static Logger log = Logger.getLogger(ComputeEngineCloudMultipeMatchingConfigurationsIT.class.getName());
+  private static Logger log =
+      Logger.getLogger(ComputeEngineCloudMultipeMatchingConfigurationsIT.class.getName());
 
   private static final String DESC_1 = "type_1";
   private static final String DESC_2 = "type_2";
@@ -67,7 +67,8 @@ public class ComputeEngineCloudMultipeMatchingConfigurationsIT {
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   private static ComputeClient client;
-  private static Map<String, String> label = getLabel(ComputeEngineCloudMultipeMatchingConfigurationsIT.class);
+  private static Map<String, String> label =
+      getLabel(ComputeEngineCloudMultipeMatchingConfigurationsIT.class);
   private static Collection<PlannedNode> planned;
 
   @BeforeClass
@@ -77,7 +78,8 @@ public class ComputeEngineCloudMultipeMatchingConfigurationsIT {
     ComputeEngineCloud cloud = initCloud(jenkinsRule);
     client = initClient(jenkinsRule, label, log);
 
-    InstanceConfiguration.Builder builder1 = new InstanceConfiguration.Builder()
+    InstanceConfiguration.Builder builder1 =
+        new InstanceConfiguration.Builder()
             .startupScript(DEB_JAVA_STARTUP_SCRIPT)
             .numExecutorsStr(NUM_EXECUTORS)
             .labels(LABEL)
@@ -86,7 +88,8 @@ public class ComputeEngineCloudMultipeMatchingConfigurationsIT {
     InstanceConfiguration configuration1 = instanceConfiguration(builder1, label);
     configuration1.setDescription(DESC_1);
 
-    InstanceConfiguration.Builder builder2 = new InstanceConfiguration.Builder()
+    InstanceConfiguration.Builder builder2 =
+        new InstanceConfiguration.Builder()
             .startupScript(DEB_JAVA_STARTUP_SCRIPT)
             .numExecutorsStr(NUM_EXECUTORS)
             .labels(LABEL)
@@ -94,12 +97,8 @@ public class ComputeEngineCloudMultipeMatchingConfigurationsIT {
 
     InstanceConfiguration configuration2 = instanceConfiguration(builder2, label);
     configuration2.setDescription(DESC_2);
-    cloud.setConfigurations(
-            Lists.newArrayList(
-                    configuration1,
-                    configuration2
-            ));
-    
+    cloud.setConfigurations(Lists.newArrayList(configuration1, configuration2));
+
     planned = cloud.provision(new LabelAtom(LABEL), 2);
   }
 
@@ -119,7 +118,8 @@ public class ComputeEngineCloudMultipeMatchingConfigurationsIT {
     checkOneNode(plannedNode, DESC_2);
   }
 
-  private void checkOneNode(PlannedNode plannedNode, String desc) throws InterruptedException, java.util.concurrent.ExecutionException {
+  private void checkOneNode(PlannedNode plannedNode, String desc)
+      throws InterruptedException, java.util.concurrent.ExecutionException {
     String name = plannedNode.displayName;
     plannedNode.future.get();
     Node node = jenkinsRule.jenkins.getNode(name);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
@@ -90,7 +90,10 @@ public class ComputeEngineCloudNoSnapshotCreatedIT {
             label);
 
     cloud.addConfiguration(instanceConfiguration);
-    assertTrue(cloud.getInstanceConfigurationByDescription(instanceConfiguration.getDescription()).isCreateSnapshot());
+    assertTrue(
+        cloud
+            .getInstanceConfigurationByDescription(instanceConfiguration.getDescription())
+            .isCreateSnapshot());
 
     FreeStyleProject project = jenkinsRule.createFreeStyleProject();
     Builder step = new Shell("echo works");

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
@@ -90,7 +90,7 @@ public class ComputeEngineCloudNoSnapshotCreatedIT {
             label);
 
     cloud.addConfiguration(instanceConfiguration);
-    assertTrue(cloud.getInstanceConfig(instanceConfiguration.getDescription()).isCreateSnapshot());
+    assertTrue(cloud.getInstanceConfigurationByDescription(instanceConfiguration.getDescription()).isCreateSnapshot());
 
     FreeStyleProject project = jenkinsRule.createFreeStyleProject();
     Builder step = new Shell("echo works");

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
@@ -93,7 +93,7 @@ public class ComputeEngineCloudSnapshotCreatedIT {
             label);
 
     cloud.addConfiguration(instanceConfiguration);
-    assertTrue(cloud.getInstanceConfig(instanceConfiguration.getDescription()).isCreateSnapshot());
+    assertTrue(cloud.getInstanceConfigurationByDescription(instanceConfiguration.getDescription()).isCreateSnapshot());
 
     FreeStyleProject project = jenkinsRule.createFreeStyleProject();
     Builder step = new Shell("exit 1");

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
@@ -93,7 +93,10 @@ public class ComputeEngineCloudSnapshotCreatedIT {
             label);
 
     cloud.addConfiguration(instanceConfiguration);
-    assertTrue(cloud.getInstanceConfigurationByDescription(instanceConfiguration.getDescription()).isCreateSnapshot());
+    assertTrue(
+        cloud
+            .getInstanceConfigurationByDescription(instanceConfiguration.getDescription())
+            .isCreateSnapshot());
 
     FreeStyleProject project = jenkinsRule.createFreeStyleProject();
     Builder step = new Shell("exit 1");


### PR DESCRIPTION
Google sometimes dont have resources in one zone to  fulfil requests..
So this requests make possible of creating same setup for multiple zones..
And they will be used in round robin fashion.

In also resolves #57 by reserving instances that are being created..