### PR TITLE
Added clarification to node retention time help file

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-retentionTimeMinutesStr.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-retentionTimeMinutesStr.html
@@ -13,9 +13,10 @@
 -->
 <div>
     The number of <strong>minutes</strong> after which an inactive node will be terminated. This value should be
-    at least as the launch timeout configured above.
+    at least as long as the launch timeout configured above.
     <p>
         Because Google Compute Engine instances boot very quickly, it may be feasible to leave this value low
-        to reduce costs associated with running unused instances.
+        to reduce costs associated with running unused instances. However, do account enough time for the instance
+        to boot up.
     </p>
 </div>


### PR DESCRIPTION
Clarified the help text for node retention time after encountering https://github.com/jenkinsci/google-compute-engine-plugin/issues/112.