### PR TITLE
Add div layout migration support

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineComputer/configure.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineComputer/configure.jelly
@@ -13,11 +13,11 @@
 -->
 <!--We want to override the form in configuring the node-->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:g="/lib/googlecomputeengine">
     <l:layout norefresh="true" permission="${app.ADMINISTER}" title="${it.name} Configuration">
         <st:include page="sidepanel.jelly"/>
         <l:main-panel>
-            <table width="100%">
+            <g:blockWrapper>
 
                 <!--These variables need to be set since we are reconfiguring rather than a newly added instance-->
                 <j:set var="instance" value="${it.node}" />
@@ -53,7 +53,7 @@
                     </f:entry>
                 </f:section>
 
-            </table>
+            </g:blockWrapper>
         </l:main-panel>
     </l:layout>
 </j:jelly>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -13,8 +13,8 @@
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
-         xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-    <table width="100%">
+         xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:g="/lib/googlecomputeengine">
+    <g:blockWrapper>
         <f:section title="General">
             <f:entry title="${%Name Prefix}" field="namePrefix">
                 <f:textbox/>
@@ -143,5 +143,5 @@
             </div>
         </f:entry>
 
-    </table>
+    </g:blockWrapper>
 </j:jelly>

--- a/src/main/resources/lib/googlecomputeengine/blockWrapper.jelly
+++ b/src/main/resources/lib/googlecomputeengine/blockWrapper.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define">
+  <!-- TODO remove and switch to div after baseline is 2.264 or newer -->
+  <j:choose>
+    <j:when test="${divBasedFormLayout}">
+      <div>
+        <d:invokeBody/>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <table width="100%">
+        <d:invokeBody/>
+      </table>
+    </j:otherwise>
+  </j:choose>
+</j:jelly>


### PR DESCRIPTION
This is to make sure the plugin is compatible with the migration from tables to divs that happened in Jenkins 2.264.