### PR TITLE
Dual-stack support (IPv6 mode)

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -57,7 +57,7 @@ View Google Compute Engine on the plugin site for more information.
 ### Google Compute Engine configuration
 Each GCE configuration can point to a different GCP project. Follow the steps below to create one.
 
- 1. Go to Manage Jenkins, then Configure System
+ 1. Go to Manage Jenkins, then Nodes and Clouds, then CLouds in the left menu 
  2. At the bottom of the page there will be a button labeled Add a new cloud, click the 
     button then click Google Compute Engine.
  3. Enter a name for your cloud configuration and the Project ID that you will be using
@@ -134,6 +134,5 @@ If you want to turn off this Strategy globally then you can set a SystemProperty
 
 Follow the steps below to configure it:
 
- 1. Go to Manage Jenkins, then Configure System
- 2. At the bottom of the page there will be a Cloud Section
- 3. Select the cloud project and look for the `No delay provisioning` checkbox, and click on to enable it. 
+ 1. Go to Manage Jenkins, then Nodes and Clouds, then CLouds in the left menu
+ 2. Select the cloud project and look for the `No delay provisioning` checkbox, and click on to enable it. 

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,10 @@
     <it.windows>false</it.windows>
     <powershell.version>1.3</powershell.version>
     <google.http.version>1.42.2</google.http.version>
-    <google.compute.api.version>1.25.0</google.compute.api.version>
+    <google.compute.api.version>1.32.1</google.compute.api.version>
     <com.google.oauth-client.version>1.34.1</com.google.oauth-client.version>
     <google.j2objc.version>1.3</google.j2objc.version>
-    <compute.revision>235</compute.revision>
+    <compute.revision>20220720</compute.revision>
     <gcp-plugin-core.version>0.3.0</gcp-plugin-core.version>
     <hpi.compatibleSinceVersion>4.1.0</hpi.compatibleSinceVersion>
     <concurrency>10</concurrency>

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -346,7 +346,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
                     // Look for a public IPv4 address
                     if (nic.getAccessConfigs() != null) {
                         for (AccessConfig ac : nic.getAccessConfigs()) {
-                            if (ac.getType().equals(InstanceConfiguration.NAT_TYPE)) {
+                            if (ac.getType().equals(NetworkInterfaceIpStackMode.NAT_TYPE)) {
                                 host = ac.getNatIP();
                             }
                         }
@@ -356,7 +356,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
                     //  his preferences to prioritize them.
                     if (nic.getIpv6AccessConfigs() != null) {
                         for (AccessConfig ac : nic.getIpv6AccessConfigs()) {
-                            if (ac.getType().equals(InstanceConfiguration.IPV6_TYPE)) {
+                            if (ac.getType().equals(NetworkInterfaceDualStack.IPV6_TYPE)) {
                                 host = ac.getExternalIpv6();
                             }
                         }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -343,7 +343,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
                 if (this.useInternalAddress) {
                     host = nic.getNetworkIP();
                 } else {
-                    // Look for a public IP address
+                    // Look for a public IPv4 address
                     if (nic.getAccessConfigs() != null) {
                         for (AccessConfig ac : nic.getAccessConfigs()) {
                             if (ac.getType().equals(InstanceConfiguration.NAT_TYPE)) {
@@ -351,9 +351,20 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
                             }
                         }
                     }
+                    // Look for a public IPv6 address
+                    // TODO: IPv6 address is preferred compared to IPv4, we could let the user select
+                    //  his preferences to prioritize them.
+                    if (nic.getIpv6AccessConfigs() != null) {
+                        for (AccessConfig ac : nic.getIpv6AccessConfigs()) {
+                            if (ac.getType().equals(InstanceConfiguration.IPV6_TYPE)) {
+                                host = ac.getExternalIpv6();
+                            }
+                        }
+                    }
                     // No public address found. Fall back to internal address
                     if (host.isEmpty()) {
                         host = nic.getNetworkIP();
+                        logInfo(computer, listener, "No public address found. Fall back to internal address.");
                     }
                 }
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -232,10 +232,6 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         this.createSnapshot = createSnapshot && this.oneShot;
     }
 
-    public List<NetworkInterfaceIpStackMode.Descriptor> getNetworkInterfaceIpStackModeDescriptors() {
-        return ExtensionList.lookup(NetworkInterfaceIpStackMode.Descriptor.class);
-    }
-
     public static Integer intOrDefault(String toParse, Integer defaultTo) {
         Integer toReturn;
         try {
@@ -937,6 +933,10 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                 return FormValidation.error(Messages.InstanceConfiguration_NumExecutorsOneShotError());
             }
             return FormValidation.ok();
+        }
+
+        public List<NetworkInterfaceIpStackMode.Descriptor> getNetworkInterfaceIpStackModeDescriptors() {
+            return ExtensionList.lookup(NetworkInterfaceIpStackMode.Descriptor.class);
         }
     }
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -116,12 +116,12 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             add("windows-sql-cloud");
         }
     });
