### PR TITLE
Issue #106: When no subnetworks are configured for the network, use the default subnetwork

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfiguration.java
@@ -14,8 +14,6 @@
 
 package com.google.jenkins.plugins.computeengine;
 
-import static com.google.jenkins.plugins.computeengine.InstanceConfiguration.ERROR_NO_SUBNETS;
-
 import com.google.api.services.compute.model.Network;
 import com.google.api.services.compute.model.Subnetwork;
 import com.google.common.base.Strings;
@@ -67,18 +65,12 @@ public class AutofilledNetworkConfiguration extends NetworkConfiguration {
           items.add(n.getName(), n.getSelfLink());
         }
         return items;
-      } catch (IOException ioe) {
+      } catch (IOException | IllegalArgumentException e) {
         String message = "Error retrieving networks";
-        LOGGER.log(Level.SEVERE, message, ioe);
+        LOGGER.log(Level.SEVERE, message, e);
         items.clear();
-        items.add(message);
+        items.add(new ListBoxModel.Option(message, "", true));
         return items;
-      } catch (IllegalArgumentException iae) {
-        String message = "Error retrieving networks";
-        LOGGER.log(Level.SEVERE, message, iae);
-        items.clear();
-        items.add(message);
-        return null;
       }
     }
 
@@ -106,7 +98,7 @@ public class AutofilledNetworkConfiguration extends NetworkConfiguration {
         List<Subnetwork> subnetworks = compute.getSubnetworks(projectId, network, region);
 
         if (subnetworks.size() == 0) {
-          items.add(new ListBoxModel.Option(ERROR_NO_SUBNETS, ERROR_NO_SUBNETS, true));
+          items.add(new ListBoxModel.Option("default", "default", true));
           return items;
         }
 
@@ -118,15 +110,12 @@ public class AutofilledNetworkConfiguration extends NetworkConfiguration {
         String message = "Error retrieving subnetworks";
         LOGGER.log(Level.SEVERE, message, e);
         items.clear();
-        items.add(message);
+        items.add(new ListBoxModel.Option(message, "", true));
         return items;
       }
     }
 
     public FormValidation doCheckSubnetwork(@QueryParameter String value) {
-      if (value.equals(ERROR_NO_SUBNETS)) {
-        return FormValidation.error(ERROR_NO_SUBNETS);
-      }
       if (value.isEmpty()) {
         return FormValidation.error("Please select a subnetwork...");
       }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -92,8 +92,6 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   public static final Integer DEFAULT_RETENTION_TIME_MINUTES =
       (DEFAULT_LAUNCH_TIMEOUT_SECONDS / 60) + 1;
   public static final String DEFAULT_RUN_AS_USER = "jenkins";
-  public static final String ERROR_NO_SUBNETS =
-      "No subnetworks exist in the given network and region.";
   public static final String METADATA_LINUX_STARTUP_SCRIPT_KEY = "startup-script";
   public static final String METADATA_WINDOWS_STARTUP_SCRIPT_KEY = "windows-startup-script-ps1";
   public static final String NAT_TYPE = "ONE_TO_ONE_NAT";


### PR DESCRIPTION
This fixes the [bug](https://github.com/jenkinsci/google-compute-engine-plugin/blob/bc082bd832e83b0620772b3b7ea7e1f3b06e01a3/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java#issuecomment-505829232) where when configuring instances for a legacy VPC which has no subnetworks, an invalid value is supplied for the subnetwork and provisioning fails.

When using the default subnetwork, the subnetwork is omitted from the NetworkInterface constructed for provisioning, see the below:
https://github.com/jenkinsci/google-compute-engine-plugin/blob/bc082bd832e83b0620772b3b7ea7e1f3b06e01a3/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java#L489-L492