### PR TITLE
Replace dropdown button to remove dependency on YUI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <revision>4</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.401.3</jenkins.version>
+    <jenkins.version>2.452.3</jenkins.version>
     <jenkinsRuleTimeout>0</jenkinsRuleTimeout>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     <skipITs>true</skipITs>
@@ -89,8 +89,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.401.x</artifactId>
-        <version>2671.va_73a_b_4c103fb_</version>
+        <artifactId>bom-2.452.x</artifactId>
+        <version>3208.vb_21177d4b_cd9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
@@ -12,28 +12,30 @@
  License.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form"
+    xmlns:l="/lib/layout" xmlns:dd="/lib/layout/dropdowns">
     <j:if test="${it.hasPermission(it.PROVISION)}">
         <tr>
             <td/>
-            <td colspan="${monitors.size()+1}">
+            <td colspan="${monitors.size()+2}">
+                <l:overflowButton icon="symbol-add"
+                                  text="${%Provision via} ${it.displayName}"
+                                  tooltip="${null}"
+                                  clazz="jenkins-!-margin-top-2">
+                    <j:forEach var="t" items="${it.configurations}">
+                        <dd:custom>
+                            <button class="jenkins-dropdown__item"
+                                    data-type="gcloud-provision"
+                                    data-url="${t.description}">
+                                ${t.description}
+                            </button>
+                        </dd:custom>
+                    </j:forEach>
+                </l:overflowButton>
                 <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision">
-                    <input type="submit" class="gce-provision-button" value="${%Provision via} ${it.displayName}"/>
-                    <select name="configuration">
-                        <j:forEach var="c" items="${it.configurations}">
-                            <option value="${c.description}">${c.description}</option>
-                        </j:forEach>
-                    </select>
-                    <st:once>
-                        <script>
-                            Behaviour.register({
-                            ".gce-provision-button" : function (e) {
-                            new YAHOO.widget.Button(e, { type: "menu", menu: e.nextSibling });
-                            }
-                            });
-                        </script>
-                    </st:once>
+                    <input type="hidden" name="configuration"/>
                 </f:form>
+                <st:adjunct includes="com.google.jenkins.plugins.computeengine.ComputeEngineCloud.provision"/>
             </td>
         </tr>
     </j:if>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/computerSet.jelly
@@ -15,6 +15,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form"
     xmlns:l="/lib/layout" xmlns:dd="/lib/layout/dropdowns">
     <j:if test="${it.hasPermission(it.PROVISION)}">
+        <j:set var="formId" value="${h.generateId()}"/>
         <tr>
             <td/>
             <td colspan="${monitors.size()+2}">
@@ -26,13 +27,14 @@
                         <dd:custom>
                             <button class="jenkins-dropdown__item"
                                     data-type="gcloud-provision"
+                                    data-form="${formId}"
                                     data-url="${t.description}">
                                 ${t.description}
                             </button>
                         </dd:custom>
                     </j:forEach>
                 </l:overflowButton>
-                <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision">
+                <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision" id="${formId}">
                     <input type="hidden" name="configuration"/>
                 </f:form>
                 <st:adjunct includes="com.google.jenkins.plugins.computeengine.ComputeEngineCloud.provision"/>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/provision.js
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/provision.js
@@ -1,6 +1,6 @@
 Behaviour.specify("[data-type='gcloud-provision']", 'gcloud-provision', -99, function(e) {
   e.addEventListener("click", function (event) {
-    const form = document.querySelector("form[name='provision']");
+    const form = document.getElementById(e.dataset.form);
     form.querySelector("[name='configuration']").value = e.dataset.url;
     buildFormTree(form);
     form.submit();

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/provision.js
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/ComputeEngineCloud/provision.js
@@ -1,0 +1,8 @@
+Behaviour.specify("[data-type='gcloud-provision']", 'gcloud-provision', -99, function(e) {
+  e.addEventListener("click", function (event) {
+    const form = document.querySelector("form[name='provision']");
+    form.querySelector("[name='configuration']").value = e.dataset.url;
+    buildFormTree(form);
+    form.submit();
+  });
+});


### PR DESCRIPTION
Fixes https://issues.jenkins.io/browse/JENKINS-73544

Replace YUI button with a more modern component, analogous to https://github.com/jenkinsci/credentials-plugin/pull/551 as part of the YUI removal initiative (https://issues.jenkins.io/browse/JENKINS-73539 )

### Testing done

Manually checked that clicking the dropdown button goes to the provision page with the correct parameters.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
