### PR TITLE
Block project ssh keys

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -51,6 +51,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
   private final WindowsConfiguration windowsConfig;
   private final boolean createSnapshot;
   private final boolean oneShot;
+  private final boolean blockProjectSSHKeys;
   private final boolean ignoreProxy;
   private final String javaExecPath;
   private final GoogleKeyPair sshKeyPair;
@@ -70,6 +71,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
       @Nullable WindowsConfiguration windowsConfig,
       boolean createSnapshot,
       boolean oneShot,
+      boolean blockProjectSSHKeys,
       boolean ignoreProxy,
       int numExecutors,
       Mode mode,
@@ -99,6 +101,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
     this.windowsConfig = windowsConfig;
     this.createSnapshot = createSnapshot;
     this.oneShot = oneShot;
+    this.blockProjectSSHKeys = blockProjectSSHKeys;
     this.ignoreProxy = ignoreProxy;
     this.javaExecPath = javaExecPath;
     this.sshKeyPair = sshKeyPair;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -87,6 +87,7 @@ import org.kohsuke.stapler.QueryParameter;
 @Log
 public class InstanceConfiguration implements Describable<InstanceConfiguration> {
   public static final String GUEST_ATTRIBUTES_METADATA_KEY = "enable-guest-attributes";
+  public static final String BLOCK_PROJECT_SSH_KEYS_METADATA_KEY = "block-project-ssh-keys";
   public static final String SSH_METADATA_KEY = "ssh-keys";
   public static final Long DEFAULT_BOOT_DISK_SIZE_GB = 10L;
   public static final Integer DEFAULT_NUM_EXECUTORS = 1;
@@ -143,6 +144,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   private String bootDiskSizeGbStr;
   private boolean oneShot;
   private String template;
+  private boolean blockProjectSSHKeys;
   // Optional not possible due to serialization requirement
   @Nullable private WindowsConfiguration windowsConfiguration;
   private boolean createSnapshot;
@@ -228,6 +230,11 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   @DataBoundSetter
   public void setCreateSnapshot(boolean createSnapshot) {
     this.createSnapshot = createSnapshot && this.oneShot;
+  }
+
+  @DataBoundSetter
+  public void setBlockProjectSSHKeys(boolean blockProjectSSHKeys) {
+    this.blockProjectSSHKeys = blockProjectSSHKeys;
   }
 
   public static Integer intOrDefault(String toParse, Integer defaultTo) {
@@ -342,6 +349,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
           .launchTimeout(getLaunchTimeoutMillis())
           .javaExecPath(javaExecPath)
           .sshKeyPair(sshKeyPair)
+          .blockProjectSSHKeys(blockProjectSSHKeys)
           .build();
     } catch (Descriptor.FormException fe) {
       log.log(Level.WARNING, "Error provisioning instance: " + fe.getMessage(), fe);
@@ -429,7 +437,8 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     metadata.setItems(new ArrayList<>());
     metadata
         .getItems()
-        .add(new Metadata.Items().setKey(GUEST_ATTRIBUTES_METADATA_KEY).setValue("TRUE"));
+        .add(new Metadata.Items().setKey(GUEST_ATTRIBUTES_METADATA_KEY).setValue("TRUE"))
+        .add(new Metadata.Items().setKey(BLOCK_PROJECT_SSH_KEYS_METADATA_KEY).setValue(blockProjectSSHKeys));
     return metadata;
   }
 
@@ -975,6 +984,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       instanceConfiguration.setRemoteFs(this.remoteFs);
       instanceConfiguration.setJavaExecPath(this.javaExecPath);
       instanceConfiguration.setCloud(this.cloud);
+      instanceConfiguration.setBlockProjectSSHKeys(this.blockProjectSSHKeys);
       if (googleLabels != null) {
         instanceConfiguration.appendLabels(this.googleLabels);
       }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -437,8 +437,13 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     metadata.setItems(new ArrayList<>());
     metadata
         .getItems()
-        .add(new Metadata.Items().setKey(GUEST_ATTRIBUTES_METADATA_KEY).setValue("TRUE"))
-        .add(new Metadata.Items().setKey(BLOCK_PROJECT_SSH_KEYS_METADATA_KEY).setValue(blockProjectSSHKeys));
+        .add(new Metadata.Items().setKey(GUEST_ATTRIBUTES_METADATA_KEY).setValue("TRUE"));
+    metadata
+        .getItems()
+        .add(
+            new Metadata.Items()
+                .setKey(BLOCK_PROJECT_SSH_KEYS_METADATA_KEY)
+                .setValue(String.valueOf(blockProjectSSHKeys)));
     return metadata;
   }
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -261,6 +261,15 @@ public class InstanceConfigurationTest {
     assertTrue(guestAttributes.isPresent());
     assertEquals(guestAttributes.get(), "TRUE");
 
+    Optional<String> blockProjectSSHKeys =
+        instance.getMetadata().getItems().stream()
+            .filter(
+                item -> item.getKey().equals(InstanceConfiguration.BLOCK_PROJECT_SSH_KEYS_METADATA_KEY))
+            .map(item -> item.getValue())
+            .findFirst();
+    assertTrue(blockProjectSSHKeys.isPresent());
+    assertEquals(blockProjectSSHKeys.get(), "FALSE");
+
     // Network
     assertEquals(SUBNETWORK_NAME, instance.getNetworkInterfaces().get(0).getSubnetwork());
     assertEquals(

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -264,11 +264,12 @@ public class InstanceConfigurationTest {
     Optional<String> blockProjectSSHKeys =
         instance.getMetadata().getItems().stream()
             .filter(
-                item -> item.getKey().equals(InstanceConfiguration.BLOCK_PROJECT_SSH_KEYS_METADATA_KEY))
+                item ->
+                    item.getKey().equals(InstanceConfiguration.BLOCK_PROJECT_SSH_KEYS_METADATA_KEY))
             .map(item -> item.getValue())
             .findFirst();
     assertTrue(blockProjectSSHKeys.isPresent());
-    assertEquals(blockProjectSSHKeys.get(), "FALSE");
+    assertEquals("false", blockProjectSSHKeys.get());
 
     // Network
     assertEquals(SUBNETWORK_NAME, instance.getNetworkInterfaces().get(0).getSubnetwork());

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -83,6 +83,7 @@ public class ComputeEngineCloudWorkerCreatedIT {
             .numExecutorsStr(NUM_EXECUTORS)
             .labels(LABEL)
             .oneShot(false)
+            .blockProjectSSHKeys(true)
             .createSnapshot(false)
             .template(NULL_TEMPLATE)
             .googleLabels(label)
@@ -144,7 +145,7 @@ public class ComputeEngineCloudWorkerCreatedIT {
   }
 
   @Test
-  public void testBlockProjectSSHKeysDisabled() {
+  public void testBlockProjectSSHKeysEnabled() {
     Optional<String> blockProjectSSHKeys =
         instance.getMetadata().getItems().stream()
             .filter(
@@ -153,6 +154,6 @@ public class ComputeEngineCloudWorkerCreatedIT {
             .map(item -> item.getValue())
             .findFirst();
     assertTrue(blockProjectSSHKeys.isPresent());
-    assertEquals(blockProjectSSHKeys.get(), "FALSE");
+    assertEquals("true", blockProjectSSHKeys.get());
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -142,4 +142,16 @@ public class ComputeEngineCloudWorkerCreatedIT {
     assertTrue(guestAttributes.isPresent());
     assertEquals(guestAttributes.get(), "TRUE");
   }
+
+  @Test
+  public void testBlockProjectSSHKeysDisabled() {
+    Optional<String> blockProjectSSHKeys =
+        instance.getMetadata().getItems().stream()
+            .filter(
+                item -> item.getKey().equals(InstanceConfiguration.BLOCK_PROJECT_SSH_KEYS_METADATA_KEY))
+            .map(item -> item.getValue())
+            .findFirst();
+    assertTrue(blockProjectSSHKeys.isPresent());
+    assertEquals(blockProjectSSHKeys.get(), "FALSE");
+  }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -148,7 +148,8 @@ public class ComputeEngineCloudWorkerCreatedIT {
     Optional<String> blockProjectSSHKeys =
         instance.getMetadata().getItems().stream()
             .filter(
-                item -> item.getKey().equals(InstanceConfiguration.BLOCK_PROJECT_SSH_KEYS_METADATA_KEY))
+                item ->
+                    item.getKey().equals(InstanceConfiguration.BLOCK_PROJECT_SSH_KEYS_METADATA_KEY))
             .map(item -> item.getValue())
             .findFirst();
     assertTrue(blockProjectSSHKeys.isPresent());

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
@@ -18,6 +18,7 @@ jenkins:
             remoteFs:           agent
             javaExecPath:       "java"
             oneShot:            true
+            blockProjectSSHKeys: false
             createSnapshot:     false
             region:             "https://www.googleapis.com/compute/v1/projects/gce-jenkins/regions/europe-west1"
             zone:               "https://www.googleapis.com/compute/v1/projects/gce-jenkins/zones/europe-west1-a"


### PR DESCRIPTION
This is my take at implementing the fix for issue #196 
My goal being to provide a basis for a quick resolution of this issue, I included some basic unit test.
I based the code on the 'oneShot' and 'guest-attributes' features already supported by the InstanceConfiguration class.
The primitive boolean type defaulting to 'false', the parameter is optional and false by default.