### PR TITLE
Bump `google.http.version` and `google.j2objc.version`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,10 @@
     <skipITs>true</skipITs>
     <it.windows>false</it.windows>
     <powershell.version>1.3</powershell.version>
-    <google.http.version>1.42.2</google.http.version>
+    <google.http.version>1.43.3</google.http.version>
     <google.compute.api.version>1.32.1</google.compute.api.version>
     <com.google.oauth-client.version>1.34.1</com.google.oauth-client.version>
-    <google.j2objc.version>1.3</google.j2objc.version>
+    <google.j2objc.version>2.8</google.j2objc.version>
     <compute.revision>20220720</compute.revision>
     <gcp-plugin-core.version>0.3.0</gcp-plugin-core.version>
     <hpi.compatibleSinceVersion>4.1.0</hpi.compatibleSinceVersion>


### PR DESCRIPTION
Routine dependency bump. The new versions are consistent with other Google plugins in the Update Center. The only testing I have done is the CI build.