### PR TITLE
Revert "Update hamcrest"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,8 +217,12 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
+      <artifactId>hamcrest-library</artifactId>
       <version>${hamcrest.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Reverts jenkinsci/google-compute-engine-plugin#397

caused the plugin to bundle hamcrest for whatever reason.

may have previously been bundling other hamcrest libraries - but as I am not intending to investigage right now just reverting to maintain the prior status quo