### PR TITLE
Unnecessary check for RunScript is removed

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -355,8 +355,6 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
 
   /** Initializes transient properties */
   protected Object readResolve() {
-    Jenkins.get().checkPermission(Jenkins.RUN_SCRIPTS);
-
     labelSet = Label.parse(labels);
     return this;
   }


### PR DESCRIPTION
Overall / Run Script is now deprecated and, in the case of `readResolve` method, looks unnecessary. It does label parsing, but there are no scripts involved in that.

This also causes NPE if authentication configuring the cloud is missing "Overall / Run Script". The parsing is not done, `labelSet` stays `null`. `labelSet` accessors do not guard against `null`, hence NPEs .

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
