### PR TITLE
Format and tidy pom file after release preparation completes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>3.36</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <artifactId>google-compute-engine</artifactId>
@@ -235,6 +235,13 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <completionGoals>xml-format:xml-format tidy:pom</completionGoals>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This occurs after the pom file is modified but before being committed by the release plugin and will prevent the back and forth that keeps happening after releases.