### PR TITLE
Fix scm connection url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:ssh://github.com/jenkinsci/google-compute-engine-plugin.git</connection>
+    <connection>scm:git:ssh://git@github.com/jenkinsci/google-compute-engine-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/google-compute-engine-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/google-compute-engine-plugin</url>
     <tag>HEAD</tag>


### PR DESCRIPTION
The connection set in the SCM section of pom.xml file is incomplete and executing the `git clone ssh://github.com/jenkinsci/google-compute-engine-plugin.git` command causes an error:

```
Permission denied (publickey).
```
@evandbrown @craigdbarber @stephenashank