### PR TITLE
Issue #106: Do not assume that default is the subnetwork for the default network.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
@@ -101,11 +101,6 @@ public class AutofilledNetworkConfiguration extends NetworkConfiguration {
         return items;
       }
 
-      if (network.endsWith("default")) {
-        items.add(new ListBoxModel.Option("default", "default", true));
-        return items;
-      }
-
       try {
         ComputeClient compute = computeClient(context, credentialsId);
         List<Subnetwork> subnetworks = compute.getSubnetworks(projectId, network, region);
@@ -119,15 +114,9 @@ public class AutofilledNetworkConfiguration extends NetworkConfiguration {
           items.add(s.getName(), s.getSelfLink());
         }
         return items;
-      } catch (IOException ioe) {
+      } catch (IOException | IllegalArgumentException e) {
         String message = "Error retrieving subnetworks";
-        LOGGER.log(Level.SEVERE, message, ioe);
-        items.clear();
-        items.add(message);
-        return items;
-      } catch (IllegalArgumentException iae) {
-        String message = "Error retrieving subnetworks";
-        LOGGER.log(Level.SEVERE, message, iae);
+        LOGGER.log(Level.SEVERE, message, e);
         items.clear();
         items.add(message);
         return items;


### PR DESCRIPTION
As seen in #106, there are cases where the subnetwork "default" does not exist for the default network, and this removes that assumption.

I refactored the tests which were impacted into separate methods and removed the tests for the old behavior. I didn't want to increase the scope of this change by making them completely parallelizable, but this refactoring makes it easier.