### PR TITLE
(#165) Add Java8 requirement in the UI

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskSourceImageName.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskSourceImageName.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2018 Google LLC
+ Copyright 2019 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskSourceImageName.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-bootDiskSourceImageName.html
@@ -1,0 +1,16 @@
+<!--
+ Copyright 2018 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<div>
+    The selected image needs Java 8 installed and on its default path.
+</div>


### PR DESCRIPTION
## What is this PR doing?
It adds a help area for the image used to provision the worker machines from a GCE image. The texts are directly copied from the existing `Home.md` file.

## Why is it important?
The existing Github docs warn the user about the fact of having Java8 installed in the chosen image, but the UI is not reflecting that information. For that reason I consider important to sync-up both of them to gather expectations.

## Screenshots
<img width="850" alt="Screenshot 2019-12-02 at 14 41 54" src="https://user-images.githubusercontent.com/951580/69968602-a3355f00-1512-11ea-9cbf-0f2a314e59aa.png">

## Author's checklist
- [x] Unit tests passing
- [ ] Integration test executed
- [x] HPI deployed to a running Jenkins instance (v2.190.3)