### PR TITLE
Adapt tests to updated version of google-oauth-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency> <!-- until it is back in the parent -->
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>google-oauth-plugin</artifactId>
+        <version>1.1.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -153,11 +158,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>commons-text-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.graphite</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,8 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency> <!-- until it is back in the parent -->
+      <!-- TODO: Remove the version here when it is integrated in the BOM -->
+      <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>google-oauth-plugin</artifactId>
         <version>1.1.1</version>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -61,8 +61,9 @@ public class ComputeEngineCloudTest {
     serviceAccountConfig.setSecretJsonKey(bytes);
     assertNotNull(serviceAccountConfig.getAccountId());
     // Create a credential
-    Credentials c =
-        (Credentials) new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
+    GoogleRobotPrivateKeyCredentials c =
+        new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
+    String credentialsId = c.getId();
     CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
     store.addCredentials(Domain.global(), c);
 
@@ -71,7 +72,7 @@ public class ComputeEngineCloudTest {
     ics.add(instanceConfigurationBuilder().build());
     ics.add(instanceConfigurationBuilder().build());
     ComputeEngineCloud cloud =
-        new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, PROJECT_ID, INSTANCE_CAP_STR);
+        new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, credentialsId, INSTANCE_CAP_STR);
     cloud.setInstanceId(INSTANCE_ID);
     cloud.setConfigurations(ics);
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloudTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
@@ -61,18 +62,18 @@ public class ComputeEngineCloudTest {
     serviceAccountConfig.setSecretJsonKey(bytes);
     assertNotNull(serviceAccountConfig.getAccountId());
     // Create a credential
-    GoogleRobotPrivateKeyCredentials c =
-        new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
-    String credentialsId = c.getId();
+    final String credentialId = "test-credential-id";
+    GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, credentialId, ACCOUNT_ID,
+                                                                              serviceAccountConfig, null);
     CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
+    assertNotNull(store);
     store.addCredentials(Domain.global(), c);
 
     // Add a few InstanceConfigurations
     List<InstanceConfiguration> ics = new ArrayList<>();
     ics.add(instanceConfigurationBuilder().build());
     ics.add(instanceConfigurationBuilder().build());
-    ComputeEngineCloud cloud =
-        new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, credentialsId, INSTANCE_CAP_STR);
+    ComputeEngineCloud cloud = new ComputeEngineCloud(CLOUD_NAME, PROJECT_ID, credentialId, INSTANCE_CAP_STR);
     cloud.setInstanceId(INSTANCE_ID);
     cloud.setConfigurations(ics);
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ConfigAsCodeTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ConfigAsCodeTest.java
@@ -4,25 +4,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
-import com.cloudbees.plugins.credentials.Credentials;
-import com.cloudbees.plugins.credentials.CredentialsStore;
-import com.cloudbees.plugins.credentials.SecretBytes;
-import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import com.cloudbees.plugins.credentials.domains.Domain;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials;
-import com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig;
 import hudson.model.Node;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import java.nio.charset.StandardCharsets;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ConfigAsCodeTest {
-
-  private static final byte[] PK_BYTES =
-      "{\"client_email\": \"example@example.com\"}".getBytes(StandardCharsets.UTF_8);
 
   @Rule public JenkinsRule jenkinsRule = new JenkinsConfiguredWithCodeRule();
 
@@ -64,16 +54,6 @@ public class ConfigAsCodeTest {
   @Test
   @ConfiguredWithCode("configuration-as-code.yml")
   public void shouldCreateGCEClientFromCode() throws Exception {
-    SecretBytes bytes = SecretBytes.fromBytes(PK_BYTES);
-    JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
-    serviceAccountConfig.setSecretJsonKey(bytes);
-    assertNotNull(serviceAccountConfig.getAccountId());
-    Credentials credentials =
-        new GoogleRobotPrivateKeyCredentials("gce-jenkins", serviceAccountConfig, null);
-
-    CredentialsStore store =
-        new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
-    store.addCredentials(Domain.global(), credentials);
 
     ComputeEngineCloud cloud =
         (ComputeEngineCloud) jenkinsRule.jenkins.clouds.getByName("gce-jenkins-build");

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
@@ -40,3 +40,14 @@ jenkins:
             bootDiskSizeGbStr:  50
             bootDiskAutoDelete: true
             serviceAccountEmail: 'jenkins-test@gce-jenkins-ops.iam.gserviceaccount.com'
+credentials:
+  system:
+    domainCredentials:
+      - credentials:
+          - googleRobotPrivateKeyCredentials:
+              id: gce-jenkins
+              projectId: gce-jenkins
+              serviceAccountConfig:
+                jsonServiceAccountConfig:
+                  # The encoded version of {"client_email": "example@example.com"}
+                  secretJsonKey: 'eyJjbGllbnRfZW1haWwiOiAiZXhhbXBsZUBleGFtcGxlLmNvbSJ9'


### PR DESCRIPTION
Supersedes https://github.com/jenkinsci/google-compute-engine-plugin/pull/416

Hello 👋

Since jenkinsci/google-oauth-plugin#186, the constructor `public GoogleRobotPrivateKeyCredentials(String projectId, ServiceAccountConfig serviceAccountConfig, @Nullable GoogleRobotCredentialsModule module)` was deprecated in favor of one allowing to specify explicitly the credential ID.
This PR provides an update in the automated tests making use of the up-to-date constructor.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
