### PR TITLE
Removed 1 unnecessary stubbing in AutofilledNetworkConfigurationTest.java

### DIFF
--- a/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/AutofilledNetworkConfigurationTest.java
@@ -94,7 +94,7 @@ public class AutofilledNetworkConfigurationTest {
 
   @Test
   public void testDoFillSubnetworkItemsEmptyRegion() throws IOException {
-    DescriptorImpl descriptor = subnetworkFillDescriptorSetup(ImmutableList.of(SUBNETWORK_NAME));
+    DescriptorImpl descriptor = subnetworkFillDescriptorSetup2(ImmutableList.of(SUBNETWORK_NAME));
     ListBoxModel got =
         descriptor.doFillSubnetworkItems(r.jenkins, "", "", PROJECT_ID, CREDENTIALS_ID);
     Assert.assertEquals(0, got.size());
@@ -157,6 +157,16 @@ public class AutofilledNetworkConfigurationTest {
     ComputeClient computeClient = Mockito.mock(ComputeClient.class);
     Mockito.when(computeClient.listSubnetworks(anyString(), anyString(), anyString()))
         .thenReturn(ImmutableList.copyOf(subnetworks));
+    DescriptorImpl.setComputeClient(computeClient);
+    return new DescriptorImpl();
+  }
+
+  private DescriptorImpl subnetworkFillDescriptorSetup2(List<String> subnetworkNames)
+      throws IOException {
+    List<Subnetwork> subnetworks = new ArrayList<>();
+    subnetworkNames.forEach(
+        subnet -> subnetworks.add(new Subnetwork().setName(subnet).setSelfLink(subnet)));
+    ComputeClient computeClient = Mockito.mock(ComputeClient.class);
     DescriptorImpl.setComputeClient(computeClient);
     return new DescriptorImpl();
   }


### PR DESCRIPTION

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

In our analysis of the project, we observed that:
1 unnecessary stubbing which stubbed `listSubnetworks` in `subnetworkFillDescriptorSetup` is created but is never executed by the test `AutofilledNetworkConfigurationTest.testDoFillSubnetworkItemsEmptyRegion`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.
