### PR TITLE
obtain commons-text dependency from the commons-text-api plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.346.x</artifactId>
-        <version>1556.vfc6a_f216e3c6</version>
+        <version>1643.v1cffef51df73</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -148,9 +148,8 @@
       <version>0.28.3</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-text-api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
Instead of just updating commons-text, I replaced it with the corresponding Jenkins plugin, which ships 1.10, provided by the BOM.

Downstream of https://github.com/jenkinsci/commons-text-api-plugin/pull/13#issuecomment-1278814319

It's probably worth to cut a release, to silence security scanners and reduce the amount of Jira issues.

cc @jenkinsci/google-compute-engine-plugin-developers 