### PR TITLE
PoC: Install Java if not installed in the agent

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -110,3 +110,8 @@ Instance configurations have many options that were not listed above. A few of t
   access from metadata. For more info, review the service account documentation.
 
 
+# Install java if not found
+
+By default the agents do require to have java installed, this particular flag feature will enable to install java before the provisioning happens.
+
+If you want to turn on this installation strategy then you set SystemProperty `com.google.jenkins.plugins.computeengine.enableJavaInstallation=true`

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -108,10 +108,5 @@ Instance configurations have many options that were not listed above. A few of t
 * GPUs - attach 1 or more GPUs to the instance. For more info, visit the GCE GPU docs.
 * Service Account E-mail - sets the service account that the instance will be able to
   access from metadata. For more info, review the service account documentation.
-
-
-# Install java if not found
-
-By default the agents do require to have java installed, this particular flag feature will enable to install java before the provisioning happens.
-
-If you want to turn on this installation strategy then you set SystemProperty `com.google.jenkins.plugins.computeengine.enableJavaInstallation=true`
+* Install Java - Java is required to be installed in the instances to be provisioned. This
+  feature will install Java before the provisioning happen if Java was not found at first.

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -50,8 +50,9 @@ import jenkins.model.Jenkins;
 import lombok.Getter;
 
 public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
-  private static final boolean ENABLE_JAVA_INSTALLATION = Boolean.valueOf(
-    System.getProperty("com.google.jenkins.plugins.computeengine.enableJavaInstallation"));
+  private static final boolean ENABLE_JAVA_INSTALLATION =
+      Boolean.valueOf(
+          System.getProperty("com.google.jenkins.plugins.computeengine.enableJavaInstallation"));
 
   private static final Logger LOGGER =
       Logger.getLogger(ComputeEngineComputerLauncher.class.getName());
