### PR TITLE
Add an option to wait for custom startup script to finish before launching the agent

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -247,27 +247,15 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
     }
   }
 
-  private boolean testCommand(
+  boolean testCommand(
       ComputeEngineComputer computer,
       Connection conn,
       String checkCommand,
       PrintStream logger,
       TaskListener listener)
       throws IOException, InterruptedException {
-    return testCommand(computer, conn, checkCommand, logger, listener, new int[] {0});
-  }
-
-  boolean testCommand(
-      ComputeEngineComputer computer,
-      Connection conn,
-      String checkCommand,
-      PrintStream logger,
-      TaskListener listener,
-      int[] successfulExitCodes)
-      throws IOException, InterruptedException {
     logInfo(computer, listener, "Verifying: " + checkCommand);
-    int cmdExitCode = conn.exec(checkCommand, logger);
-    return IntStream.of(successfulExitCodes).anyMatch(code -> code == cmdExitCode);
+    return conn.exec(checkCommand, logger) == 0;
   }
 
   protected abstract Optional<Connection> setupConnection(

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -41,6 +41,7 @@ import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -295,8 +296,11 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
     final long startTime = System.currentTimeMillis();
 
     // How much timeout is left after waiting for instance creation
+    // Instant's can't parse timestamps with offsets until Java 12.
     final long timeout =
-        Instant.parse(computer.getInstance().getCreationTimestamp()).toEpochMilli()
+        DateTimeFormatter.ISO_OFFSET_DATE_TIME
+                .parse(computer.getInstance().getCreationTimestamp(), Instant::from)
+                .toEpochMilli()
             + node.getLaunchTimeoutMillis()
             - startTime;
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -48,10 +48,9 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import java.util.stream.IntStream;
+import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import lombok.Getter;
-
-import javax.annotation.Nonnull;
 
 public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
   private static final Logger LOGGER =
@@ -270,11 +269,9 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
 
   protected abstract String getPathSeparator();
 
-  /**
-   * Checks if a custom startup script provided by the instance metadata has exited.
-   */
+  /** Checks if a custom startup script provided by the instance metadata has exited. */
   protected abstract boolean checkStartupScriptFinished(
-          ComputeEngineComputer computer, Connection conn, PrintStream logger, TaskListener listener);
+      ComputeEngineComputer computer, Connection conn, PrintStream logger, TaskListener listener);
 
   /** Waits until user-provided startup script has exited. */
   protected void waitForStartupScriptComplete(

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -68,14 +68,20 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
   private final String zone;
   private final String cloudName;
   @Getter protected final boolean useInternalAddress;
+  @Getter protected final boolean waitForStartupScript;
 
   public ComputeEngineComputerLauncher(
-      String cloudName, String insertOperationId, String zone, boolean useInternalAddress) {
+      String cloudName,
+      String insertOperationId,
+      String zone,
+      boolean useInternalAddress,
+      boolean waitForStartupScript) {
     super();
     this.cloudName = cloudName;
     this.insertOperationId = insertOperationId;
     this.zone = zone;
     this.useInternalAddress = useInternalAddress;
+    this.waitForStartupScript = waitForStartupScript;
   }
 
   public static void log(Logger logger, Level level, TaskListener listener, String message) {
@@ -281,6 +287,11 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
       @Nonnull PrintStream logger,
       @Nonnull TaskListener listener)
       throws Exception {
+    // If it shouldn't wait for the startup script, just return
+    if (!this.isWaitForStartupScript()) {
+      return;
+    }
+
     final long startTime = System.currentTimeMillis();
 
     // How much timeout is left after waiting for instance creation

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -366,6 +366,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
         return;
       }
       conn = cleanupConn.get();
+      waitForStartupScriptComplete(computer, node, conn, logger, listener);
       String javaExecPath = node.getJavaExecPathOrDefault();
       if (!checkJavaInstalled(computer, conn, logger, listener, javaExecPath)) {
         return;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -48,7 +48,6 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
-import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import lombok.Getter;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -46,6 +46,8 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
+import java.util.stream.IntStream;
+
 import jenkins.model.Jenkins;
 import lombok.Getter;
 
@@ -238,14 +240,26 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
   }
 
   private boolean testCommand(
+          ComputeEngineComputer computer,
+          Connection conn,
+          String checkCommand,
+          PrintStream logger,
+          TaskListener listener)
+          throws IOException, InterruptedException {
+    return testCommand(computer, conn, checkCommand, logger, listener, new int[]{0});
+  }
+
+  boolean testCommand(
       ComputeEngineComputer computer,
       Connection conn,
       String checkCommand,
       PrintStream logger,
-      TaskListener listener)
+      TaskListener listener,
+      int[] successfulExitCodes)
       throws IOException, InterruptedException {
     logInfo(computer, listener, "Verifying: " + checkCommand);
-    return conn.exec(checkCommand, logger) == 0;
+    int cmdExitCode = conn.exec(checkCommand, logger);
+    return IntStream.of(successfulExitCodes).anyMatch(code -> code == cmdExitCode);
   }
 
   protected abstract Optional<Connection> setupConnection(

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -133,14 +133,12 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
       if (!testCommand(
           computer,
           conn,
-          "systemctl is-active --quiet google-startup-scripts",
+          // default value will be 0 until it finishes
+          "exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d \"=\" -f 2)",
+          // not "initializing" or "starting" - benefit is doesn't require google-startup-scripts
+          // "[ \"$(systemctl is-system-running)\" != \"starting\" ]",
           logger,
-          listener,
-          // 0 = unit active
-          // 4 = unit doesn't exist
-          // https://www.freedesktop.org/software/systemd/man/systemctl.html#Exit%20status
-          // We should accept both as they are neither failed or in progress.
-          new int[] {0, 4})) {
+          listener)) {
         return true;
       }
     } catch (IOException | InterruptedException ex) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -135,8 +135,6 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
           conn,
           // default value will be 0 until it finishes
           "exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d \"=\" -f 2)",
