### PR TITLE
Use BOM and update reference to the JCasC demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Please see the [Google Compute Engine Plugin](docs/Home.md) docs for complete do
 1. Choose the Jenkins plugin file downloaded in Step 1.
 1. Click the **Upload** button.
 
+## Configuration as Code Support
+Support for [Jenkins Configuration as Code](https://jenkins.io/projects/jcasc/). See the below examples that are already automatically tested:
+
+* [A configuration example](./src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml)
+* [Another configuration example with Windows workers](./src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml)
+
+
 ## Feature requests and bug reports
 Please file feature requests and bug reports under [issues](https://github.com/jenkinsci/google-compute-engine-plugin/issues).
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.150.3</jenkins.version>
     <jenkinsRuleTimeout>0</jenkinsRuleTimeout>
     <java.level>8</java.level>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -75,7 +75,6 @@
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     <skipITs>true</skipITs>
     <it.windows>false</it.windows>
-    <configuration-as-code.version>1.14</configuration-as-code.version>
     <powershell.version>1.3</powershell.version>
     <google-oauth.version>1.0.0</google-oauth.version>
     <google.guava.version>20.0</google.guava.version>
@@ -83,17 +82,26 @@
     <google.api.version>1.25.0</google.api.version>
     <compute.revision>214</compute.revision>
     <gcp-plugin-core.version>0.2.1</gcp-plugin-core.version>
-    <jsch.version>0.1.55</jsch.version>
     <hpi.compatibleSinceVersion>4.1.0</hpi.compatibleSinceVersion>
     <concurrency>10</concurrency>
     <it.runOrder>balanced</it.runOrder>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.150.x</artifactId>
+        <version>4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsch</artifactId>
-      <version>${jsch.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -103,12 +111,10 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-credentials</artifactId>
-      <version>1.17</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -175,7 +181,6 @@
     <dependency><!-- OnceRetentionStrategy -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>durable-task</artifactId>
-      <version>1.28</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -199,26 +204,17 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
-      <version>1.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>${configuration-as-code.version}</version>
       <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.configuration-as-code</groupId>
-      <artifactId>configuration-as-code-support</artifactId>
-      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
+      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Simplify POM dependencies with the BOM and bump the Jenkins core dependency.

Probably https://github.com/jenkinsci/google-compute-engine-plugin/pull/177 could take advantage of this change and move to the upcoming BOM version.