### PR TITLE
Prevent ITs from being executed by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ mvn test
 ```
 
 ##### Integration Tests
+* By default, the integration tests are not executed. In case you are interested in executing 
+  them, disable the `skipITs` property.
 * The following environment variables are required to run the integration tests. 5, 6, and 7 are
   only required when running a windows integration test.
 
@@ -74,7 +76,7 @@ mvn test
 
 * Run the following:
 ```
-mvn verify
+mvn verify -DskipITs=false
 ```
 
 ###### Windows Integration Test

--- a/Jenkinsfile.linux
+++ b/Jenkinsfile.linux
@@ -42,7 +42,7 @@ pipeline {
                             sh "mvn clean package -ntp"
 
                             // run tests
-                            sh "mvn verify -ntp"
+                            sh "mvn verify -ntp -DskipITs=false"
                         }
 
                         sh "jenkins/saveAndCompress.sh"

--- a/Jenkinsfile.windows
+++ b/Jenkinsfile.windows
@@ -47,7 +47,7 @@ pipeline {
                             sh "mvn clean package -ntp"
 
                             // run tests
-                            sh "mvn verify -ntp -Dit.windows=true"
+                            sh "mvn verify -ntp -Dit.windows=true -DskipITs=false"
                         }
 
                         sh "jenkins/saveAndCompress.sh"

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
+    <skipITs>true</skipITs>
     <it.windows>false</it.windows>
     <configuration-as-code.version>1.14</configuration-as-code.version>
     <powershell.version>1.3</powershell.version>
@@ -293,6 +294,7 @@
           </execution>
         </executions>
         <configuration>
+          <skipITs>${skipITs}</skipITs>
           <disableXmlReport>true</disableXmlReport>
           <useFile>false</useFile>
           <systemPropertyVariables>


### PR DESCRIPTION
In the same way any other plugin in the community can be installed locally without configuring any external system, this plugin should allow to do the same. However, if I execute a `mvn verify` or `mvn install` I get errors because the integration tests are executed and I don't have any configured GCE instance.

This PR pretends to make possible the local installation of the plugin giving as well a mechanism that allows to execute those integration tests.

@evandbrown @craigdbarber @stephenashank 