### PR TITLE
Use `Cloud#getUrl` in /provision URL

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
@@ -17,7 +17,7 @@
         <tr>
             <td/>
             <td colspan="${monitors.size()+1}">
-                <f:form action="${rootURL}/cloud/${it.name}/provision" method="post" name="provision">
+                <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision">
                     <input type="submit" class="gce-provision-button" value="${%Provision via} ${it.displayName}"/>
                     <select name="configuration">
                         <j:forEach var="c" items="${it.configurations}">


### PR DESCRIPTION
Follow up of https://github.com/jenkinsci/jenkins/pull/7573.

This has no effect on older versions of Jenkins. On newer versions of Jenkins this prevents a bug that I've briefly described in the PR linked above.