### PR TITLE
Make windows config non-transient on ComputeEngineInstance.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -45,7 +45,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
   private final String zone;
   private final String cloudName;
   private final String sshUser;
-  private final transient Optional<WindowsConfiguration> windowsConfig;
+  private final WindowsConfiguration windowsConfig;
   private final boolean createSnapshot;
   private final boolean oneShot;
   private final String javaExecPath;
@@ -61,7 +61,8 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
       String nodeDescription,
       String sshUser,
       String remoteFS,
-      Optional<WindowsConfiguration> windowsConfig,
+      // NOTE(stephenashank): Could not use optional due to serialization req.
+      @Nullable WindowsConfiguration windowsConfig,
       boolean createSnapshot,
       boolean oneShot,
       int numExecutors,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Optional;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import lombok.Getter;
@@ -63,7 +62,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
   protected Optional<Connection> setupConnection(
       ComputeEngineInstance node, ComputeEngineComputer computer, TaskListener listener)
       throws Exception {
-    if (!node.getWindowsConfig().isPresent()) {
+    if (node.getWindowsConfig() == null) {
       logWarning(computer, listener, "Non-windows node provided");
       return Optional.empty();
     }
@@ -76,7 +75,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
     // connect fresh as ROOT
     logInfo(computer, listener, "connect fresh as root");
     Connection cleanupConn = connectToSsh(computer, listener);
-    if (!authenticateSSH(node.getSshUser(), node.getWindowsConfig().get(), cleanupConn, listener)) {
+    if (!authenticateSSH(node.getSshUser(), node.getWindowsConfig(), cleanupConn, listener)) {
       logWarning(computer, listener, "Authentication failed");
       return Optional.empty(); // failed to connect
     }
@@ -113,10 +112,10 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
     ComputeEngineInstance node = computer.getNode();
     if (node == null) {
       throw new IllegalArgumentException("A ComputeEngineComputer with no node was provided");
-    } else if (!node.getWindowsConfig().isPresent()) {
+    } else if (node.getWindowsConfig() == null) {
       throw new IllegalArgumentException("A non-windows ComputeEngineComputer was provided.");
     }
-    WindowsConfiguration windowsConfig = node.getWindowsConfig().get();
+    WindowsConfiguration windowsConfig = node.getWindowsConfig();
     Connection bootstrapConn = null;
     try {
       int tries = bootstrapAuthTries;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -62,7 +62,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import jenkins.model.Jenkins;
 import lombok.AccessLevel;
@@ -308,7 +307,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
           .nodeDescription(instance.getDescription())
           .sshUser(runAsUser)
           .remoteFS(targetRemoteFs)
-          .windowsConfig(Optional.ofNullable(windowsConfiguration))
+          .windowsConfig(windowsConfiguration)
           .createSnapshot(createSnapshot)
           .oneShot(oneShot)
           .numExecutors(numExecutors)


### PR DESCRIPTION
@ingwarsw 

This addresses the issue where windows credential ID values are being lost. Optional must be removed along with transient because Optional fields are not serializable.