### PR TITLE
Add userinfo-email OAuth2 scope when associating service account

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -542,11 +542,11 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     private List<ServiceAccount> serviceAccounts() {
         if (notNullOrEmpty(serviceAccountEmail)) {
             List<ServiceAccount> serviceAccounts = new ArrayList<>();
-            serviceAccounts.add(new ServiceAccount()
-                    .setEmail(serviceAccountEmail)
-                    .setScopes(Arrays.asList(new String[] {
+            serviceAccounts.add(
+                    new ServiceAccount().setEmail(serviceAccountEmail).setScopes(Arrays.asList(new String[] {
                         "https://www.googleapis.com/auth/cloud-platform",
-                        "https://www.googleapis.com/auth/userinfo.email"})));
+                        "https://www.googleapis.com/auth/userinfo.email"
+                    })));
             return serviceAccounts;
         } else {
             return null;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -544,7 +544,9 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             List<ServiceAccount> serviceAccounts = new ArrayList<>();
             serviceAccounts.add(new ServiceAccount()
                     .setEmail(serviceAccountEmail)
-                    .setScopes(Arrays.asList(new String[] {"https://www.googleapis.com/auth/cloud-platform"})));
+                    .setScopes(Arrays.asList(new String[] {
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/userinfo.email"})));
             return serviceAccounts;
         } else {
             return null;

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-serviceAccountEmail.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-serviceAccountEmail.html
@@ -16,6 +16,7 @@
 
     <p>
         Use IAM to specify the capabilities of the service account. The service account will be granted the <em>https://www.googleapis.com/auth/cloud-platform</em>
+        and <em>https://www.googleapis.com/auth/userinfo.email</em>
         scope,
         allowing it full access to those specified capabilities.
     </p>


### PR DESCRIPTION
### Background:
Service account associating with Jenkins agents provisioned by GCE plugin does not have the scope `userinfo-email`, which is suggested by [official GKE docs](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#forbidden_error_for_service_accounts_on_vm_instances) to configure RBAC for the service account to deploy to GKE.

### Proposal:
Add the `userinfo-email` OAuth2 scope beside current `cloud-platform` scope.

### Github issue:
https://github.com/jenkinsci/google-compute-engine-plugin/issues/476

### Testing done
Local unit test passed using `maven:3.8.6-openjdk-11`:
```
[INFO] Results:
[INFO] 
[INFO] Tests run: 55, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  33:15 min
[INFO] Finished at: 2024-10-13T13:16:31Z
[INFO] ------------------------------------------------------------------------
```
