### PR TITLE
Allow compute engine instances to be launched with Secure Boot enabled.

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -108,6 +108,7 @@ Instance configurations have many options that were not listed above. A few of t
 * GPUs - attach 1 or more GPUs to the instance. For more info, visit the GCE GPU docs.
 * Service Account E-mail - sets the service account that the instance will be able to
   access from metadata. For more info, review the service account documentation.
+* Enable Secure Boot - Enables the Shielded VM Secure Boot option which helps protect against boot-level and kernel-level malware and rootkits.
 
 
 # No delay provisioning

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -34,6 +34,7 @@ import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Region;
 import com.google.api.services.compute.model.Scheduling;
 import com.google.api.services.compute.model.ServiceAccount;
+import com.google.api.services.compute.model.ShieldedInstanceConfig;
 import com.google.api.services.compute.model.Tags;
 import com.google.api.services.compute.model.Zone;
 import com.google.cloud.graphite.platforms.plugin.client.ClientFactory;
@@ -155,6 +156,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
   private Integer launchTimeoutSeconds;
   private Long bootDiskSizeGb;
   private transient Set<LabelAtom> labelSet;
+  private boolean enableSecureBoot;
 
   @Getter(AccessLevel.PROTECTED)
   @Setter(AccessLevel.PROTECTED)
@@ -400,6 +402,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       instance.setGuestAccelerators(accelerators());
       instance.setNetworkInterfaces(networkInterfaces());
       instance.setServiceAccounts(serviceAccounts());
+      instance.setShieldedInstanceConfig(shieldedInstanceConfig());
 
       // optional
       if (notNullOrEmpty(minCpuPlatform)) {
@@ -530,6 +533,12 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     } else {
       return null;
     }
+  }
+
+  private ShieldedInstanceConfig shieldedInstanceConfig() {
+    ShieldedInstanceConfig shieldedInstanceConfig = new ShieldedInstanceConfig();
+    shieldedInstanceConfig.setEnableSecureBoot(enableSecureBoot);
+    return shieldedInstanceConfig;
   }
 
   @Extension
@@ -978,6 +987,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
       if (googleLabels != null) {
         instanceConfiguration.appendLabels(this.googleLabels);
       }
+      instanceConfiguration.setEnableSecureBoot(enableSecureBoot);
       return instanceConfiguration;
     }
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -134,6 +134,11 @@
                         <f:textbox/>
                     </f:entry>
                 </f:section>
+                <f:section title="Security">
+                    <f:entry field="enableSecureBoot" title="${%Enable Secure Boot}">
+                        <f:checkbox/>
+                    </f:entry>
+                </f:section>
             </f:advanced>
         </f:section>
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ConfigAsCodeTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ConfigAsCodeTest.java
@@ -54,9 +54,7 @@ public class ConfigAsCodeTest {
     assertEquals("Wrong configurations runAsUser", "jenkins", configuration.getRunAsUser());
     assertEquals("Wrong configurations remoteFs", "agent", configuration.getRemoteFs());
     assertEquals("Wrong configurations javaExecPath", "java", configuration.getJavaExecPath());
-    assertEquals(
-        "Wrong configurations enableSecureBoot", true, configuration.isEnableSecureBoot());
-
+    assertEquals("Wrong configurations enableSecureBoot", true, configuration.isEnableSecureBoot());
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ConfigAsCodeTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ConfigAsCodeTest.java
@@ -54,6 +54,9 @@ public class ConfigAsCodeTest {
     assertEquals("Wrong configurations runAsUser", "jenkins", configuration.getRunAsUser());
     assertEquals("Wrong configurations remoteFs", "agent", configuration.getRemoteFs());
     assertEquals("Wrong configurations javaExecPath", "java", configuration.getJavaExecPath());
+    assertEquals(
+        "Wrong configurations enableSecureBoot", true, configuration.isEnableSecureBoot());
+
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -212,7 +212,7 @@ public class InstanceConfigurationTest {
     r.assertEqualBeans(
         want,
         got,
-        "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,acceleratorConfiguration,networkConfiguration,externalAddress,networkTags,serviceAccountEmail");
+        "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,acceleratorConfiguration,networkConfiguration,externalAddress,networkTags,serviceAccountEmail,enableSecureBoot");
   }
 
   @Test
@@ -339,7 +339,8 @@ public class InstanceConfigurationTest {
         .acceleratorConfiguration(new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
         .runAsUser(RUN_AS_USER)
         .oneShot(false)
-        .template(null);
+        .template(null)
+        .enableSecureBoot(true);
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -129,6 +129,7 @@ class ITUtil {
       String.format("%s@%s.iam.gserviceaccount.com", System.getenv("GOOGLE_SA_NAME"), PROJECT_ID);
   private static final String RETENTION_TIME_MINUTES_STR = "";
   private static final String LAUNCH_TIMEOUT_SECONDS_STR = "";
+  private static final boolean ENABLE_SECURE_BOOT = true;
   static final int SNAPSHOT_TIMEOUT = windows ? 600 : 300;
   private static final GoogleKeyPair SSH_KEY = GoogleKeyPair.generate(RUN_AS_USER);
   static final String SSH_PRIVATE_KEY = SSH_KEY.getPrivateKey();
@@ -318,7 +319,8 @@ class ITUtil {
         .acceleratorConfiguration(new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
         .runAsUser(RUN_AS_USER)
         .startupScript(STARTUP_SCRIPT)
-        .javaExecPath("java -Dhudson.remoting.Launcher.pingIntervalSec=-1");
+        .javaExecPath("java -Dhudson.remoting.Launcher.pingIntervalSec=-1")
+        .enableSecureBoot(ENABLE_SECURE_BOOT);
   }
 
   /*

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
@@ -40,3 +40,4 @@ jenkins:
             bootDiskSizeGbStr:  50
             bootDiskAutoDelete: true
             serviceAccountEmail: 'jenkins-test@gce-jenkins-ops.iam.gserviceaccount.com'
+            enableSecureBoot: true

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
@@ -38,3 +38,4 @@ jenkins:
             bootDiskSizeGbStr:  10
             bootDiskAutoDelete: true
             serviceAccountEmail: "${env.GOOGLE_SA_NAME}@${env.GOOGLE_PROJECT_ID}.iam.gserviceaccount.com"
+            enableSecureBoot: true

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-non-standard-java-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-non-standard-java-it.yml
@@ -38,3 +38,4 @@ jenkins:
             bootDiskSizeGbStr:  10
             bootDiskAutoDelete: true
             serviceAccountEmail: "${env.GOOGLE_SA_NAME}@${env.GOOGLE_PROJECT_ID}.iam.gserviceaccount.com"
+            enableSecureBoot: true

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml
@@ -40,6 +40,7 @@ jenkins:
             bootDiskSizeGbStr:  50
             bootDiskAutoDelete: true
             serviceAccountEmail: "${env.GOOGLE_SA_NAME}@${env.GOOGLE_PROJECT_ID}.iam.gserviceaccount.com"
+            enableSecureBoot: true
 credentials:
   system:
     domainCredentials:


### PR DESCRIPTION
Added an option to allow the compute engine instances to be launched with secure boot enabled. The new boolean field enableSecureBoot can be set in the Jenkins UI or via CasC. This is a security feature that helps protect against boot-level and kernel-level malware and rootkits.

- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


