### PR TITLE
Bump fmt-maven-plugin to 2.9 to improve build stability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <configuration>
           <sourceDirectory>src/main/java</sourceDirectory>
           <testSourceDirectory>src/test/java</testSourceDirectory>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

In our CI, the plugin fails to build from time to time, with the following error:
```
[ERROR] Failed to execute goal com.coveo:fmt-maven-plugin:2.8:format (default) on project google-compute-engine: Execution default of goal com.coveo:fmt-maven-plugin:2.8:format failed. ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0 -> [Help 1]
```

I tracked this down to https://github.com/spotify/fmt-maven-plugin/issues/42. The issue was fixed in https://github.com/spotify/fmt-maven-plugin/pull/52 and released in [2.9](https://github.com/spotify/fmt-maven-plugin/releases/tag/2.9.0), which is compatible with Java 8. (I see that bumping to 2.10 (#222, #384) and beyond was unsuccessful). I propose bumping to 2.9 to pick up this helpful fix until the plugin eventually advances to Java 11.

### Testing done

Builds locally, i.e. no regression. Only time will tell whether the flakiness is fully addressed as expected.

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