-    public static final String IP_SINGLE_STACK = "IPV4_ONLY";
-    public static final String IP_DUAL_STACK = "IPV4_IPV6";
+    public static final String SINGLE_IP_STACK_TYPE = "IPV4_ONLY";
+    public static final String DUAL_IP_STACK_TYPE = "IPV4_IPV6";
     public static final List<String> IP_STACK_TYPES = Collections.unmodifiableList(new ArrayList<String>() {
         {
-            add(IP_SINGLE_STACK);
-            add(IP_DUAL_STACK);
+            add(SINGLE_IP_STACK_TYPE);
+            add(DUAL_IP_STACK_TYPE);
         }
     });
     public static final String PREMIUM_NETWORK_TIER = "PREMIUM";

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -130,6 +130,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     private String bootDiskSourceImageProject;
     private NetworkConfiguration networkConfiguration;
     private NetworkInterfaceIpStackMode networkInterfaceIpStackMode;
+    @Deprecated private boolean externalAddress;
     private boolean useInternalAddress;
     private boolean ignoreProxy;
     private String networkTags;
@@ -349,6 +350,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     /** Initializes transient properties */
     protected Object readResolve() {
         labelSet = Label.parse(labels);
+        this.networkInterfaceIpStackMode = new NetworkInterfaceSingleStack(externalAddress);
         return this;
     }
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -130,7 +130,10 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     private String bootDiskSourceImageProject;
     private NetworkConfiguration networkConfiguration;
     private NetworkInterfaceIpStackMode networkInterfaceIpStackMode;
-    @Deprecated private boolean externalAddress;
+
+    @Deprecated
+    private boolean externalAddress;
+
     private boolean useInternalAddress;
     private boolean ignoreProxy;
     private String networkTags;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack.java
