### PR TITLE
Update hamcrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,12 +217,8 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>${hamcrest.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
_🤖 This is an automatic PR for replacing the deprecated 'hamcrest-*' modules with 'hamcrest'._

  All deprecated modules' code has been merged into 'hamcrest'.
  Consumers of `hamcrest-*` should replace the dependency with `hamcrest`, which is the drop-in module containing the code of the deprecated `hamcrest-*` modules.

  Ping `@NotMyFault` if you have questions.

  _[script source](https://github.com/NotMyFault/jenkins-version-updater)_