### PR TITLE
Issue #132: Add option to ignore proxy in instance configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.iml
 target
 work
+.surefire-*
 
 ### Emacs ###
 *~

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,7 @@
             <exclude>**/ITUtil.java</exclude>
           </excludes>
           <argLine>-Djenkins.test.timeout=${jenkinsRuleTimeout}</argLine>
+          <runOrder>balanced</runOrder>
         </configuration>
       </plugin>
       <plugin>
@@ -276,6 +277,7 @@
         <version>2.20.1</version>
         <configuration>
           <skipTests>${skip.surefire.tests}</skipTests>
+          <runOrder>balanced</runOrder>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -331,7 +331,8 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
       // We only care about instances that have a label indicating they
       // belong to this cloud
       Map<String, String> filterLabel = ImmutableMap.of(CLOUD_ID_LABEL_KEY, getInstanceId());
-      List<Instance> instances = getClient().listInstancesWithLabel(projectId, filterLabel);
+      List<Instance> instances =
+          new ArrayList<>(getClient().listInstancesWithLabel(projectId, filterLabel));
 
       // Don't count instances that are not running (or starting up)
       Iterator it = instances.iterator();

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -374,7 +374,9 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
         Connection conn = new Connection(host, port);
         ProxyConfiguration proxyConfig = Jenkins.get().proxy;
         Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
-        if (!node.isIgnoreProxy() && !proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
+        if (!node.isIgnoreProxy()
+            && !proxy.equals(Proxy.NO_PROXY)
+            && proxy.address() instanceof InetSocketAddress) {
           InetSocketAddress address = (InetSocketAddress) proxy.address();
           HTTPProxyData proxyData = null;
           if (proxyConfig.getUserName() != null) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -374,7 +374,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
         Connection conn = new Connection(host, port);
         ProxyConfiguration proxyConfig = Jenkins.get().proxy;
         Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
-        if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
+        if (!node.isIgnoreProxy() && !proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
           InetSocketAddress address = (InetSocketAddress) proxy.address();
           HTTPProxyData proxyData = null;
           if (proxyConfig.getUserName() != null) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -50,8 +50,9 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
   private static final String AGENT_JAR = "agent.jar";
 
   // TODO(google-compute-engine-plugin/issues/134): make this configurable
-  public static final Integer SSH_PORT = 22;
-  public static final Integer SSH_TIMEOUT = 10000;
+  private static final int SSH_PORT = 22;
+  private static final int SSH_TIMEOUT_MILLIS = 10000;
+  private static final int SSH_SLEEP_MILLIS = 5000;
 
   private final String insertOperationId;
   private final String zone;
@@ -370,7 +371,13 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
         logInfo(
             computer,
             listener,
-            "Connecting to " + host + " on port " + port + ", with timeout " + SSH_TIMEOUT + ".");
+            "Connecting to "
+                + host
+                + " on port "
+                + port
+                + ", with timeout "
+                + SSH_TIMEOUT_MILLIS
+                + ".");
         Connection conn = new Connection(host, port);
         ProxyConfiguration proxyConfig = Jenkins.get().proxy;
         Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
@@ -401,15 +408,15 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
                 return true;
               }
             },
-            SSH_TIMEOUT,
-            SSH_TIMEOUT);
+            SSH_TIMEOUT_MILLIS,
+            SSH_TIMEOUT_MILLIS);
         logInfo(computer, listener, "Connected via SSH.");
         return conn;
       } catch (IOException e) {
         // keep retrying until SSH comes up
         logInfo(computer, listener, "Failed to connect via ssh: " + e.getMessage());
         logInfo(computer, listener, "Waiting for SSH to come up. Sleeping 5.");
-        Thread.sleep(5000);
+        Thread.sleep(SSH_SLEEP_MILLIS);
       }
     }
   }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -16,23 +16,32 @@
 
 package com.google.jenkins.plugins.computeengine;
 
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.Operation;
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient.OperationException;
 import com.trilead.ssh2.Connection;