@@ -1,0 +1,62 @@
+package com.google.jenkins.plugins.computeengine;
+
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.NetworkInterface;
+import hudson.Extension;
+import java.util.ArrayList;
+import java.util.List;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class NetworkInterfaceDualStack extends NetworkInterfaceIpStackMode {
+    public static final String PREMIUM_NETWORK_TIER = "PREMIUM";
+    public static final String IPV6_TYPE = "DIRECT_IPV6";
+    public static final String IPV6_NAME = "external-ipv6";
+
+    private boolean externalIPV4Address;
+    private static final boolean externalIPV6Address = true; // always true in dual-stack type
+
+    @DataBoundConstructor
+    public NetworkInterfaceDualStack() {}
+
+    public boolean getExternalIPV4Address() {
+        return externalIPV4Address;
+    }
+
+    public boolean getExternalIPV46ddress() {
+        return externalIPV6Address;
+    }
+
+    @DataBoundSetter
+    public void setExternalIPV4Address(boolean externalIPV4Address) {
+        this.externalIPV4Address = externalIPV4Address;
+    }
+
+    @Override
+    protected NetworkInterface getNetworkInterface() {
+        List<AccessConfig> accessConfigs = new ArrayList<>();
+        NetworkInterface networkInterface = new NetworkInterface().setStackType(DUAL_IP_STACK_TYPE);
+        if (externalIPV4Address) {
+            accessConfigs.add(new AccessConfig().setType(NAT_TYPE).setName(NAT_NAME));
+            networkInterface.setAccessConfigs(accessConfigs);
+        }
+        List<AccessConfig> ipv6AccessConfigs = new ArrayList<>();
+        if (externalIPV6Address) { // always true
+            ipv6AccessConfigs.add(
+                    new AccessConfig().setType(IPV6_TYPE).setName(IPV6_NAME).setNetworkTier(PREMIUM_NETWORK_TIER));
+            networkInterface.setIpv6AccessConfigs(ipv6AccessConfigs);
+        }
+
+        return networkInterface;
+    }
+
+    @Extension
+    @Symbol("dualStack")
+    public static class DescriptorImpl extends NetworkInterfaceIpStackMode.Descriptor {
+        @Override
+        public String getDisplayName() {
+            return DUAL_IP_STACK_TYPE + " (dual-stack)";
+        }
+    }
+}

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.google.api.services.compute.model.AccessConfig;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceIpStackMode.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceIpStackMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.google.api.services.compute.model.NetworkInterface;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceIpStackMode.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceIpStackMode.java
@@ -1,0 +1,18 @@
+package com.google.jenkins.plugins.computeengine;
+
+import com.google.api.services.compute.model.NetworkInterface;
+import hudson.model.AbstractDescribableImpl;
+
+public abstract class NetworkInterfaceIpStackMode extends AbstractDescribableImpl<NetworkInterfaceIpStackMode> {
+    public static final String NAT_TYPE = "ONE_TO_ONE_NAT";
+    public static final String NAT_NAME = "External NAT";
+
+    public static final String SINGLE_IP_STACK_TYPE = "IPV4_ONLY";
+    public static final String DUAL_IP_STACK_TYPE = "IPV4_IPV6";
+
+    protected NetworkInterface getNetworkInterface() {
+        return null;
+    }
+
+    public static class Descriptor extends hudson.model.Descriptor<NetworkInterfaceIpStackMode> {}
+}

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack.java
@@ -1,0 +1,51 @@
+package com.google.jenkins.plugins.computeengine;
+
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.NetworkInterface;
+import hudson.Extension;
+import java.util.ArrayList;
+import java.util.List;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class NetworkInterfaceSingleStack extends NetworkInterfaceIpStackMode {
+
+    private boolean externalIPV4Address;
+
+    @DataBoundConstructor
+    public NetworkInterfaceSingleStack() {}
+
+    public NetworkInterfaceSingleStack(boolean externalIPV4Address) {
+        this.externalIPV4Address = externalIPV4Address;
+    }
+
+    public boolean getExternalIPV4Address() {
+        return externalIPV4Address;
+    }
+
+    @DataBoundSetter
+    public void setExternalIPV4Address(boolean externalIPV4Address) {
+        this.externalIPV4Address = externalIPV4Address;
+    }
+
+    @Override
+    protected NetworkInterface getNetworkInterface() {
+        List<AccessConfig> accessConfigs = new ArrayList<>();
+        NetworkInterface networkInterface = new NetworkInterface().setStackType(SINGLE_IP_STACK_TYPE);
+        if (externalIPV4Address) {
+            accessConfigs.add(new AccessConfig().setType(NAT_TYPE).setName(NAT_NAME));
+            networkInterface.setAccessConfigs(accessConfigs);
+        }
+        return networkInterface;
+    }
+
+    @Extension
+    @Symbol("singleStack")
+    public static class DescriptorImpl extends NetworkInterfaceIpStackMode.Descriptor {
+        @Override
+        public String getDisplayName() {
+            return SINGLE_IP_STACK_TYPE + " (single-stack)";
+        }
+    }
+}

--- a/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.computeengine;
 
 import com.google.api.services.compute.model.AccessConfig;

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -109,7 +109,13 @@
                     <f:entry title="${%Network tags}" field="networkTags">
                         <f:textbox/>
                     </f:entry>
