### PR TITLE
Use trilead-api plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,15 +165,11 @@
       <version>${gcp-plugin-core.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>trilead-ssh2</artifactId>
-      <version>build-217-jenkins-14</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.i2p.crypto</groupId>
-          <artifactId>eddsa</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>trilead-api</artifactId>
+      <!-- Version can be removed when bumping the version for the BOM and
+        https://github.com/jenkinsci/bom/pull/110/files get merged -->
+      <version>1.0.5</version>
     </dependency>
     <dependency>
       <groupId>net.i2p.crypto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,12 @@
       <!-- Version can be removed when bumping the version for the BOM and
         https://github.com/jenkinsci/bom/pull/110/files get merged -->
       <version>1.0.3</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.i2p.crypto</groupId>
+          <artifactId>eddsa</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.i2p.crypto</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
       <artifactId>trilead-api</artifactId>
       <!-- Version can be removed when bumping the version for the BOM and
         https://github.com/jenkinsci/bom/pull/110/files get merged -->
-      <version>1.0.5</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>net.i2p.crypto</groupId>


### PR DESCRIPTION
Use https://github.com/jenkinsci/trilead-api-plugin and bump version.

If https://github.com/jenkinsci/bom/pull/110 get merged then the BOM could be bumped and the version for the trilead-api could be implicit instead.