@@ -328,7 +329,8 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
       if (!checkJavaInstalled(computer, conn, logger, listener, javaExecPath)) {
         if (ENABLE_JAVA_INSTALLATION) {
           logInfo(computer, listener, "Let's install java for some *nix flavours");
-          if (!installJava(computer, conn, logger, listener, "sudo yum install -y java-1.8.0-openjdk.x86_64")) {
+          if (!installJava(
+              computer, conn, logger, listener, "sudo yum install -y java-1.8.0-openjdk.x86_64")) {
             if (!installJava(computer, conn, logger, listener, "sudo apt install openjdk-8-jdk")) {
               return;
             }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -327,7 +327,8 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
           logInfo(computer, listener, "Let's install java for some *nix flavours");
           if (!installJava(
               computer, conn, logger, listener, "sudo yum install -y java-1.8.0-openjdk.x86_64")) {
-            if (!installJava(computer, conn, logger, listener, "sudo apt install openjdk-8-jdk")) {
+            if (!installJava(
+                computer, conn, logger, listener, "sudo apt install -y openjdk-8-jdk")) {
               return;
             }
           }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -50,10 +50,6 @@ import jenkins.model.Jenkins;
 import lombok.Getter;
 
 public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
-  private static final boolean ENABLE_JAVA_INSTALLATION =
-      Boolean.valueOf(
-          System.getProperty("com.google.jenkins.plugins.computeengine.enableJavaInstallation"));
-
   private static final Logger LOGGER =
       Logger.getLogger(ComputeEngineComputerLauncher.class.getName());
   private static final SimpleFormatter sf = new SimpleFormatter();
@@ -327,7 +323,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
       conn = cleanupConn.get();
       String javaExecPath = node.getJavaExecPathOrDefault();
       if (!checkJavaInstalled(computer, conn, logger, listener, javaExecPath)) {
-        if (ENABLE_JAVA_INSTALLATION) {
+        if (node.isInstallJava()) {
           logInfo(computer, listener, "Let's install java for some *nix flavours");
           if (!installJava(
               computer, conn, logger, listener, "sudo yum install -y java-1.8.0-openjdk.x86_64")) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -52,6 +52,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
   private final boolean createSnapshot;
   private final boolean oneShot;
   private final boolean ignoreProxy;
+  private final boolean installJava;
   private final String javaExecPath;
   private final GoogleKeyPair sshKeyPair;
   private Integer launchTimeout; // Seconds
@@ -80,7 +81,8 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
       // NOTE(craigatgoogle): Could not use Optional due to serialization req.
       @Nullable String javaExecPath,
       @Nullable GoogleKeyPair sshKeyPair,
-      @Nullable ComputeEngineCloud cloud)
+      @Nullable ComputeEngineCloud cloud,
+      boolean installJava)
       throws Descriptor.FormException, IOException {
     super(
         name,
@@ -103,6 +105,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
     this.javaExecPath = javaExecPath;
     this.sshKeyPair = sshKeyPair;
     this.cloud = cloud;
+    this.installJava = installJava;
   }
 
   @Override

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -134,6 +134,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   private boolean externalAddress;
   private boolean useInternalAddress;
   private boolean ignoreProxy;
+  private boolean installJava;
   private String networkTags;
   private String serviceAccountEmail;
   private Node.Mode mode;
@@ -217,6 +218,11 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   public void setBootDiskSizeGbStr(String bootDiskSizeGbStr) {
     this.bootDiskSizeGb = longOrDefault(bootDiskSizeGbStr, DEFAULT_BOOT_DISK_SIZE_GB);
     this.bootDiskSizeGbStr = this.bootDiskSizeGb.toString();
+  }
+
+  @DataBoundSetter
+  public void setInstallJava(boolean installJava) {
+    this.installJava = installJava;
   }
 
   @DataBoundSetter
@@ -334,6 +340,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
           .createSnapshot(createSnapshot)
           .oneShot(oneShot)
           .ignoreProxy(ignoreProxy)
+          .installJava(installJava)
           .numExecutors(numExecutors)
           .mode(mode)
           .labelString(labels)
@@ -962,6 +969,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       instanceConfiguration.setExternalAddress(this.externalAddress);
       instanceConfiguration.setUseInternalAddress(this.useInternalAddress);
       instanceConfiguration.setIgnoreProxy(this.ignoreProxy);
+      instanceConfiguration.setInstallJava(this.installJava);
       instanceConfiguration.setNetworkTags(this.networkTags);
       instanceConfiguration.setServiceAccountEmail(this.serviceAccountEmail);
       instanceConfiguration.setMode(this.mode);

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -50,6 +50,9 @@
             <f:entry title="${%Remote Location}" field="remoteFs">
                 <f:textbox default=""/>
             </f:entry>
+            <f:entry field="installJava" title="${%Install Java}">
+                <f:checkbox/>
+            </f:entry>
             <f:entry title="${%Java Exec Path}" field="javaExecPath">
                 <f:textbox default="java"/>
             </f:entry>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-installJava.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-installJava.html
@@ -1,0 +1,16 @@
+<!--
+ Copyright 2020 Elastic, Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<div>
+  Install Java in the node in case Java was not found.
+</div>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudInstallJavaIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudInstallJavaIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Elastic, Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine.integration;
+
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.*;
+import static org.junit.Assert.*;
+
+import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
+import com.google.common.collect.ImmutableList;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Node;
+import hudson.model.Result;
+import hudson.model.labels.LabelAtom;
+import hudson.tasks.Builder;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.awaitility.Awaitility;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Integration test suite for {@link ComputeEngineCloud}. Verifies that instances without any Java
+ * installation got a installed one.
+ */
+public class ComputeEngineCloudInstallJavaIT {
+  private static Logger log = Logger.getLogger(ComputeEngineCloudInstallJavaIT.class.getName());
+  private static final int QUIET_PERIOD_SECS = 30;
+
+  @ClassRule
+  public static Timeout timeout = new Timeout(10 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
+  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+  private static ComputeClient client;
+  private static Map<String, String> label = getLabel(ComputeEngineCloudInstallJavaIT.class);
+  private static FreeStyleBuild build;
+  private static String nodeName;
+  private static Future<FreeStyleBuild> otherBuildFuture;
+  private static Node otherNode;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    log.info("init");
+    initCredentials(jenkinsRule);
+    ComputeEngineCloud cloud = initCloud(jenkinsRule);
+    client = initClient(jenkinsRule, label, log);
+
+    cloud.setConfigurations(
+        ImmutableList.of(
+            instanceConfigurationBuilder()
+                .numExecutorsStr(NUM_EXECUTORS)
+                .labels(LABEL)
+                .oneShot(true)
+                .createSnapshot(false)
+                .template(NULL_TEMPLATE)
+                .googleLabels(label)
+                .installJava(true)
+                .startupScript("")
+                .build()));
+    jenkinsRule.jenkins.getNodesObject().setNodes(Collections.emptyList());
+
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    Builder step = execute(Commands.ECHO, "works");
+    project.getBuildersList().add(step);
+    project.setAssignedLabel(new LabelAtom(LABEL));
+    Future<FreeStyleBuild> buildFuture = project.scheduleBuild2(0);
+
+    FreeStyleProject otherProject = jenkinsRule.createFreeStyleProject();
+    Builder otherStep = execute(Commands.ECHO, "\"also works\"");
+    otherProject.getBuildersList().add(otherStep);
+    otherProject.setAssignedLabel(new LabelAtom(LABEL));
+    // Wait for a bit to make sure that this build finishes second.
+    otherBuildFuture = otherProject.scheduleBuild2(QUIET_PERIOD_SECS);
+
+    build = buildFuture.get();
+    assertNotNull(build);
+    assertEquals(Result.SUCCESS, build.getResult());
+    nodeName = build.getBuiltOn().getNodeName();
+  }
+
+  @AfterClass
+  public static void teardown() throws IOException {
+    teardownResources(client, label, log);
+  }
+
+  @Test
+  public void testInstallJavaInstanceLogContainsExpectedOutput() throws Exception {
+    jenkinsRule.assertLogContains("works", build);
+  }
+
+  @Test
+  public void testInstallJavaInstanceNodeDeletedFromJenkins() {
+    Awaitility.await()
+        .timeout(10, TimeUnit.SECONDS)
+        .until(() -> jenkinsRule.jenkins.getNode(nodeName) == null);
+  }
+
+  @Test
+  public void testInstallJavanstanceDeletedFromGCP() {
+    Awaitility.await()
+        .timeout(3, TimeUnit.MINUTES)
+        .pollInterval(10, TimeUnit.SECONDS)
+        .until(() -> client.listInstancesWithLabel(PROJECT_ID, label).isEmpty());
+  }
+
+  @Test
+  public void testInstallJavaInstanceSuccessful() throws Exception {
+    FreeStyleBuild otherBuild = otherBuildFuture.get();
+    assertNotNull(otherBuild);
+    assertEquals(Result.SUCCESS, otherBuild.getResult());
+    otherNode = otherBuild.getBuiltOn();
+    jenkinsRule.assertLogContains("also works", otherBuild);
+  }
+
+  @Test
+  public void testOtherInstanceRanOnDifferentNode() throws Exception {
+    assertNotNull(otherNode);
+    assertNotEquals(nodeName, otherNode.getNodeName());
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeInstallJavaTestIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeInstallJavaTestIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Elastic, Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine.integration;
+
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeFalse;
+
+import com.google.api.services.compute.model.Instance;
+import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import hudson.model.FreeStyleProject;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProvisioner;
+import hudson.tasks.Builder;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Integration tests for Jenkins agents without any java installation that are configured with
+ * Configuration as Code with the install java before the provisionign happens.
+ */
+public class ConfigAsCodeInstallJavaTestIT {
+  private static Logger log = Logger.getLogger(ConfigAsCodeNonStandardJavaIT.class.getName());
+  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+  @ClassRule
+  public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
+  private static ComputeClient client;
+  private static Map<String, String> label = getLabel(ConfigAsCodeNonStandardJavaIT.class);
+
+  @BeforeClass
+  public static void init() throws Exception {
+    assumeFalse(windows);
+    log.info("init");
+    initCredentials(jenkinsRule);
+    client = initClient(jenkinsRule, label, log);
+  }
+
+  @AfterClass
+  public static void teardown() throws IOException {
+    teardownResources(client, label, log);
+  }
+
+  @Test
+  public void testNonStandardJavaWorkerCreated() throws Exception {
+    assumeFalse(windows);
+    ConfigurationAsCode.get()
+        .configure(
+            this.getClass().getResource("configuration-as-code-install-java-it.yml").toString());
+    ComputeEngineCloud cloud =
+        (ComputeEngineCloud) jenkinsRule.jenkins.clouds.getByName("gce-integration");
+
+    // Should be 1 configuration
+    assertEquals(1, cloud.getConfigurations().size());
+    cloud.getConfigurations().get(0).setGoogleLabels(label);
+
+    // Add a new node
+    Collection<NodeProvisioner.PlannedNode> planned =
+        cloud.provision(new LabelAtom("integration-install-java"), 1);
+
+    // There should be a planned node
+    assertEquals(1, planned.size());
+    String name = planned.iterator().next().displayName;
+
+    // Wait for the node creation to finish
+    planned.iterator().next().future.get();
+    Instance instance = client.getInstance(PROJECT_ID, ZONE, name);
+    assertNotNull(instance);
+
+    FreeStyleProject project = jenkinsRule.createFreeStyleProject();
+    Builder step = execute(Commands.ECHO, "works");
+    project.getBuildersList().add(step);
+    jenkinsRule.buildAndAssertSuccess(project);
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -318,7 +318,8 @@ class ITUtil {
         .acceleratorConfiguration(new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
         .runAsUser(RUN_AS_USER)
         .startupScript(STARTUP_SCRIPT)
-        .javaExecPath("java -Dhudson.remoting.Launcher.pingIntervalSec=-1");
+        .javaExecPath("java -Dhudson.remoting.Launcher.pingIntervalSec=-1")
+        .installJava(false);
   }
 
   /*

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-install-java-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-install-java-it.yml
@@ -6,12 +6,12 @@ jenkins:
         instanceCapStr: 10
         credentialsId: ${env.GOOGLE_PROJECT_ID}
         configurations:
-          - namePrefix:         integration
-            description:        integration
+          - namePrefix:         integration-install-java
+            description:        integration-install-java
             launchTimeoutSecondsStr: ''
             retentionTimeMinutesStr: ''
             mode:               EXCLUSIVE
-            labelString:        integration
+            labelString:        integration-install-java
             numExecutorsStr:    1
             runAsUser:          jenkins
             remoteFs:           ''
@@ -23,7 +23,6 @@ jenkins:
             machineType:        "https://www.googleapis.com/compute/v1/projects/${env.GOOGLE_PROJECT_ID}/zones/${env.GOOGLE_ZONE}/machineTypes/n1-standard-1"
             preemptible:        false
             minCpuPlatform:     '' # tried not setting, added when 'saved' in UI
-            startupScript:      "#!/bin/bash\n/etc/init.d/ssh stop\necho \"deb http://http.debian.net/debian stretch-backports main\" | \\\n      sudo tee --append /etc/apt/sources.list > /dev/null\napt-get -y update\napt-get -y install -t stretch-backports openjdk-8-jdk\nupdate-java-alternatives -s java-1.8.0-openjdk-amd64\n/etc/init.d/ssh start" 
             networkConfiguration:
               autofilled:
                 network:        default 
@@ -37,4 +36,4 @@ jenkins:
             bootDiskSizeGbStr:  10
             bootDiskAutoDelete: true
             serviceAccountEmail: "${env.GOOGLE_SA_NAME}@${env.GOOGLE_PROJECT_ID}.iam.gserviceaccount.com"
-            installJava:        false
+            installJava:        true


### PR DESCRIPTION
This is a PoC to allow using the agents that are already provided in the default projects without any need to customise the Java installation in the default images for the default projects.

- https://github.com/jenkinsci/google-compute-engine-plugin/blob/2e047393d2e0826c2689c88a8ab431ca441c6cf6/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java#L101-L116


A similar approach was implemented with the EC2-plugin:
- https://github.com/jenkinsci/ec2-plugin/blob/69a4b310549764c2a0a69e8ca1e2b8e6c518a553/src/main/java/hudson/plugins/ec2/ssh/EC2UnixLauncher.java#L221-L222

## Screenshots

![image](https://user-images.githubusercontent.com/2871786/74323513-87a1cc80-4d7d-11ea-9a08-f900ee605560.png)

## Actions
- [ ] Validate the installation steps are good enough
- [x] Validate some of the projects to confirm it works as expected
- [ ] Support windows if possible.

## Manual tests

I did run some tests in one of my instances:

- When the apt install didn't have `-y` then

the global logs said something like the below:

![image](https://user-images.githubusercontent.com/2871786/74475750-ee1f0b80-4e9f-11ea-81da-d4cf86de3d46.png)

and the logs in the agent said the below

![image](https://user-images.githubusercontent.com/2871786/74475812-10188e00-4ea0-11ea-93c5-8045c9f9a162.png)

- When the apt install did have `-y` then:

![image](https://user-images.githubusercontent.com/2871786/74475845-1eff4080-4ea0-11ea-8699-9cdfeb632b34.png)



## Questions
- A kind of similar approach can be accomplished with the Startup Script, see -> https://github.com/jenkinsci/google-compute-engine-plugin/blob/2e047393d2e0826c2689c88a8ab431ca441c6cf6/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml#L26
  - Do we want to support this feature with this new property? I see certain pros, for instance, it's not required to stop the ssh service to do other things. 

- Do we want to enable this feature and also the script in charge of the installation? In other words, similar to the startup script but without the ssh stop/start. What do you think?

## Related issues

- Blocked by https://github.com/jenkinsci/google-compute-engine-plugin/issues/189