-                    <f:entry field="externalAddress" title="${%Attach External IP?}">
+                    <f:entry field="ipStackType" title="${%Network Interface IP stack type}">
+                        <f:select/>
+                    </f:entry>
+                    <f:entry field="externalAddress" title="${%Attach External IPV4 address?}">
+                        <f:checkbox/>
+                    </f:entry>
+                    <f:entry field="externalIPV6Address" title="${%Attach External IPV6 address?}">
                         <f:checkbox/>
                     </f:entry>
                 </f:section>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -109,14 +109,9 @@
                     <f:entry title="${%Network tags}" field="networkTags">
                         <f:textbox/>
                     </f:entry>
-                    <f:entry field="ipStackType" title="${%Network Interface IP stack type}">
-                        <f:select/>
-                    </f:entry>
-                    <f:entry field="externalAddress" title="${%Attach External IPV4 address?}">
-                        <f:checkbox/>
-                    </f:entry>
-                    <f:entry field="externalIPV6Address" title="${%Attach External IPV6 address?}">
-                        <f:checkbox/>
+                    <f:entry title="Network Interface IP stack type">
+                        <f:hetero-radio field="networkInterfaceIpStackMode"
+                                        descriptors="${instance.networkInterfaceIpStackModeDescriptors}"/>
                     </f:entry>
                 </f:section>
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -111,7 +111,7 @@
                     </f:entry>
                     <f:entry title="Network Interface IP stack type">
                         <f:hetero-radio field="networkInterfaceIpStackMode"
-                                        descriptors="${instance.networkInterfaceIpStackModeDescriptors}"/>
+                                        descriptors="${descriptor.networkInterfaceIpStackModeDescriptors}"/>
                     </f:entry>
                 </f:section>
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-externalIPV6Address.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-externalIPV6Address.html
@@ -1,0 +1,17 @@
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<div>
+    Configure external IPv6 address for the instance network interface.
+    The subnetwork and network interface IP stack type needs to be set to dual-stack mode (IPV4_IPV6).
+</div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-ipStackType.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-ipStackType.html
@@ -1,0 +1,17 @@
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<div>
+    The IP stack type to use for the instance network interface configuration.
+    Check that the configuration of your subnetwork match the selected stack type.
+</div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkInterfaceIpStackMode.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkInterfaceIpStackMode.html
@@ -1,15 +1,17 @@
 <!--
- Copyright 2020 Google LLC
+Copyright 2024 CloudBees, Inc.
 
- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-        https://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software distributed under the License
- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- implied. See the License for the specific language governing permissions and limitations under the
- License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <div>
     The IP stack type to use for the instance network interface configuration.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkInterfaceIpStackMode.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-networkInterfaceIpStackMode.html
@@ -12,6 +12,7 @@
  License.
 -->
 <div>
-    Configure external IPv6 address for the instance network interface.
-    The subnetwork and network interface IP stack type needs to be set to dual-stack mode (IPV4_IPV6).
+    The IP stack type to use for the instance network interface configuration.
+    Check that the configuration of your subnetwork match the selected stack type.
 </div>
+

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <f:entry field="externalIPV4Address" title="${%Attach External IPV4 address?}">
+        <f:checkbox/>
+    </f:entry>
+    <f:entry field="externalIPV6Address" title="${%Attach External IPV6 address?}">
+        <f:checkbox checked="true" readonly="true"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/config.jelly
@@ -1,3 +1,18 @@
+<!--
+Copyright 2024 CloudBees, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry field="externalIPV4Address" title="${%Attach External IPV4 address?}">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/help-externalIPV4Address.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/help-externalIPV4Address.html
@@ -12,6 +12,6 @@
  License.
 -->
 <div>
-    Dictates whether the instance should receive an <strong>external routable IP</strong> address. In GCE, you will need to have either an <em>external IP</em> or a <a href="https://cloud.google.com/vpc/docs/special-configurations#multiple-natgateways">NAT gateway</a> setup in order to download anything from the internet.
+    Configure external IPv4 address for the instance network interface.
 </div>
 

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/help-externalIPV4Address.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/help-externalIPV4Address.html
@@ -1,15 +1,17 @@
 <!--
- Copyright 2020 Google LLC
+Copyright 2024 CloudBees, Inc.
 
- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-        https://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software distributed under the License
- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- implied. See the License for the specific language governing permissions and limitations under the
- License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <div>
     Configure external IPv4 address for the instance network interface.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/help-externalIPV6Address.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/help-externalIPV6Address.html
@@ -1,15 +1,17 @@
 <!--
- Copyright 2020 Google LLC
+Copyright 2024 CloudBees, Inc.
 
- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-        https://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software distributed under the License
- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- implied. See the License for the specific language governing permissions and limitations under the
- License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <div>
     Configure external IPv6 address for the instance network interface.

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/help-externalIPV6Address.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceDualStack/help-externalIPV6Address.html
@@ -1,0 +1,17 @@
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<div>
+    Configure external IPv6 address for the instance network interface.
+    External IPV6 address is mandatory in dual-stack mode, the field is in read-only mode.
+</div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <f:entry field="externalIPV4Address" title="${%Attach External IPV4 address?}">
+        <f:checkbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack/config.jelly
@@ -1,3 +1,18 @@
+<!--
+Copyright 2024 CloudBees, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:entry field="externalIPV4Address" title="${%Attach External IPV4 address?}">

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack/help-externalIPV4Address.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack/help-externalIPV4Address.html
@@ -12,6 +12,5 @@
  License.
 -->
 <div>
-    The IP stack type to use for the instance network interface configuration.
-    Check that the configuration of your subnetwork match the selected stack type.
+    Dictates whether the instance should receive an <strong>external routable IP</strong> address. In GCE, you will need to have either an <em>external IP</em> or a <a href="https://cloud.google.com/vpc/docs/special-configurations#multiple-natgateways">NAT gateway</a> setup in order to download anything from the internet.
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack/help-externalIPV4Address.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/NetworkInterfaceSingleStack/help-externalIPV4Address.html
@@ -1,15 +1,17 @@
 <!--
- Copyright 2020 Google LLC
+Copyright 2024 CloudBees, Inc.
 
- Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
- compliance with the License. You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-        https://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software distributed under the License
- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- implied. See the License for the specific language governing permissions and limitations under the
- License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <div>
     Dictates whether the instance should receive an <strong>external routable IP</strong> address. In GCE, you will need to have either an <em>external IP</em> or a <a href="https://cloud.google.com/vpc/docs/special-configurations#multiple-natgateways">NAT gateway</a> setup in order to download anything from the internet.

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -204,7 +204,7 @@ public class InstanceConfigurationTest {
         r.assertEqualBeans(
                 want,
                 got,
-                "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,acceleratorConfiguration,networkConfiguration,externalAddress,networkTags,serviceAccountEmail");
+                "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,acceleratorConfiguration,networkConfiguration,networkInterfaceIpStackMode,networkTags,serviceAccountEmail");
     }
 
     @Test
@@ -319,7 +319,7 @@ public class InstanceConfigurationTest {
                 .createSnapshot(false)
                 .remoteFs(null)
                 .networkConfiguration(new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME))
-                .externalAddress(EXTERNAL_ADDR)
+                .networkInterfaceIpStackMode(new NetworkInterfaceSingleStack(true))
                 .useInternalAddress(false)
                 .ignoreProxy(false)
                 .networkTags(NETWORK_TAGS)

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateIT.java
@@ -17,6 +17,7 @@
 package com.google.jenkins.plugins.computeengine.integration;
 
 import static com.google.cloud.graphite.platforms.plugin.client.util.ClientUtil.nameFromSelfLink;