-          // not "initializing" or "starting" - benefit is doesn't require google-startup-scripts
-          // "[ \"$(systemctl is-system-running)\" != \"starting\" ]",
           logger,
           listener)) {
         return true;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -117,38 +117,22 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
     return Optional.of(bootstrapConn);
   }
 
-  /**
-   * Checks if a custom startup script provided by the instance metadata has exited.
-   *
-   * Method 1:
-   * $ systemctl is-active --quiet google-startup-scripts
-   * $ echo $?
-   * 3
-   * $ systemctl is-active google-startup-scripts
-   * inactive
-   *
-   * Method 2:
-   * $ systemctl show -p ActiveState --value google-startup-scripts
-   * inactive
-   */
-  private boolean checkStartupComplete(
-          ComputeEngineComputer computer,
-          Connection conn,
-          PrintStream logger,
-          TaskListener listener) {
+  @Override
+  protected boolean checkStartupScriptFinished(
+      ComputeEngineComputer computer, Connection conn, PrintStream logger, TaskListener listener) {
     try {
       // A successful command indicates service is still running
       if (!testCommand(
-              computer,
-              conn,
-              "systemctl is-active --quiet google-startup-scripts",
-              logger,
-              listener,
-              // 0 = unit active
-              // 4 = unit doesn't exist
-              // https://www.freedesktop.org/software/systemd/man/systemctl.html#Exit%20status
-              // We should accept both as they are neither failed or in progress.
-              new int[]{0, 4})) {
+          computer,
+          conn,
+          "systemctl is-active --quiet google-startup-scripts",
+          logger,
+          listener,
+          // 0 = unit active
+          // 4 = unit doesn't exist
+          // https://www.freedesktop.org/software/systemd/man/systemctl.html#Exit%20status
+          // We should accept both as they are neither failed or in progress.
+          new int[] {0, 4})) {
         return true;
       }
     } catch (IOException | InterruptedException ex) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -35,8 +35,16 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
   private static int bootstrapAuthSleepMs = 15000;
 
   public ComputeEngineLinuxLauncher(
-      String cloudName, Operation insertOperation, boolean useInternalAddress) {
-    super(cloudName, insertOperation.getName(), insertOperation.getZone(), useInternalAddress);
+      String cloudName,
+      Operation insertOperation,
+      boolean useInternalAddress,
+      boolean waitForStartupScript) {
+    super(
+        cloudName,
+        insertOperation.getName(),
+        insertOperation.getZone(),
+        useInternalAddress,
+        waitForStartupScript);
   }
 
   protected Logger getLogger() {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -38,8 +38,16 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
   private static int bootstrapAuthSleepMs = 15000;
 
   public ComputeEngineWindowsLauncher(
-      String cloudName, Operation insertOperation, boolean useInternalAddress) {
-    super(cloudName, insertOperation.getName(), insertOperation.getZone(), useInternalAddress);
+      String cloudName,
+      Operation insertOperation,
+      boolean useInternalAddress,
+      boolean waitForStartupScript) {
+    super(
+        cloudName,
+        insertOperation.getName(),
+        insertOperation.getZone(),
+        useInternalAddress,
+        waitForStartupScript);
   }
 
   protected Logger getLogger() {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.trilead.ssh2.Connection;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -126,6 +127,13 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
       return Optional.empty();
     }
     return Optional.ofNullable(bootstrapConn);
+  }
+
+  @Override
+  protected boolean checkStartupScriptFinished(
+      ComputeEngineComputer computer, Connection conn, PrintStream logger, TaskListener listener) {
+    // Not implemented
+    return true;
   }
 
   @Override

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -124,6 +124,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   private String machineType;
   private String numExecutorsStr;
   private String startupScript;
+  private boolean waitForStartupScript;
   private boolean preemptible;
   private String minCpuPlatform;
   private String labels;
@@ -313,14 +314,20 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       if (this.windowsConfiguration != null) {
         launcher =
             new ComputeEngineWindowsLauncher(
-                cloud.getCloudName(), operation, this.useInternalAddress);
+                cloud.getCloudName(),
+                operation,
+                this.useInternalAddress,
+                this.waitForStartupScript);
         if (Strings.isNullOrEmpty(targetRemoteFs)) {
           targetRemoteFs = "C:\\";
         }
       } else {
         launcher =
             new ComputeEngineLinuxLauncher(
-                cloud.getCloudName(), operation, this.useInternalAddress);
+                cloud.getCloudName(),
+                operation,
+                this.useInternalAddress,
+                this.waitForStartupScript);
         if (Strings.isNullOrEmpty(targetRemoteFs)) {
           targetRemoteFs = "/tmp";
         }
