### PR TITLE
Update to version 20.0 of guava.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
 
   <artifactId>google-compute-engine</artifactId>
-  <version>4.0.1-SNAPSHOT</version>
+  <version>4.1.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Google Compute Engine Plugin</name>
@@ -76,6 +76,10 @@
     <it.windows>false</it.windows>
     <configuration-as-code.version>1.14</configuration-as-code.version>
     <powershell.version>1.3</powershell.version>
+    <google-oauth.version>1.0.0-SNAPSHOT</google-oauth.version>
+    <google.guava.version>20.0</google.guava.version>
+    <gcp-plugin-core.version>0.2.0-SNAPSHOT</gcp-plugin-core.version>
+    <hpi.compatibleSinceVersion>4.1.0</hpi.compatibleSinceVersion>
     <concurrency>10</concurrency>
     <it.runOrder>balanced</it.runOrder>
   </properties>
@@ -89,7 +93,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-oauth-plugin</artifactId>
-      <version>0.9</version>
+      <version>${google-oauth.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -104,7 +108,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version>
+      <version>${google.guava.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -114,7 +118,7 @@
     <dependency>
       <groupId>com.google.cloud.graphite</groupId>
       <artifactId>gcp-client</artifactId>
-      <version>0.1.2</version>
+      <version>${gcp-plugin-core.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
     <it.windows>false</it.windows>
     <configuration-as-code.version>1.14</configuration-as-code.version>
     <powershell.version>1.3</powershell.version>
-    <google-oauth.version>1.0.0-SNAPSHOT</google-oauth.version>
+    <google-oauth.version>1.0.0</google-oauth.version>
     <google.guava.version>20.0</google.guava.version>
     <google.http.version>1.21.0</google.http.version>
     <google.api.version>1.25.0</google.api.version>
     <compute.revision>214</compute.revision>
-    <gcp-plugin-core.version>0.2.0-SNAPSHOT</gcp-plugin-core.version>
+    <gcp-plugin-core.version>0.2.0</gcp-plugin-core.version>
     <hpi.compatibleSinceVersion>4.1.0</hpi.compatibleSinceVersion>
     <concurrency>10</concurrency>
     <it.runOrder>balanced</it.runOrder>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,9 @@
     <powershell.version>1.3</powershell.version>
     <google-oauth.version>1.0.0-SNAPSHOT</google-oauth.version>
     <google.guava.version>20.0</google.guava.version>
+    <google.http.version>1.21.0</google.http.version>
+    <google.api.version>1.25.0</google.api.version>
+    <compute.revision>214</compute.revision>
     <gcp-plugin-core.version>0.2.0-SNAPSHOT</gcp-plugin-core.version>
     <hpi.compatibleSinceVersion>4.1.0</hpi.compatibleSinceVersion>
     <concurrency>10</concurrency>
@@ -109,6 +112,27 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${google.guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>${google.http.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client</artifactId>
+      <version>${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-compute</artifactId>
+      <version>v1-rev${compute.revision}-${google.api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -153,6 +177,19 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>3.1.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>${google.api.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Depends on upstream changes and releases:
- [x] Change: https://github.com/jenkinsci/google-oauth-plugin/pull/75
- [x] Release 1.0.0 of google-oauth-plugin
- [x] https://github.com/GoogleCloudPlatform/gcp-plugin-core-java/pull/9
- [x] Release 0.2.0 of gcp-plugin-core-java
