### PR TITLE
Remove "Use internal IP?" from advanced configuration

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -32,15 +32,6 @@
             <f:entry title="${%Number of Executors}" field="numExecutorsStr">
                 <f:textbox default="1"/>
             </f:entry>
-            <f:entry field="windows" title="${%Windows?}">
-                <f:checkbox/>
-            </f:entry>
-            <f:entry field="windowsPasswordCredentialsId" title="${%Windows Account Credentials}">
-                <c:select/>
-            </f:entry>
-            <f:entry field="windowsPrivateKeyCredentialsId" title="${%Windows SSH Private Key Credentials}">
-                <c:select/>
-            </f:entry>
         </f:section>
 
         <f:section title="Launch Configuration">
@@ -58,6 +49,15 @@
             </f:entry>
             <f:entry title="${%Java Exec Path}" field="javaExecPath">
                 <f:textbox default="java"/>
+            </f:entry>
+            <f:entry field="windows" title="${%Windows?}">
+                <f:checkbox/>
+            </f:entry>
+            <f:entry field="windowsPasswordCredentialsId" title="${%Windows Account Credentials}">
+                <c:select/>
+            </f:entry>
+            <f:entry field="windowsPrivateKeyCredentialsId" title="${%Windows SSH Private Key Credentials}">
+                <c:select/>
             </f:entry>
         </f:section>
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -22,9 +22,6 @@
             <f:entry title="${%Description}" field="description">
                 <f:textbox/>
             </f:entry>
-            <f:entry title="${%Launch Timeout (seconds)}" field="launchTimeoutSecondsStr">
-                <f:textbox default="${descriptor.defaultLaunchTimeoutSeconds()}"/>
-            </f:entry>
             <f:entry title="${%Node Retention Time (minutes)}" field="retentionTimeMinutesStr">
                 <f:textbox default="${descriptor.defaultRetentionTimeMinutes()}"/>
             </f:entry>
@@ -35,15 +32,6 @@
             <f:entry title="${%Number of Executors}" field="numExecutorsStr">
                 <f:textbox default="1"/>
             </f:entry>
-            <f:entry title="${%Run as user}" field="runAsUser">
-                <f:textbox default="${descriptor.defaultRunAsUser()}"/>
-            </f:entry>
-            <f:entry title="${%Remote Location}" field="remoteFs">
-                <f:textbox default=""/>
-            </f:entry>
-            <f:entry title="${%Java Exec Path}" field="javaExecPath">
-                <f:textbox default="java"/> 
-            </f:entry>
             <f:entry field="windows" title="${%Windows?}">
                 <f:checkbox/>
             </f:entry>
@@ -52,6 +40,24 @@
             </f:entry>
             <f:entry field="windowsPrivateKeyCredentialsId" title="${%Windows SSH Private Key Credentials}">
                 <c:select/>
+            </f:entry>
+        </f:section>
+
+        <f:section title="Launch Configuration">
+            <f:entry title="${%Launch Timeout (seconds)}" field="launchTimeoutSecondsStr">
+                <f:textbox default="${descriptor.defaultLaunchTimeoutSeconds()}"/>
+            </f:entry>
+            <f:entry title="${%Use Internal IP?}" field="useInternalAddress">
+                <f:checkbox/>
+            </f:entry>
+            <f:entry title="${%Run as user}" field="runAsUser">
+                <f:textbox default="${descriptor.defaultRunAsUser()}"/>
+            </f:entry>
+            <f:entry title="${%Remote Location}" field="remoteFs">
+                <f:textbox default=""/>
+            </f:entry>
+            <f:entry title="${%Java Exec Path}" field="javaExecPath">
+                <f:textbox default="java"/>
             </f:entry>
         </f:section>
 
@@ -104,9 +110,6 @@
                         <f:textbox/>
                     </f:entry>
                     <f:entry field="externalAddress" title="${%Attach External IP?}">
-                        <f:checkbox/>
-                    </f:entry>
-                    <f:entry field="useInternalAddress" title="${%Use Internal IP?}">
                         <f:checkbox/>
                     </f:entry>
                 </f:section>


### PR DESCRIPTION
This makes it so that it can be configured without the user needing to open advanced configuration or change any of those settings. I also split out a few launch-specific items into their own section. Here's what that looks like:
![launchconfig](https://user-images.githubusercontent.com/19915795/58841881-b24d5a00-8620-11e9-96ae-30077149e716.png)