### PR TITLE
Stop bundling an unused copy of Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,10 +120,6 @@
       <artifactId>credentials</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.j2objc</groupId>
       <artifactId>j2objc-annotations</artifactId>
       <version>${google.j2objc.version}</version>


### PR DESCRIPTION
#220 by @alecharp reset the bundled Guava to that included in Jenkins core—11—but this is just misleading as the plugin did not specify `maskClasses` nor `pluginFirstClassLoader` to begin with, so it was already using the copy from core.

https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#pluginfirstclassloader-and-its-discontents
