### PR TITLE
Moving docs to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
  License.
 -->
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/google-compute-engine-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/google-compute-engine-plugin/job/master/)
+[![Build Status](https://ci.jenkins.io/job/Plugins/job/google-compute-engine-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/google-compute-engine-plugin/job/develop/)
 [![Contributors](https://img.shields.io/github/contributors/jenkinsci/google-compute-engine-plugin.svg)](https://github.com/jenkinsci/google-compute-engine-plugin/graphs/contributors)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/google-compute-engine.svg)](https://plugins.jenkins.io/google-compute-engine)
-[![GitHub release](https://img.shields.io/github/release/jenkinsci/google-compute-engine-plugin.svg?label=changelog)](https://github.com/jenkinsci/google-compute-engine-plugin/releases/latest)
+[![GitHub release](https://img.shields.io/github/v/tag/jenkinsci/google-compute-engine-plugin?label=changelog)](https://github.com/jenkinsci/google-compute-engine-plugin/blob/develop/CHANGELOG.md)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/google-compute-engine.svg?color=blue)](https://plugins.jenkins.io/google-compute-engine)
 
 # Google Compute Engine Plugin for Jenkins

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@
  implied. See the License for the specific language governing permissions and limitations under the
  License.
 -->
+
+[![Build Status](https://ci.jenkins.io/job/Plugins/job/google-compute-engine-plugin/job/master/badge/icon)](https://ci.jenkins.io/job/Plugins/job/google-compute-engine-plugin/job/master/)
+[![Contributors](https://img.shields.io/github/contributors/jenkinsci/google-compute-engine-plugin.svg)](https://github.com/jenkinsci/google-compute-engine-plugin/graphs/contributors)
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/google-compute-engine.svg)](https://plugins.jenkins.io/google-compute-engine)
+[![GitHub release](https://img.shields.io/github/release/jenkinsci/google-compute-engine-plugin.svg?label=changelog)](https://github.com/jenkinsci/google-compute-engine-plugin/releases/latest)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/google-compute-engine.svg?color=blue)](https://plugins.jenkins.io/google-compute-engine)
+
 # Google Compute Engine Plugin for Jenkins
 The Google Compute Engine (GCE) Plugin allows you to use GCE virtual machines (VMs) with Jenkins to execute build tasks. GCE VMs provision quickly, are destroyed by Jenkins when idle, and offer Preemptible VMs that run at a much lower price than regular VMs.
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <name>Google Compute Engine Plugin</name>
   <description>This plugin allows Jenkins to provision dynamic worker nodes on Google Compute Engine.</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Google+Compute+Engine+Plugin</url>
+  <url>https://github.com/jenkinsci/google-compute-engine-plugin</url>
   <organization>
     <name>Google</name>
     <url>https://www.google.com</url>


### PR DESCRIPTION
Closes [JENKINS-60837](https://issues.jenkins-ci.org/browse/JENKINS-60837)
See https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/