### PR TITLE
throw an error when the provisioning a node failed

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -271,6 +271,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
       }
     } catch (IOException ioe) {
       log.log(Level.WARNING, "Error provisioning node", ioe);
+      throw ioe;
     } catch (NoConfigurationException nce) {
       log.log(
           Level.WARNING,


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

### What

Honour the [onFailure](https://github.com/jenkinsci/jenkins/blob/677fbb2a81fa8e9a0bc37ad5eca56565612e1f2e/core/src/main/java/hudson/slaves/CloudProvisioningListener.java#L110-L132) method in the `CloudProvisioningListener`.

### Why

Otherwise the extensions cannot benefit from the above interface and for instance create some monitoring to report when there are errors in the cloud providers.

### Issues

Closes https://github.com/jenkinsci/google-compute-engine-plugin/issues/260
