### PR TITLE
adapt tests to new google credential ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency> <!-- until it is back in the parent -->
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>google-oauth-plugin</artifactId>
+        <version>1.1.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -153,11 +158,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>commons-text-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.graphite</groupId>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -61,8 +61,9 @@ public class ComputeEngineCloudTest {
     serviceAccountConfig.setSecretJsonKey(bytes);
     assertNotNull(serviceAccountConfig.getAccountId());
     // Create a credential
-    Credentials c =
-        (Credentials) new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
+    GoogleRobotPrivateKeyCredentials c =
+        new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
+    String credentialsId = c.getId();
     CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
     store.addCredentials(Domain.global(), c);
 
@@ -71,7 +72,7 @@ public class ComputeEngineCloudTest {
     ics.add(instanceConfigurationBuilder().build());
     ics.add(instanceConfigurationBuilder().build());
     ComputeEngineCloud cloud =
-        new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
+        new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, credentialsId, INSTANCE_CAP_STR);
     cloud.setInstanceId(INSTANCE_ID);
     cloud.setConfigurations(ics);
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ConfigAsCodeTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ConfigAsCodeTest.java
@@ -4,25 +4,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
-import com.cloudbees.plugins.credentials.Credentials;
-import com.cloudbees.plugins.credentials.CredentialsStore;
-import com.cloudbees.plugins.credentials.SecretBytes;
-import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import com.cloudbees.plugins.credentials.domains.Domain;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials;
-import com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig;
 import hudson.model.Node;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import java.nio.charset.StandardCharsets;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ConfigAsCodeTest {
-
-  private static final byte[] PK_BYTES =
-      "{\"client_email\": \"example@example.com\"}".getBytes(StandardCharsets.UTF_8);
 
   @Rule public JenkinsRule jenkinsRule = new JenkinsConfiguredWithCodeRule();
 
@@ -64,16 +54,6 @@ public class ConfigAsCodeTest {
   @Test
   @ConfiguredWithCode("configuration-as-code.yml")
   public void shouldCreateGCEClientFromCode() throws Exception {
-    SecretBytes bytes = SecretBytes.fromBytes(PK_BYTES);
-    JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
-    serviceAccountConfig.setSecretJsonKey(bytes);
-    assertNotNull(serviceAccountConfig.getAccountId());
-    Credentials credentials =
-        new GoogleRobotPrivateKeyCredentials("gce-jenkins", serviceAccountConfig, null);
-
-    CredentialsStore store =
-        new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
-    store.addCredentials(Domain.global(), credentials);
 
     ComputeEngineCloud cloud =
         (ComputeEngineCloud) jenkinsRule.jenkins.clouds.getByName("gce-jenkins-build");

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
@@ -40,3 +40,14 @@ jenkins:
             bootDiskSizeGbStr:  50
             bootDiskAutoDelete: true
             serviceAccountEmail: 'jenkins-test@gce-jenkins-ops.iam.gserviceaccount.com'
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - googleRobotPrivateKeyCredentials:
+              id: gce-jenkins
+              projectId: gce-jenkins
+              serviceAccountConfig:
+                jsonServiceAccountConfig:
+                  # The encoded version of {"client_email": "example@example.com"}
+                  secretJsonKey: 'eyJjbGllbnRfZW1haWwiOiAiZXhhbXBsZUBleGFtcGxlLmNvbSJ9'


### PR DESCRIPTION
After https://github.com/jenkinsci/google-oauth-plugin/pull/186 , when we create a google credential, the ID is no longer the project id but a generated one. Editing tests to no longer rely on that assumption. For the CasC test, it is now entirely CasC-ified, with creating the credential through CasC as well (creating a credential on the UI, ignoring the output and applying a CasC file made before we knew it wasn't a very realistic scenario.)


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
