### PR TITLE
Issue #124: Stop accepting multiple tasks for oneshot instances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>3.36</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <artifactId>google-compute-engine</artifactId>

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineRetentionStrategy.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineRetentionStrategy.java
@@ -68,8 +68,13 @@ public class ComputeEngineRetentionStrategy extends RetentionStrategy<ComputeEng
   public void taskAccepted(Executor executor, Queue.Task task) {
     if (oneShot) {
       // When a oneshot instance is used only one task is run, so better not accept more.
-      ((ComputeEngineComputer) executor.getOwner()).setAcceptingTasks(false);
-      delegate.taskAccepted(executor, task);
+      synchronized (this) {
+        ComputeEngineComputer computer = (ComputeEngineComputer) executor.getOwner();
+        if (computer.isAcceptingTasks()) {
+          computer.setAcceptingTasks(false);
+          delegate.taskAccepted(executor, task);
+        }
+      }
     }
   }
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineRetentionStrategy.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineRetentionStrategy.java
@@ -67,6 +67,8 @@ public class ComputeEngineRetentionStrategy extends RetentionStrategy<ComputeEng
   @Override
   public void taskAccepted(Executor executor, Queue.Task task) {
     if (oneShot) {
+      // When a oneshot instance is used only one task is run, so better not accept more.
+      ((ComputeEngineComputer) executor.getOwner()).setAcceptingTasks(false);
       delegate.taskAccepted(executor, task);
     }
   }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -892,6 +892,20 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       }
       return FormValidation.ok();
     }
+
+    public FormValidation doCheckNumExecutorsStr(
+        @AncestorInPath Jenkins context,
+        @QueryParameter String value,
+        @QueryParameter("oneShot") boolean oneShot) {
+      int numExecutors = intOrDefault(value, DEFAULT_NUM_EXECUTORS);
+      if (numExecutors < 1) {
+        return FormValidation.error(
+            Messages.InstanceConfiguration_NumExecutorsLessThanOneConfigError());
+      } else if (numExecutors > 1 && oneShot) {
+        return FormValidation.error(Messages.InstanceConfiguration_NumExecutorsOneShotError());
+      }
+      return FormValidation.ok();
+    }
   }
 
   public static class Builder {

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-oneShot.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-oneShot.html
@@ -12,6 +12,7 @@
  License.
 -->
 <div>
-    <a href="https://wiki.jenkins.io/display/JENKINS/One-Shot+Executor">One-Shot</a> executors create nodes dedicated
-    to a single build. Upon completion of the build the node is terminated.
+    <a href="https://wiki.jenkins.io/display/JENKINS/One-Shot+Executor">One-Shot</a> executors
+    create nodes dedicated to a single build. Upon completion of the build the node is terminated.
+    Number of executors for these nodes should not exceed one.
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/Messages.properties
@@ -12,4 +12,6 @@
 ComputeEngineCloud.DisplayName=Google Compute Engine
 ComputeEngineAgent.DisplayName=Google Compute Engine
 InstanceConfiguration.SnapshotConfigError=One-shot must be enabled to create snapshots
+InstanceConfiguration.NumExecutorsLessThanOneConfigError=Number of executors must not be less than 1
+InstanceConfiguration.NumExecutorsOneShotError=Number of executors should not exceed 1 with oneshot enabled
 RebuildCause.ShortDescription=Rebuilding preempted job


### PR DESCRIPTION
See Issue #124: Once a task is accepted on an executor for a oneshot instance, do not accept further tasks. Add validation messaging and help text to discourage creating oneshot nodes with multiple executors.