+import static com.google.jenkins.plugins.computeengine.NetworkInterfaceIpStackMode.NAT_TYPE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
@@ -153,7 +154,7 @@ public class ComputeEngineCloudTemplateIT {
             String host = "";
             if (nic.getAccessConfigs() != null) {
                 for (AccessConfig ac : nic.getAccessConfigs()) {
-                    if (ac.getType().equals(InstanceConfiguration.NAT_TYPE)) {
+                    if (ac.getType().equals(NAT_TYPE)) {
                         host = ac.getNatIP();
                     }
                 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -21,8 +21,8 @@ import static com.google.common.collect.ImmutableList.copyOf;
 import static com.google.common.collect.ImmutableList.of;
 import static com.google.jenkins.plugins.computeengine.InstanceConfiguration.METADATA_LINUX_STARTUP_SCRIPT_KEY;
 import static com.google.jenkins.plugins.computeengine.InstanceConfiguration.METADATA_WINDOWS_STARTUP_SCRIPT_KEY;
-import static com.google.jenkins.plugins.computeengine.InstanceConfiguration.NAT_NAME;
-import static com.google.jenkins.plugins.computeengine.InstanceConfiguration.NAT_TYPE;
+import static com.google.jenkins.plugins.computeengine.NetworkInterfaceIpStackMode.NAT_NAME;
+import static com.google.jenkins.plugins.computeengine.NetworkInterfaceIpStackMode.NAT_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -55,6 +55,7 @@ import com.google.jenkins.plugins.computeengine.AcceleratorConfiguration;
 import com.google.jenkins.plugins.computeengine.AutofilledNetworkConfiguration;
 import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
 import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import com.google.jenkins.plugins.computeengine.NetworkInterfaceSingleStack;
 import com.google.jenkins.plugins.computeengine.SshConfiguration;
 import com.google.jenkins.plugins.computeengine.WindowsConfiguration;
 import com.google.jenkins.plugins.computeengine.client.ClientUtil;
@@ -318,7 +319,7 @@ class ITUtil {
                                 : null)
                 .remoteFs(null)
                 .networkConfiguration(new AutofilledNetworkConfiguration(NETWORK_NAME, SUBNETWORK_NAME))
-                .externalAddress(EXTERNAL_ADDR)
+                .networkInterfaceIpStackMode(new NetworkInterfaceSingleStack(true))
                 .useInternalAddress(false)
                 .ignoreProxy(false)
                 .networkTags(NETWORK_TAGS)

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
@@ -32,9 +32,9 @@ jenkins:
                 region:         europe-west1
                 subnetworkShortName: gce-jenkins-cloud
             networkTags:        jenkins-agent
-            ipStackType:        "IPV4_ONLY"
-            externalAddress:    true
-            externalIPV6Address: false
+            networkInterfaceIpStackMode:
+              singleStack:
+                externalIPV4Address:    true
             useInternalAddress: false
             bootDiskSourceImageProject: gce-jenkins
             bootDiskSourceImageName: "https://www.googleapis.com/compute/v1/projects/gce-jenkins/global/images/gce-jenkins-build-image"

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/configuration-as-code.yml
@@ -32,7 +32,9 @@ jenkins:
                 region:         europe-west1
                 subnetworkShortName: gce-jenkins-cloud
             networkTags:        jenkins-agent
+            ipStackType:        "IPV4_ONLY"
             externalAddress:    true
+            externalIPV6Address: false
             useInternalAddress: false
             bootDiskSourceImageProject: gce-jenkins
             bootDiskSourceImageName: "https://www.googleapis.com/compute/v1/projects/gce-jenkins/global/images/gce-jenkins-build-image"

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
@@ -30,7 +30,9 @@ jenkins:
                 network:        default 
                 subnetwork:     default
             networkTags:        "jenkins-agent ssh"
+            ipStackType:        "IPV4_ONLY"
             externalAddress:    true
+            externalIPV6Address: false
             useInternalAddress: false
             bootDiskSourceImageProject: debian-cloud
             bootDiskSourceImageName: "projects/debian-cloud/global/images/family/debian-9"

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
@@ -30,9 +30,9 @@ jenkins:
                 network:        default 
                 subnetwork:     default
             networkTags:        "jenkins-agent ssh"
-            ipStackType:        "IPV4_ONLY"
-            externalAddress:    true
-            externalIPV6Address: false
+            networkInterfaceIpStackMode:
+              singleStack:
+                externalIPV4Address:    true
             useInternalAddress: false
             bootDiskSourceImageProject: debian-cloud
             bootDiskSourceImageName: "projects/debian-cloud/global/images/family/debian-9"

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-non-standard-java-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-non-standard-java-it.yml
@@ -30,7 +30,9 @@ jenkins:
                 network:        default 
                 subnetwork:     default
             networkTags:        "jenkins-agent ssh"
+            ipStackType:        "IPV4_ONLY"
             externalAddress:    true
+            externalIPV6Address: false
             useInternalAddress: false
             bootDiskSourceImageProject: debian-cloud
             bootDiskSourceImageName: "projects/debian-cloud/global/images/family/debian-9"

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-non-standard-java-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-non-standard-java-it.yml
@@ -30,9 +30,9 @@ jenkins:
                 network:        default 
                 subnetwork:     default
             networkTags:        "jenkins-agent ssh"
-            ipStackType:        "IPV4_ONLY"
-            externalAddress:    true
-            externalIPV6Address: false
+            networkInterfaceIpStackMode:
+              singleStack:
+                externalIPV4Address:    true
             useInternalAddress: false
             bootDiskSourceImageProject: debian-cloud
             bootDiskSourceImageName: "projects/debian-cloud/global/images/family/debian-9"

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml
@@ -32,7 +32,9 @@ jenkins:
                 network:        default
                 subnetwork:     default
             networkTags:        "jenkins-agent ssh"
+            ipStackType:        "IPV4_ONLY"
             externalAddress:    true
+            externalIPV6Address: false
             useInternalAddress: false
             bootDiskSourceImageProject: ${env.GOOGLE_BOOT_DISK_PROJECT_ID}
             bootDiskSourceImageName: "projects/${env.GOOGLE_BOOT_DISK_PROJECT_ID}/global/images/${env.GOOGLE_BOOT_DISK_IMAGE_NAME}"

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-windows-it.yml
@@ -32,9 +32,9 @@ jenkins:
                 network:        default
                 subnetwork:     default
             networkTags:        "jenkins-agent ssh"
-            ipStackType:        "IPV4_ONLY"
-            externalAddress:    true
-            externalIPV6Address: false
+            networkInterfaceIpStackMode:
+              singleStack:
+                externalIPV4Address:    true
             useInternalAddress: false
             bootDiskSourceImageProject: ${env.GOOGLE_BOOT_DISK_PROJECT_ID}
             bootDiskSourceImageName: "projects/${env.GOOGLE_BOOT_DISK_PROJECT_ID}/global/images/${env.GOOGLE_BOOT_DISK_IMAGE_NAME}"


### PR DESCRIPTION
This PR wants to add the configuration to set up dual-stack compute engine instance with an external IPv6 address.

I made manual testing with a GCP project.

## Manual testing

### Set up

I created a test environment on GCP.

<details><summary>More info :arrow_down:</summary>
<p>

I created a GSA (google service account) with the good roles (more details [here](https://github.com/jenkinsci/google-compute-engine-plugin/blob/develop/docs/Home.md#iam-credentials)) then I generated a private key to use this GSA in the plugin.

```bash
export PROJECT_ID="MY_GCP_PROJECT_ID"
export REGION="MY_REGION"
export ZONE="MY_ZONE"

gcloud auth login
gcloud config set project ${PROJECT_ID}

export SA_NAME="my-sa-name"
export SA_DESC="my-sa-desc"

# https://cloud.google.com/iam/docs/service-accounts-create#iam-service-accounts-create-gcloud
gcloud iam service-accounts create ${SA_NAME} \
    --description="${SA_DESC}" \
    --display-name="${SA_NAME}"

# https://cloud.google.com/compute/docs/access/iam
gcloud projects add-iam-policy-binding ${PROJECT_ID} \
    --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
    --role="roles/compute.instanceAdmin"
gcloud projects add-iam-policy-binding ${PROJECT_ID} \
    --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
    --role="roles/compute.networkAdmin"
gcloud projects add-iam-policy-binding ${PROJECT_ID} \
    --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
    --role="iam/compute.serviceAccountUser"

# check GSA roles
gcloud projects get-iam-policy ${PROJECT_ID} \
    --flatten="bindings[].members" \
    --format='table(bindings.role)' \
    --filter="bindings.members:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"

# https://cloud.google.com/iam/docs/keys-create-delete
export KEY_FILE="${SA_NAME}-private-key.json"
gcloud iam service-accounts keys create "${KEY_FILE}" \
    --iam-account="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
```

I also created a network and a subnetwork with dual-stack mode.

```bash
# create network
export NETWORK_NAME="my-network"
gcloud compute networks create ${NETWORK_NAME} --project=${PROJECT_ID} --subnet-mode=custom --mtu=1460 --bgp-routing-mode=regional
gcloud compute networks list

# this one don't seem to be required
export FIREWALL_ALLOW_ALL_NAME="my-firewall-allow-all-custom"
gcloud compute firewall-rules create ${FIREWALL_ALLOW_ALL_NAME} --project=${PROJECT_ID} --network=projects/${PROJECT_ID}/global/networks/${NETWORK_NAME} --description="Allows connection from any source to any instance on the network using custom protocols." --direction=INGRESS --priority=65534 --source-ranges=10.0.0.0/24 --action=ALLOW --rules=all

# this one is a single-stack subnetwork, not required for our tests
export SINGLE_STACK_SUBNETWORK_NAME="my-single-stack-subnetwork"
gcloud compute networks subnets create ${SINGLE_STACK_SUBNETWORK_NAME} --project=${PROJECT_ID} --range=10.0.0.0/16 --stack-type=IPV4_ONLY --region=${REGION} --network=${NETWORK_NAME}

# this one is a dual-stack subnetwork
export DUAL_STACK_SUBNETWORK_NAME="my-dual-stack-bis-subnetwork"
gcloud compute networks subnets create ${DUAL_STACK_SUBNETWORK_NAME} --project=${PROJECT_ID} --range=10.2.0.0/16 --stack-type=IPV4_IPV6 --ipv6-access-type=EXTERNAL --network=${NETWORK_NAME} --region=${REGION}
```

In the plugin, I created a Cloud configuration from the GSA private JSON key.
In the _Machine Configuration_ I used an `e2-standard-4` machine type with the networks I created then I played with the new options I added:
![image](https://github.com/jenkinsci/google-compute-engine-plugin/assets/24521660/affa2fe1-d46c-43a5-8ba0-bba06686f473)
</p>
</details> 

## Testing

You'll find the tests I did below with the subnetwork configured in dual-mode (**IPV4_IPV6**).

| plugin configuration                 | GCP configuration                                                                | telnet ADDRESS 22                        | plugin SSH connection                            |
|------------------------------------------------------|----------------------------------------------------------------------------------|------------------------------------------|--------------------------------------------------|
| IPV4_only with IPV4 external address                 | OK :green_circle:                                                                               | IPv4: OK  :green_circle:                                 | OK  :green_circle:  (IPv4 address used)                           |
| ~~IPV4_IPV6 with IPv4 external address~~                 | NOK but it's normal :green_circle: (IPv6 address is mandatory on network interface dual-stack mode)             | IPv4: OK :green_circle: / IPv6: NOK  :orange_circle:  (Network Unreachable) | NOK  :orange_circle:  (IPv6 has the priority on IPv4 and is unreachable) |
| IPV4_IPV6 with both IPv4 and IPv6 external addresses | OK   :green_circle:                                                                              | IPv4: OK :green_circle: / IPv6: NOK  :orange_circle:  (Network Unreachable) | NOK  :orange_circle: (IPv6 has the priority on IPv4 and is unreachable) |
| IPV4_IPV6 with IPv6 external address                 | OK  :green_circle:  (IPv4 is not mandatory on network interface dual-stack mode compared to IPv6) | IPv6: NOK :orange_circle: (Network Unreachable)          | NOK  :orange_circle: (IPv6 is unreachable)                              |
| ~~IPV4_IPv6 without any external addresses~~             | NOK but it's normal :green_circle:  (IPv6 address is mandatory on network interface dual-stack mode)             | IPv6: NOK  :orange_circle:  (Network Unreachable)          | NOK  :orange_circle: (IPv6 is unreachable)                              |

:information_source: 
**The :orange_circle: are only related to my local network configuration. I can't access IPv6 for now but I'm currently trying to configure it (my ISP needs to provide IPv6 address and I need to configure my local router to use DHCPv6). Other than that, the GCP configuration works well. :tada:**

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