@@ -983,6 +990,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       instanceConfiguration.setMachineType(this.machineType);
       instanceConfiguration.setNumExecutorsStr(this.numExecutorsStr);
       instanceConfiguration.setStartupScript(this.startupScript);
+      instanceConfiguration.setWaitForStartupScript(this.waitForStartupScript);
       instanceConfiguration.setPreemptible(this.preemptible);
       instanceConfiguration.setMinCpuPlatform(this.minCpuPlatform);
       instanceConfiguration.setLabelString(this.labels);

--- a/src/main/java/com/google/jenkins/plugins/computeengine/LaunchTimeoutException.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/LaunchTimeoutException.java
@@ -1,0 +1,8 @@
+package com.google.jenkins.plugins.computeengine;
+
+/** Instance did not launch before the specified timeout. */
+public class LaunchTimeoutException extends Exception {
+  public LaunchTimeoutException(String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -98,6 +98,9 @@
                 <f:entry field="startupScript" title="${%Startup script}">
                     <f:textarea/>
                 </f:entry>
+                <f:entry field="waitForStartupScript" title="${%Wait for startup script to finish?}">
+                    <f:checkbox/>
+                </f:entry>
                 <f:optionalProperty field="acceleratorConfiguration" title="GPUs">
                     <st:include page="config.jelly" class="${descriptor.clazz}"/>
                 </f:optionalProperty>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -212,7 +212,7 @@ public class InstanceConfigurationTest {
     r.assertEqualBeans(
         want,
         got,
-        "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,acceleratorConfiguration,networkConfiguration,externalAddress,networkTags,serviceAccountEmail");
+        "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,acceleratorConfiguration,networkConfiguration,externalAddress,networkTags,serviceAccountEmail,waitForStartupScript");
   }
 
   @Test
@@ -290,6 +290,7 @@ public class InstanceConfigurationTest {
     assertFalse(instanceConfiguration.isUseInternalAddress());
     assertNull(instanceConfiguration.instance().getMinCpuPlatform());
     assertNull(instanceConfiguration.getWindowsConfiguration());
+    assertFalse(instanceConfiguration.isWaitForStartupScript());
   }
 
   @Test
@@ -339,7 +340,8 @@ public class InstanceConfigurationTest {
         .acceleratorConfiguration(new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
         .runAsUser(RUN_AS_USER)
         .oneShot(false)
-        .template(null);
+        .template(null)
+        .waitForStartupScript(false);
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWaitForStartupScriptIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWaitForStartupScriptIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine.integration;
+
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfigurationBuilder;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.windows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+
+import com.google.api.services.compute.model.Instance;
+import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
+import com.google.common.collect.ImmutableList;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Integration test suite for {@link ComputeEngineCloudWaitForStartupScriptIT}. Verifies that
+ * instances wait for their startup script to finish before launching the agent.
+ */
+public class ComputeEngineCloudWaitForStartupScriptIT {
+  /**
+   * We can check that the launcher waited to launch the agent if we move java, wait, and then move
+   * it back. If the agent tries to launch, it should fail unless it waits.
+   */
+  private static final String SLOW_STARTUP_SCRIPT =
+      "#!/bin/bash\n"
+          + "ORIGINAL_JAVA_PATH=$(which java)\n"
+          + "sudo mv $ORIGINAL_JAVA_PATH $ORIGINAL_JAVA_PATH.hidden\n"
+          + "sleep 30\n"
+          + "sudo mv $ORIGINAL_JAVA_PATH.hidden $ORIGINAL_JAVA_PATH";
+
+  private static final Logger log =
+      Logger.getLogger(ComputeEngineCloudWaitForStartupScriptIT.class.getName());
+
+  @ClassRule
+  public static Timeout timeout = new Timeout(5L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
+  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+
+  private static ComputeClient client;
+  private static final Map<String, String> label =
+      getLabel(ComputeEngineCloudWaitForStartupScriptIT.class);
+  private static Collection<PlannedNode> planned;
+  private static Instance instance;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    assumeFalse(windows);
+    log.info("init");
+    initCredentials(jenkinsRule);
+    ComputeEngineCloud cloud = initCloud(jenkinsRule);
+    client = initClient(jenkinsRule, label, log);
+
+    InstanceConfiguration instanceConfiguration =
+        instanceConfigurationBuilder()
+            .startupScript(SLOW_STARTUP_SCRIPT)
+            .numExecutorsStr(NUM_EXECUTORS)
+            .labels(LABEL)
+            .oneShot(false)
+            .createSnapshot(false)
+            .template(NULL_TEMPLATE)
+            .googleLabels(label)
+            .waitForStartupScript(true)
+            .build();
+
+    cloud.setConfigurations(ImmutableList.of(instanceConfiguration));
+    planned = cloud.provision(new LabelAtom(LABEL), 1);
+    planned.iterator().next().future.get();
+    instance =
+        cloud.getClient().getInstance(PROJECT_ID, ZONE, planned.iterator().next().displayName);
+  }
+
+  @AfterClass
+  public static void teardown() throws IOException {
+    teardownResources(client, label, log);
+  }
+
+  @Test
+  public void testWorkerCreatedOnePlannedNode() {
+    assertEquals(1, planned.size());
+  }
+
+  @Test
+  public void testInstanceStatusRunning() {
+    assertEquals("RUNNING", instance.getStatus());
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -349,7 +349,8 @@ class ITUtil {
         .acceleratorConfiguration(new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
         .runAsUser(RUN_AS_USER)
         .startupScript(STARTUP_SCRIPT)
-        .javaExecPath("java -Dhudson.remoting.Launcher.pingIntervalSec=-1");
+        .javaExecPath("java -Dhudson.remoting.Launcher.pingIntervalSec=-1")
+        .waitForStartupScript(false);
   }
 
   /*

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
@@ -26,6 +26,7 @@ jenkins:
             preemptible:        false
             minCpuPlatform:     '' # tried not setting, added when 'saved' in UI
             startupScript:      '' # tried not setting, added when 'saved' in UI
+            waitForStartupScript: false
             networkConfiguration:
               sharedVpc:
                 projectId:      gce-jenkins-cloud-123456

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
@@ -25,6 +25,7 @@ jenkins:
             preemptible:        false
             minCpuPlatform:     '' # tried not setting, added when 'saved' in UI
             startupScript:      "#!/bin/bash\n/etc/init.d/ssh stop\necho \"deb http://http.debian.net/debian stretch-backports main\" | \\\n      sudo tee --append /etc/apt/sources.list > /dev/null\napt-get -y update\napt-get -y install -t stretch-backports openjdk-8-jdk\nupdate-java-alternatives -s java-1.8.0-openjdk-amd64\n/etc/init.d/ssh start" 
+            waitForStartupScript: true
             networkConfiguration:
               autofilled:
                 network:        default 


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/google-compute-engine-plugin/issues/338

Adds a new option to the instance configuration that enables waiting to launch the agent until `google-startup-scripts` has finished running.

<img width="353" alt="image" src="https://user-images.githubusercontent.com/16676170/179688676-08e37940-d43c-45bc-a7a8-a8786187c2e3.png">

<details>
<summary>Agent log - launcher checks startup status and it's already done</summary>
<pre>
Jul 19, 2022 9:48:14 PM null
FINEST: Instance vl843h is running and ready...
Jul 19, 2022 9:48:14 PM null
INFO: Launching instance: vl843h
Jul 19, 2022 9:48:14 PM null
INFO: bootstrap
Jul 19, 2022 9:48:14 PM null
INFO: Getting keypair...
Jul 19, 2022 9:48:14 PM null
INFO: Using autogenerated keypair
Jul 19, 2022 9:48:14 PM null
INFO: Authenticating as jenkins
Jul 19, 2022 9:48:14 PM null
INFO: Connecting to 10.240.0.130 on port 22, with timeout 10000.
Jul 19, 2022 9:48:24 PM null
INFO: Failed to connect via ssh: The kexTimeout (10000 ms) expired.
Jul 19, 2022 9:48:24 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 9:48:29 PM null
INFO: Connecting to 10.240.0.130 on port 22, with timeout 10000.
Jul 19, 2022 9:48:37 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.0.130:22
Jul 19, 2022 9:48:37 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 9:48:42 PM null
INFO: Connecting to 10.240.0.130 on port 22, with timeout 10000.
Jul 19, 2022 9:48:42 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.0.130:22
Jul 19, 2022 9:48:42 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 9:48:47 PM null
INFO: Connecting to 10.240.0.130 on port 22, with timeout 10000.
Jul 19, 2022 9:48:47 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.0.130:22
Jul 19, 2022 9:48:47 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 9:48:52 PM null
INFO: Connecting to 10.240.0.130 on port 22, with timeout 10000.
Jul 19, 2022 9:48:52 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.0.130:22
Jul 19, 2022 9:48:52 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 9:48:57 PM null
INFO: Connecting to 10.240.0.130 on port 22, with timeout 10000.
Jul 19, 2022 9:48:57 PM null
INFO: Connected via SSH.
Jul 19, 2022 9:48:57 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 9:48:58 PM null
INFO: Configured startup script is finished.
Jul 19, 2022 9:48:58 PM null
INFO: Verifying: /usr/lib/jvm/java-11-openjdk-amd64/bin/java -fullversion
openjdk full version "11.0.7+10-post-Ubuntu-2ubuntu218.04"
Jul 19, 2022 9:48:58 PM null
INFO: Copying agent.jar to: /var/lib/jenkins/workspace
Jul 19, 2022 9:48:58 PM null
INFO: Launching Jenkins agent via plugin SSH: /usr/lib/jvm/java-11-openjdk-amd64/bin/java -jar /var/lib/jenkins/workspace/agent.jar
<===[JENKINS REMOTING CAPACITY]===>Remoting version: 4.10.1
This is a Unix agent
Evacuated stdout
Agent successfully connected and online
</pre>
</details>

<details>
<summary>Agent log - launcher checks startup status and it's sleeping for 60s</summary>
<pre>
Jul 19, 2022 10:46:51 PM null
FINEST: Instance 3pi9fj is running and ready...
Jul 19, 2022 10:46:51 PM null
INFO: Launching instance: 3pi9fj
Jul 19, 2022 10:46:51 PM null
INFO: bootstrap
Jul 19, 2022 10:46:51 PM null
INFO: Getting keypair...
Jul 19, 2022 10:46:51 PM null
INFO: Using autogenerated keypair
Jul 19, 2022 10:46:51 PM null
INFO: Authenticating as jenkins
Jul 19, 2022 10:46:51 PM null
INFO: Connecting to 10.240.1.147 on port 22, with timeout 10000.
Jul 19, 2022 10:47:01 PM null
INFO: Failed to connect via ssh: The kexTimeout (10000 ms) expired.
Jul 19, 2022 10:47:01 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:47:06 PM null
INFO: Connecting to 10.240.1.147 on port 22, with timeout 10000.
Jul 19, 2022 10:47:07 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.1.147:22
Jul 19, 2022 10:47:07 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:47:12 PM null
INFO: Connecting to 10.240.1.147 on port 22, with timeout 10000.
Jul 19, 2022 10:47:12 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.1.147:22
Jul 19, 2022 10:47:12 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:47:17 PM null
INFO: Connecting to 10.240.1.147 on port 22, with timeout 10000.
Jul 19, 2022 10:47:17 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.1.147:22
Jul 19, 2022 10:47:17 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:47:22 PM null
INFO: Connecting to 10.240.1.147 on port 22, with timeout 10000.
Jul 19, 2022 10:47:22 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.1.147:22
Jul 19, 2022 10:47:22 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:47:27 PM null
INFO: Connecting to 10.240.1.147 on port 22, with timeout 10000.
Jul 19, 2022 10:47:28 PM null
INFO: Connected via SSH.
Jul 19, 2022 10:47:28 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:47:28 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:47:28 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:47:33 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:47:33 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:47:33 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:47:38 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:47:38 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:47:38 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:47:43 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:47:43 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:47:43 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:47:48 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:47:48 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:47:48 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:47:53 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:47:53 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:47:53 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:47:58 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:47:58 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:47:58 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:03 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:03 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:48:03 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:08 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:08 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:48:08 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:13 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:13 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:48:13 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:18 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:18 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:48:18 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:23 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:23 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:48:23 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:28 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:28 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:48:28 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:33 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:33 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:48:33 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:38 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:38 PM null
WARNING: google-startup-scripts has not finished
Jul 19, 2022 10:48:38 PM null
INFO: Waiting for the startup script to finish. Sleeping 5.
Jul 19, 2022 10:48:43 PM null
INFO: Verifying: exit $(systemctl show google-startup-scripts --property ExecMainExitTimestampMonotonic | cut -d "=" -f 2)
Jul 19, 2022 10:48:43 PM null
INFO: Configured startup script is finished.
Jul 19, 2022 10:48:43 PM null
INFO: Verifying: /usr/lib/jvm/java-11-openjdk-amd64/bin/java -fullversion
openjdk full version "11.0.7+10-post-Ubuntu-2ubuntu218.04"
Jul 19, 2022 10:48:43 PM null
INFO: Copying agent.jar to: /var/lib/jenkins/workspace
Jul 19, 2022 10:48:43 PM null
INFO: Launching Jenkins agent via plugin SSH: /usr/lib/jvm/java-11-openjdk-amd64/bin/java -jar /var/lib/jenkins/workspace/agent.jar
<===[JENKINS REMOTING CAPACITY]===>Remoting version: 4.10.1
This is a Unix agent
Evacuated stdout
Agent successfully connected and online
</pre>
</details>

<details>
<summary>Agent log - option disabled and launcher does not check startup status</summary>
<pre>
Jul 19, 2022 10:54:22 PM null
FINEST: Instance o8pom3 is running and ready...
Jul 19, 2022 10:54:22 PM null
INFO: Launching instance: o8pom3
Jul 19, 2022 10:54:22 PM null
INFO: bootstrap
Jul 19, 2022 10:54:22 PM null
INFO: Getting keypair...
Jul 19, 2022 10:54:22 PM null
INFO: Using autogenerated keypair
Jul 19, 2022 10:54:22 PM null
INFO: Authenticating as jenkins
Jul 19, 2022 10:54:22 PM null
INFO: Connecting to 10.240.0.11 on port 22, with timeout 10000.
Jul 19, 2022 10:54:32 PM null
INFO: Failed to connect via ssh: The kexTimeout (10000 ms) expired.
Jul 19, 2022 10:54:32 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:54:37 PM null
INFO: Connecting to 10.240.0.11 on port 22, with timeout 10000.
Jul 19, 2022 10:54:38 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.0.11:22
Jul 19, 2022 10:54:38 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:54:43 PM null
INFO: Connecting to 10.240.0.11 on port 22, with timeout 10000.
Jul 19, 2022 10:54:43 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.0.11:22
Jul 19, 2022 10:54:43 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:54:48 PM null
INFO: Connecting to 10.240.0.11 on port 22, with timeout 10000.
Jul 19, 2022 10:54:48 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.0.11:22
Jul 19, 2022 10:54:48 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:54:53 PM null
INFO: Connecting to 10.240.0.11 on port 22, with timeout 10000.
Jul 19, 2022 10:54:54 PM null
INFO: Failed to connect via ssh: There was a problem while connecting to 10.240.0.11:22
Jul 19, 2022 10:54:54 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Jul 19, 2022 10:54:59 PM null
INFO: Connecting to 10.240.0.11 on port 22, with timeout 10000.
Jul 19, 2022 10:54:59 PM null
INFO: Connected via SSH.
Jul 19, 2022 10:54:59 PM null
INFO: Verifying: /usr/lib/jvm/java-11-openjdk-amd64/bin/java -fullversion
openjdk full version "11.0.7+10-post-Ubuntu-2ubuntu218.04"
Jul 19, 2022 10:54:59 PM null
INFO: Copying agent.jar to: /var/lib/jenkins/workspace
Jul 19, 2022 10:54:59 PM null
INFO: Launching Jenkins agent via plugin SSH: /usr/lib/jvm/java-11-openjdk-amd64/bin/java -jar /var/lib/jenkins/workspace/agent.jar
<===[JENKINS REMOTING CAPACITY]===>Remoting version: 4.10.1
This is a Unix agent
Evacuated stdout
Agent successfully connected and online
</pre>
</details>


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