+import com.trilead.ssh2.HTTPProxyData;
 import com.trilead.ssh2.SCPClient;
+import com.trilead.ssh2.ServerHostKeyVerifier;
 import com.trilead.ssh2.Session;
+import hudson.ProxyConfiguration;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.SlaveComputer;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import jenkins.model.Jenkins;
+import lombok.Getter;
 
 public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
   private static final Logger LOGGER =
@@ -40,15 +49,22 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
   private static final SimpleFormatter sf = new SimpleFormatter();
   private static final String AGENT_JAR = "agent.jar";
 
+  // TODO: make this configurable
+  public static final Integer SSH_PORT = 22;
+  public static final Integer SSH_TIMEOUT = 10000;
+
   private final String insertOperationId;
   private final String zone;
   private final String cloudName;
+  @Getter protected final boolean useInternalAddress;
 
-  public ComputeEngineComputerLauncher(String cloudName, String insertOperationId, String zone) {
+  public ComputeEngineComputerLauncher(
+      String cloudName, String insertOperationId, String zone, boolean useInternalAddress) {
     super();
     this.cloudName = cloudName;
     this.insertOperationId = insertOperationId;
     this.zone = zone;
+    this.useInternalAddress = useInternalAddress;
   }
 
   public static void log(Logger logger, Level level, TaskListener listener, String message) {
@@ -302,6 +318,97 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
           });
     } catch (Exception e) {
       logException(computer, listener, "Error: ", e);
+    }
+  }
+
+  protected Connection connectToSsh(ComputeEngineComputer computer, TaskListener listener)
+      throws Exception {
+    ComputeEngineInstance node = computer.getNode();
+    if (node == null) {
+      throw new IllegalArgumentException("A ComputeEngineComputer with no node was provided");
+    }
+
+    final long timeout = node.getLaunchTimeoutMillis();
+    final long startTime = System.currentTimeMillis();
+    while (true) {
+      try {
+        long waitTime = System.currentTimeMillis() - startTime;
+        if (timeout > 0 && waitTime > timeout) {
+          // TODO: better exception
+          throw new Exception(
+              "Timed out after "
+                  + (waitTime / 1000)
+                  + " seconds of waiting for ssh to become available. (maximum timeout configured is "
+                  + (timeout / 1000)
+                  + ")");
+        }
+        Instance instance = computer.refreshInstance();
+
+        String host = "";
+
+        // TODO: handle multiple NICs
+        NetworkInterface nic = instance.getNetworkInterfaces().get(0);
+
+        if (this.useInternalAddress) {
+          host = nic.getNetworkIP();
+        } else {
+          // Look for a public IP address
+          if (nic.getAccessConfigs() != null) {
+            for (AccessConfig ac : nic.getAccessConfigs()) {
+              if (ac.getType().equals(InstanceConfiguration.NAT_TYPE)) {
+                host = ac.getNatIP();
+              }
+            }
+          }
+          // No public address found. Fall back to internal address
+          if (host.isEmpty()) {
+            host = nic.getNetworkIP();
+          }
+        }
+
+        int port = SSH_PORT;
+        logInfo(
+            computer,
+            listener,
+            "Connecting to " + host + " on port " + port + ", with timeout " + SSH_TIMEOUT + ".");
+        Connection conn = new Connection(host, port);
+        ProxyConfiguration proxyConfig = Jenkins.get().proxy;
+        Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
+        if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
+          InetSocketAddress address = (InetSocketAddress) proxy.address();
+          HTTPProxyData proxyData = null;
+          if (proxyConfig.getUserName() != null) {
+            proxyData =
+                new HTTPProxyData(
+                    address.getHostName(),
+                    address.getPort(),
+                    proxyConfig.getUserName(),
+                    proxyConfig.getPassword());
+          } else {
+            proxyData = new HTTPProxyData(address.getHostName(), address.getPort());
+          }
+          conn.setProxyData(proxyData);
+          logInfo(computer, listener, "Using HTTP Proxy Configuration");
+        }
+        // TODO: verify host key
+        conn.connect(
+            new ServerHostKeyVerifier() {
+              public boolean verifyServerHostKey(
+                  String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey)
+                  throws Exception {
+                return true;
+              }
+            },
+            SSH_TIMEOUT,
+            SSH_TIMEOUT);
+        logInfo(computer, listener, "Connected via SSH.");
+        return conn;
+      } catch (IOException e) {
+        // keep retrying until SSH comes up
+        logInfo(computer, listener, "Failed to connect via ssh: " + e.getMessage());
+        logInfo(computer, listener, "Waiting for SSH to come up. Sleeping 5.");
+        Thread.sleep(5000);
+      }
     }
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -385,7 +385,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
             && proxy.address() instanceof InetSocketAddress) {
           InetSocketAddress address = (InetSocketAddress) proxy.address();
           HTTPProxyData proxyData = null;
-          if (proxyConfig.getUserName() != null) {
+          if (proxyConfig.getUserName() != null && proxyConfig.getPassword() != null) {
             proxyData =
                 new HTTPProxyData(
                     address.getHostName(),

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -24,7 +24,6 @@ import com.google.cloud.graphite.platforms.plugin.client.ComputeClient.Operation
 import com.trilead.ssh2.Connection;
 import com.trilead.ssh2.HTTPProxyData;
 import com.trilead.ssh2.SCPClient;
-import com.trilead.ssh2.ServerHostKeyVerifier;
 import com.trilead.ssh2.Session;
 import hudson.ProxyConfiguration;
 import hudson.model.TaskListener;
@@ -401,13 +400,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
         }
         // TODO(google-compute-engine-plugin/issues/137): verify host key
         conn.connect(
-            new ServerHostKeyVerifier() {
-              public boolean verifyServerHostKey(
-                  String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey)
-                  throws Exception {
-                return true;
-              }
-            },
+            (hostname, portNum, serverHostKeyAlgorithm, serverHostKey) -> true,
             SSH_TIMEOUT_MILLIS,
             SSH_TIMEOUT_MILLIS);
         logInfo(computer, listener, "Connected via SSH.");

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -398,7 +398,9 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
           conn.setProxyData(proxyData);
           logInfo(computer, listener, "Using HTTP Proxy Configuration");
         }
-        // TODO(google-compute-engine-plugin/issues/137): verify host key
+        /* TODO(google-compute-engine-plugin/issues/137): Verify host key by checking that the key
+         *   fingerprint is known.
+         */
         conn.connect(
             (hostname, portNum, serverHostKeyAlgorithm, serverHostKey) -> true,
             SSH_TIMEOUT_MILLIS,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -49,7 +49,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
   private static final SimpleFormatter sf = new SimpleFormatter();
   private static final String AGENT_JAR = "agent.jar";
 
-  // TODO: make this configurable
+  // TODO(google-compute-engine-plugin/issues/134): make this configurable
   public static final Integer SSH_PORT = 22;
   public static final Integer SSH_TIMEOUT = 10000;
 
@@ -334,7 +334,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
       try {
         long waitTime = System.currentTimeMillis() - startTime;
         if (timeout > 0 && waitTime > timeout) {
-          // TODO: better exception
+          // TODO(google-compute-engine-plugin/issues/135): better exception
           throw new Exception(
               "Timed out after "
                   + (waitTime / 1000)
@@ -346,7 +346,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
 
         String host = "";
 
-        // TODO: handle multiple NICs
+        // TODO(google-compute-engine-plugin/issues/136): handle multiple NICs
         NetworkInterface nic = instance.getNetworkInterfaces().get(0);
 
         if (this.useInternalAddress) {
@@ -390,7 +390,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
           conn.setProxyData(proxyData);
           logInfo(computer, listener, "Using HTTP Proxy Configuration");
         }
-        // TODO: verify host key
+        // TODO(google-compute-engine-plugin/issues/137): verify host key
         conn.connect(
             new ServerHostKeyVerifier() {
               public boolean verifyServerHostKey(

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -50,6 +50,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
   private final WindowsConfiguration windowsConfig;
   private final boolean createSnapshot;
   private final boolean oneShot;
+  private final boolean ignoreProxy;
   private final String javaExecPath;
   private final GoogleKeyPair sshKeyPair;
   private Integer launchTimeout; // Seconds
@@ -67,6 +68,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
       @Nullable WindowsConfiguration windowsConfig,
       boolean createSnapshot,
       boolean oneShot,
+      boolean ignoreProxy,
       int numExecutors,
       Mode mode,
       String labelString,
@@ -94,6 +96,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
     this.windowsConfig = windowsConfig;
     this.createSnapshot = createSnapshot;
     this.oneShot = oneShot;
+    this.ignoreProxy = ignoreProxy;
     this.javaExecPath = javaExecPath;
     this.sshKeyPair = sshKeyPair;
   }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -41,7 +41,8 @@ import lombok.Getter;
 public class ComputeEngineInstance extends AbstractCloudSlave {
   private static final long serialVersionUID = 1;
   private static final Logger LOGGER = Logger.getLogger(ComputeEngineInstance.class.getName());
-  private static final long CREATE_SNAPSHOT_TIMEOUT = 120000;
+  private static final long CREATE_SNAPSHOT_TIMEOUT_LINUX = 120000;
+  private static final long CREATE_SNAPSHOT_TIMEOUT_WINDOWS = 600000;
 
   // TODO: https://issues.jenkins-ci.org/browse/JENKINS-55518
   private final String zone;
@@ -117,10 +118,14 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
           && computer != null
           && !computer.getBuilds().failureOnly().isEmpty()) {
         LOGGER.log(Level.INFO, "Creating snapshot for node ... " + this.getNodeName());
+        long createSnapshotTimeout =
+            (windowsConfig != null)
+                ? CREATE_SNAPSHOT_TIMEOUT_WINDOWS
+                : CREATE_SNAPSHOT_TIMEOUT_LINUX;
         cloud
             .getClient()
             .createSnapshotSync(
-                cloud.getProjectId(), this.zone, this.getNodeName(), CREATE_SNAPSHOT_TIMEOUT);
+                cloud.getProjectId(), this.zone, this.getNodeName(), createSnapshotTimeout);
       }
 
       // If the instance is running, attempt to terminate it. This is an asynch call and we

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -16,39 +16,23 @@
 
 package com.google.jenkins.plugins.computeengine;
 
-import com.google.api.services.compute.model.AccessConfig;
-import com.google.api.services.compute.model.Instance;
-import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.Operation;
 import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyPair;
 import com.trilead.ssh2.Connection;
-import com.trilead.ssh2.HTTPProxyData;
-import com.trilead.ssh2.ServerHostKeyVerifier;
-import hudson.ProxyConfiguration;
 import hudson.model.TaskListener;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
 import java.util.Optional;
 import java.util.logging.Logger;
-import jenkins.model.Jenkins;
-import lombok.Getter;
 
 public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
   private static final Logger LOGGER = Logger.getLogger(ComputeEngineLinuxLauncher.class.getName());
 
-  @Getter private final boolean useInternalAddress;
-
-  // TODO: make this configurable
-  public static final Integer SSH_PORT = 22;
-  public static final Integer SSH_TIMEOUT = 10000;
   private static int bootstrapAuthTries = 30;
   private static int bootstrapAuthSleepMs = 15000;
 
   public ComputeEngineLinuxLauncher(
       String cloudName, Operation insertOperation, boolean useInternalAddress) {
-    super(cloudName, insertOperation.getName(), insertOperation.getZone());
-    this.useInternalAddress = useInternalAddress;
+    super(cloudName, insertOperation.getName(), insertOperation.getZone(), useInternalAddress);
   }
 
   protected Logger getLogger() {
@@ -129,97 +113,6 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
       }
     }
     return true;
-  }
-
-  private Connection connectToSsh(ComputeEngineComputer computer, TaskListener listener)
-      throws Exception {
-    ComputeEngineInstance node = computer.getNode();
-    if (node == null) {
-      throw new IllegalArgumentException("A ComputeEngineComputer with no node was provided");
-    }
-
-    final long timeout = node.getLaunchTimeoutMillis();
-    final long startTime = System.currentTimeMillis();
-    while (true) {
-      try {
-        long waitTime = System.currentTimeMillis() - startTime;
-        if (timeout > 0 && waitTime > timeout) {
-          // TODO: better exception
-          throw new Exception(
-              "Timed out after "
-                  + (waitTime / 1000)
-                  + " seconds of waiting for ssh to become available. (maximum timeout configured is "
-                  + (timeout / 1000)
-                  + ")");
-        }
-        Instance instance = computer.refreshInstance();
-
-        String host = "";
-
-        // TODO: handle multiple NICs
-        NetworkInterface nic = instance.getNetworkInterfaces().get(0);
-
-        if (this.useInternalAddress) {
-          host = nic.getNetworkIP();
-        } else {
-          // Look for a public IP address
-          if (nic.getAccessConfigs() != null) {
-            for (AccessConfig ac : nic.getAccessConfigs()) {
-              if (ac.getType().equals(InstanceConfiguration.NAT_TYPE)) {
-                host = ac.getNatIP();
-              }
-            }
-          }
-          // No public address found. Fall back to internal address
-          if (host.isEmpty()) {
-            host = nic.getNetworkIP();
-          }
-        }
-
-        int port = SSH_PORT;
-        logInfo(
-            computer,
-            listener,
-            "Connecting to " + host + " on port " + port + ", with timeout " + SSH_TIMEOUT + ".");
-        Connection conn = new Connection(host, port);
-        ProxyConfiguration proxyConfig = Jenkins.get().proxy;
-        Proxy proxy = proxyConfig == null ? Proxy.NO_PROXY : proxyConfig.createProxy(host);
-        if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
-          InetSocketAddress address = (InetSocketAddress) proxy.address();
-          HTTPProxyData proxyData = null;
-          if (null != proxyConfig.getUserName()) {
-            proxyData =
-                new HTTPProxyData(
-                    address.getHostName(),
-                    address.getPort(),
-                    proxyConfig.getUserName(),
-                    proxyConfig.getPassword());
-          } else {
-            proxyData = new HTTPProxyData(address.getHostName(), address.getPort());
-          }
-          conn.setProxyData(proxyData);
-          logInfo(computer, listener, "Using HTTP Proxy Configuration");
-        }
-        // TODO: verify host key
-        conn.connect(
-            new ServerHostKeyVerifier() {
-              public boolean verifyServerHostKey(
-                  String hostname, int port, String serverHostKeyAlgorithm, byte[] serverHostKey)
-                  throws Exception {
-                return true;
-              }
-            },
-            SSH_TIMEOUT,
-            SSH_TIMEOUT);
-        logInfo(computer, listener, "Connected via SSH.");
-        return conn;
-      } catch (IOException e) {
-        // keep retrying until SSH comes up
-        logInfo(computer, listener, "Failed to connect via ssh: " + e.getMessage());
-        logInfo(computer, listener, "Waiting for SSH to come up. Sleeping 5.");
-        Thread.sleep(5000);
-      }
-    }
   }
 
   @Override

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -130,6 +130,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   private NetworkConfiguration networkConfiguration;
   private boolean externalAddress;
   private boolean useInternalAddress;
+  private boolean ignoreProxy;
   private String networkTags;
   private String serviceAccountEmail;
   private Node.Mode mode;
@@ -328,6 +329,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
           .windowsConfig(windowsConfiguration)
           .createSnapshot(createSnapshot)
           .oneShot(oneShot)
+          .ignoreProxy(ignoreProxy)
           .numExecutors(numExecutors)
           .mode(mode)
           .labelString(labels)
@@ -932,6 +934,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       instanceConfiguration.setNetworkConfiguration(this.networkConfiguration);
       instanceConfiguration.setExternalAddress(this.externalAddress);
       instanceConfiguration.setUseInternalAddress(this.useInternalAddress);
+      instanceConfiguration.setIgnoreProxy(this.ignoreProxy);
       instanceConfiguration.setNetworkTags(this.networkTags);
       instanceConfiguration.setServiceAccountEmail(this.serviceAccountEmail);
       instanceConfiguration.setMode(this.mode);

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -41,6 +41,9 @@
             <f:entry title="${%Use Internal IP?}" field="useInternalAddress">
                 <f:checkbox/>
             </f:entry>
+            <f:entry title="${%Ignore Jenkins Proxy?}" field="ignoreProxy">
+                <f:checkbox/>
+            </f:entry>
             <f:entry title="${%Run as user}" field="runAsUser">
                 <f:textbox default="${descriptor.defaultRunAsUser()}"/>
             </f:entry>
@@ -51,7 +54,7 @@
                 <f:textbox default="java"/>
             </f:entry>
             <f:optionalProperty field="windowsConfiguration" title="${%Windows?}">
-                  <st:include page="config.jelly" class="${descriptor.clazz}"/>
+                <st:include page="config.jelly" class="${descriptor.clazz}"/>
             </f:optionalProperty>
         </f:section>
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-ignoreProxy.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-ignoreProxy.html
@@ -1,0 +1,17 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<div>
+    When left unchecked, the global proxy configuration of your Jenkins master will be used when launching and
+    connecting to the agent. Check this if you would like to bypass this and connect directly to your agents.
+</div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-ignoreProxy.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-ignoreProxy.html
@@ -12,6 +12,7 @@
  License.
 -->
 <div>
-    When left unchecked, the global proxy configuration of your Jenkins master will be used when launching and
-    connecting to the agent. Check this if you would like to bypass this and connect directly to your agents.
+    When left unchecked, the global proxy configuration of your Jenkins master will be used when
+    launching and connecting to the agent. Check this if you would like to bypass this and connect
+    directly to your agents.
 </div>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -321,6 +321,7 @@ public class InstanceConfigurationTest {
         .networkConfiguration(new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME))
         .externalAddress(EXTERNAL_ADDR)
         .useInternalAddress(false)
+        .ignoreProxy(false)
         .networkTags(NETWORK_TAGS)
         .serviceAccountEmail(SERVICE_ACCOUNT_EMAIL)
         .retentionTimeMinutesStr(RETENTION_TIME_MINUTES_STR)

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudIgnoreProxyIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudIgnoreProxyIT.java
@@ -62,7 +62,6 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 @Log
 public class ComputeEngineCloudIgnoreProxyIT {
-
   @ClassRule
   public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudIgnoreProxyIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudIgnoreProxyIT.java
@@ -30,11 +30,11 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardo
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
 import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
 import com.google.jenkins.plugins.computeengine.ComputeEngineInstance;
 import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
-import com.google.jenkins.plugins.computeengine.client.ComputeClient;
 import hudson.ProxyConfiguration;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudIgnoreProxyIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudIgnoreProxyIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine.integration;
+
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.DEB_JAVA_STARTUP_SCRIPT;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfigurationBuilder;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import com.google.jenkins.plugins.computeengine.ComputeEngineInstance;
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import com.google.jenkins.plugins.computeengine.client.ComputeClient;
+import hudson.ProxyConfiguration;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Node;
+import hudson.model.labels.LabelAtom;
+import hudson.tasks.Builder;
+import hudson.tasks.Shell;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import jenkins.model.Jenkins;
+import lombok.extern.java.Log;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Integration test suite for {@link ComputeEngineCloud}. Verifies that when the ignore proxy flag
+ * is set to true, connections to GCE VMs bypass the proxy, and when set to false the proxy is used.
+ */
+@Log
+public class ComputeEngineCloudIgnoreProxyIT {
+
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
+  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+  private static ComputeClient client;
+  private static Map<String, String> label = getLabel(ComputeEngineCloudIgnoreProxyIT.class);
+  private static ComputeEngineCloud cloud;
+  private static FreeStyleProject project;
+  private static Node worker;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    log.info("init");
+    initCredentials(jenkinsRule);
+    cloud = initCloud(jenkinsRule);
+    client = initClient(jenkinsRule, label, log);
+
+    InstanceConfiguration instanceConfiguration =
+        instanceConfigurationBuilder()
+            .startupScript(DEB_JAVA_STARTUP_SCRIPT)
+            .numExecutorsStr(NUM_EXECUTORS)
+            .labels(LABEL)
+            .template(NULL_TEMPLATE)
+            .googleLabels(label)
+            .oneShot(true)
+            .ignoreProxy(true)
+            .build();
+
+    Jenkins jenkins = jenkinsRule.getInstance();
+    jenkins.proxy = new ProxyConfiguration("127.0.0.1", 8080);
+    jenkins.proxy.save();
+    jenkins.save();
+    cloud.setConfigurations(ImmutableList.of(instanceConfiguration));
+    assertTrue(
+        cloud
+            .getInstanceConfigurationByDescription(instanceConfiguration.getDescription())
+            .isIgnoreProxy());
+
+    project = jenkinsRule.createFreeStyleProject();
+    Builder step = new Shell("echo works");
+    project.getBuildersList().add(step);
+    project.setAssignedLabel(new LabelAtom(LABEL));
+
+    FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
+    worker = build.getBuiltOn();
+    assertNotNull(worker);
+  }
+
+  @AfterClass
+  public static void teardown() throws IOException {
+    teardownResources(client, label, log);
+  }
+
+  @Test
+  public void testWorkerIgnoringProxy() {
+    ComputeEngineInstance node = (ComputeEngineInstance) worker;
+    assertTrue(node.isIgnoreProxy());
+  }
+
+  // Due to the proxy configured for Jenkins, the build fails because it is not able to connect to
+  // the node through the proxy.
+  @Test(expected = TimeoutException.class)
+  public void testWorkerNotIgnoringProxyFails() throws Exception {
+    cloud.getConfigurations().get(0).setIgnoreProxy(false);
+    Future<FreeStyleBuild> build = project.scheduleBuild2(0);
+    build.get(100, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudOneShotInstanceIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudOneShotInstanceIT.java
@@ -135,17 +135,17 @@ public class ComputeEngineCloudOneShotInstanceIT {
   }
 
   @Test
-  public void testOtherInstanceRanOnDifferentNode() throws Exception {
-    Node node = otherBuildFuture.get().getBuiltOn();
-    assertNotNull(node);
-    assertNotEquals(nodeName, node.getNodeName());
-  }
-
-  @Test
   public void testOtherInstanceSuccessful() throws Exception {
     FreeStyleBuild otherBuild = otherBuildFuture.get();
     assertNotNull(otherBuild);
     assertEquals(Result.SUCCESS, otherBuild.getResult());
     jenkinsRule.assertLogContains("also works", otherBuild);
+  }
+
+  @Test
+  public void testOtherInstanceRanOnDifferentNode() throws Exception {
+    Node node = otherBuildFuture.get().getBuiltOn();
+    assertNotNull(node);
+    assertNotEquals(nodeName, node.getNodeName());
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWindowsIT.java
@@ -282,6 +282,7 @@ public class ComputeEngineCloudWindowsIT {
     }
   }
 
+  // TODO(google-compute-engine-plugin/issues/49): Remove this test when refactoring windows tests.
   @Test(timeout = 500000)
   public void testIgnoreProxy() throws Exception {
     logOutput.reset();

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWindowsIT.java
@@ -246,7 +246,7 @@ public class ComputeEngineCloudWindowsIT {
 
   // Tests snapshot is created when we have failure builds for given node
   // Snapshot creation is longer for windows one-shot vm's.
-  @Test(timeout = 0)
+  @Test(timeout = 800000)
   public void testSnapshotCreated() throws Exception {
     logOutput.reset();
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeWindowsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeWindowsIT.java
@@ -1,23 +1,20 @@
 package com.google.jenkins.plugins.computeengine.integration;
 
-import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
-import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
-import com.google.api.services.compute.model.Instance;
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
 import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import hudson.model.FreeStyleProject;
 import hudson.model.labels.LabelAtom;
-import hudson.slaves.NodeProvisioner.PlannedNode;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Builder;
 import io.jenkins.plugins.casc.ConfigurationAsCode;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -34,7 +31,7 @@ public class ConfigAsCodeWindowsIT {
   @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
 
   @ClassRule
-  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+  public static Timeout timeout = new Timeout(10 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
   private static ComputeClient client;
   private static Map<String, String> label = getLabel(ConfigAsCodeWindowsIT.class);
@@ -65,16 +62,11 @@ public class ConfigAsCodeWindowsIT {
     assertEquals(1, cloud.getConfigurations().size());
     cloud.getConfigurations().get(0).setGoogleLabels(label);
 
-    // Add a new node
-    Collection<PlannedNode> planned = cloud.provision(new LabelAtom("integration-windows"), 1);
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    Builder step = new BatchFile("echo works");
+    project.getBuildersList().add(step);
+    project.setAssignedLabel(new LabelAtom("integration-windows"));
 
-    // There should be a planned node
-    assertEquals(1, planned.size());
-    String name = planned.iterator().next().displayName;
-
-    // Wait for the node creation to finish
-    planned.iterator().next().future.get();
-    Instance instance = client.getInstance(PROJECT_ID, ZONE, name);
-    assertNotNull(instance);
+    jenkinsRule.buildAndAssertSuccess(project);
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -236,6 +236,7 @@ class ITUtil {
         .networkConfiguration(new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME))
         .externalAddress(EXTERNAL_ADDR)
         .useInternalAddress(false)
+        .ignoreProxy(false)
         .networkTags(NETWORK_TAGS)
         .serviceAccountEmail(SERVICE_ACCOUNT_EMAIL)
         .retentionTimeMinutesStr(RETENTION_TIME_MINUTES_STR)

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -105,7 +105,7 @@ class ITUtil {
   private static final String NETWORK_NAME = format("projects/%s/global/networks/default");
   private static final String SUBNETWORK_NAME = "default";
   private static final boolean EXTERNAL_ADDR = true;
-  private static final String NETWORK_TAGS = "ssh";
+  private static final String NETWORK_TAGS = "jenkins-agent ssh";
   private static final String SERVICE_ACCOUNT_EMAIL = "";
   private static final String RETENTION_TIME_MINUTES_STR = "";
   private static final String LAUNCH_TIMEOUT_SECONDS_STR = "";

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml
@@ -26,7 +26,7 @@ jenkins:
             machineType:        "https://www.googleapis.com/compute/v1/projects/${env.GOOGLE_PROJECT_ID}/zones/us-west1-a/machineTypes/n1-standard-1"
             preemptible:        false
             minCpuPlatform:     '' # tried not setting, added when 'saved' in UI
-            startupScript:      "Stop-Service sshd\n$ConfiguredPublicKey = \":${env.GOOGLE_PUBLIC_KEY}\"\nWrite-Output \"Second phase\"\nSet-Content -Path $env:PROGRAMDATA\\ssh\\administrators_authorized_keys -Value $ConfiguredPublicKey\nicacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /inheritance:jenkinsRule\nicacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /grant SYSTEM:`(F`)\nicacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /grant BUILTIN\\Administrators:`(F`)\nRestart-Service sshd"
+            startupScript:      "Stop-Service sshd\n$ConfiguredPublicKey = \":${env.GOOGLE_PUBLIC_KEY}\"\nWrite-Output \"Second phase\"\nSet-Content -Path $env:PROGRAMDATA\\ssh\\administrators_authorized_keys -Value $ConfiguredPublicKey\nicacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /inheritance:r\nicacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /grant SYSTEM:`(F`)\nicacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /grant BUILTIN\\Administrators:`(F`)\nRestart-Service sshd"
             networkConfiguration:
               autofilled:
                 network:        default


### PR DESCRIPTION
See #132

The connectToSsh method was duplicated in both launchers so that was consolidated so that I only needed to make this change once.