### PR TITLE
Update integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ An essential part of getting your change through is to make sure all existing te
 
 ##### Integration Tests
 
-Integration tests actually provision instances in a GCP project, run pipeline, take snapshot etc.
+Integration tests provision actual instances in a GCP project, run pipeline, take snapshot etc.
 Therefore, they are disabled in the CI and expected to be executed by contributors in their laptop itself.
 
 Reasons for disabling integration test in CI,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,9 +79,9 @@ Steps to execute integration test
   ```bash
   bash setup-gce-image.sh
   ```
-  * The above agent image contains the `java` command is available in the PATH; which the plugin uses by default for launching the agent.
-    This plugin also supports configuring up a custom path for java executable, and we have an integration test for that `ComputeEngineCloudNonStandardJavaIT`.
-    If you would like to execute this test, please create an image with not having `java` on the path, but at a custom path `/usr/bin/non-standard-java`.  
+  * The above agent image contains the `java` command available on the PATH; which the plugin uses by default for launching the agent.
+    This plugin also supports configuring custom path for java executable, and we have an integration test for that `ComputeEngineCloudNonStandardJavaIT`.
+    If you would like to execute this test, please create an image with `java` command not being on the PATH, but at a custom path `/usr/bin/non-standard-java`.  
     To create a non-standard java image, execute,
     ```bash
     bash setup-gce-image.sh non-standard-java

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,6 @@ Steps to execute integration test
   * In addition to the environment variables mentioned in the previous section, also export these variables too,  
     ```bash
     export GOOGLE_BOOT_DISK_PROJECT_ID=your-project-id # will be the same as your project id
-    expot GOOGLE_BOOT_DISK_IMAGE_NAME=windows-image-name # will be the name of the image you created using packer in Google cloud console
+    export GOOGLE_BOOT_DISK_IMAGE_NAME=windows-image-name # will be the name of the image you created using packer in Google cloud console
     export GOOGLE_JENKINS_PASSWORD=password # will be the password you set when creating the image with packer, used for password based ssh authentication.
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,13 @@ Steps to execute integration test
   ```bash
   bash setup-gce-image.sh
   ```
-  If you want to execute the integration tests for `non-standard-java` location, then create non-standard-java image as,
-  ```bash
-  bash setup-gce-image.sh non-standard-java
-  ```
+  * The above agent image contains the `java` command is available in the PATH; which the plugin uses by default for launching the agent.
+    This plugin also supports configuring up a custom path for java executable, and we have an integration test for that `ComputeEngineCloudNonStandardJavaIT`.
+    If you would like to execute this test, please create an image with not having `java` on the path, but at a custom path `/usr/bin/non-standard-java`.  
+    To create a non-standard java image, execute,
+    ```bash
+    bash setup-gce-image.sh non-standard-java
+    ```
   If you want to delete the images or recreate them, use the arguments `--recreate` or `--delete`.
 
 * Create a service account with relevant access - See [Refer to IAM Credentials](Home.md#iam-credentials)   

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,45 +54,75 @@ An essential part of getting your change through is to make sure all existing te
 * Make sure you are at the directory where pom.xml is located.
 
 ##### Unit Tests
-* Run the following:
-
-```
-mvn test
-```
+* Run the following: 
+    ```
+    mvn test
+    ```
 
 ##### Integration Tests
-* By default, the integration tests are not executed. In case you are interested in executing 
-  them, disable the `skipITs` property.
-* The following environment variables are required to run the integration tests. 5, 6, and 7 are
-  only required when running a windows integration test.
 
-1. GOOGLE_PROJECT_ID
-1. GOOGLE_CREDENTIALS
-1. GOOGLE_REGION
-1. GOOGLE_ZONE
-1. GOOGLE_BOOT_DISK_PROJECT_ID
-1. GOOGLE_BOOT_DISK_IMAGE_NAME
-1. GOOGLE_JENKINS_PASSWORD
-1. GOOGLE_SA_NAME
+Integration tests actually provision instances in a GCP project, run pipeline, take snapshot etc.
+Therefore, they are disabled in the CI and expected to be executed by contributors in their laptop itself.
 
-* Run the following:
-```
-mvn verify -DskipITs=false
-```
+Reasons for disabling integration test in CI,
+* getting provisioning GCP infra is not possible
+* even if we did get a GCP infra setup in the CI, it is risky to expose that, as someone can abuse the CI.
+
+By default, integration tests are skipped from the maven goals, need to enable using the `skipITs` property.
+
+Steps to execute integration test
+* Prepare VM images  
+  (ideally we should automate this see idea [here](https://github.com/jenkinsci/google-compute-engine-plugin/pull/492#discussion_r1892705637))  
+  The jenkins agent images need to have java installed. We have a packer script to create the image and upload to your configured GCP project.
+  The scripts are located in [testimages/linux](./testimages/linux)
+  Navigate to the directory and execute,
+  ```bash
+  bash setup-gce-image.sh
+  ```
+  If you want to execute the integration tests for `non-standard-java` location, then create non-standard-java image as,
+  ```bash
+  bash setup-gce-image.sh non-standard-java
+  ```
+  If you want to delete the images or recreate them, use the arguments `--recreate` or `--delete`.
+
+* Create a service account with relevant access - See [Refer to IAM Credentials](Home.md#iam-credentials)   
+
+* Export these mandatory environment variable   
+  ```bash
+  export GOOGLE_PROJECT_ID=your-project-id
+  export GOOGLE_CREDENTIALS=/path/to/sa-key.json
+  export GOOGLE_REGION=us-central1
+  export GOOGLE_ZONE=us-central1-a
+  export GOOGLE_SA_NAME=jenkins-agent-sa
+  ```
+* Run the integration tests as,  
+  * Run all the tests   
+    ```bash
+    mvn verify -DskipITs=false -Djenkins.test.timeout=1200
+    ```
+  * Run a specific test class  
+    ```bash
+    mvn clean test -Dtest=ComputeEngineCloudRestartPreemptedIT
+    ```
+  * Run a specific test method  
+    ```bash
+    mvn clean test -Dtest=ComputeEngineCloudRestartPreemptedIT#testIfNodeWasPreempted
+    ```
+  You can also debug the tests with surefire by passing `-Dmaven.surefire.debug=true` and in your IDE connect to remote debug port `8000`.
 
 ###### Windows Integration Test
 * By default, the integration tests only use linux based agents for testing. If you make a
   windows-related change, or otherwise want to test that a change still works for windows agents,
-  run the tests with the flag `-Dit.windows=true` like this:
-```bash
-mvn verify -Dit.windows=true
-```
-
-Make sure you have these extra environment variables configured:
-  * GOOGLE_BOOT_DISK_PROJECT_ID will be the same as your project id.
-  * GOOGLE_BOOT_DISK_IMAGE_NAME will be the name of the image you created using packer in Google
-    cloud console.
-  * GOOGLE_JENKINS_PASSWORD will be the password you set when creating the image with packer, used
-    for password based ssh authentication.
-  * More information on building your baseline windows image can be found [here](WINDOWS.md) 
-    and an example powershell script for setup can be found [here](windows-it-install.ps1).
+  run the tests with the flag `-Dit.windows=true` like this:  
+  ```bash
+  mvn verify -Dit.windows=true
+  ```
+* You need to prepare the windows image before running the tests.  
+  * More information on building your baseline windows image can be found [here](WINDOWS.md)  
+      and an example powershell script for setup can be found [here](windows-it-install.ps1).  
+  * In addition to the environment variables mentioned in the previous section, also export these variables too,  
+    ```bash
+    export GOOGLE_BOOT_DISK_PROJECT_ID=your-project-id # will be the same as your project id
+    expot GOOGLE_BOOT_DISK_IMAGE_NAME=windows-image-name # will be the name of the image you created using packer in Google cloud console
+    export GOOGLE_JENKINS_PASSWORD=password # will be the password you set when creating the image with packer, used for password based ssh authentication.
+    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Steps to execute integration test
 * Run the integration tests as,  
   * Run all the tests   
     ```bash
-    mvn verify -DskipITs=false -Djenkins.test.timeout=1200
+    mvn verify -DskipITs=false
     ```
   * Run a specific test class  
     ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.version>2.452.3</jenkins.version>
-    <jenkinsRuleTimeout>0</jenkinsRuleTimeout>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     <skipITs>true</skipITs>
     <it.windows>false</it.windows>
@@ -379,7 +378,6 @@
           <excludes>
             <exclude>**/ITUtil.java</exclude>
           </excludes>
-          <argLine>-Djenkins.test.timeout=${jenkinsRuleTimeout}</argLine>
           <runOrder>${it.runOrder}</runOrder>
           <reuseForks>false</reuseForks>
         </configuration>
@@ -398,6 +396,9 @@
           <skipTests>${skip.surefire.tests}</skipTests>
           <runOrder>balanced</runOrder>
           <reuseForks>false</reuseForks>
+          <systemPropertyVariables>
+            <jenkins.test.timeout>600</jenkins.test.timeout>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,27 @@
       <version>${powershell.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- Test Dependencies -->
+    <!--
+    The 3 plugins `workflow-cps`, `workflow-durable-task-step`, `workflow-job` are put here
+      to assist tests to also test for `Pipeline` based jobs.
+      It is good to have tests that do test for both `FreeStyle` and `Pipeline` jobs to ensure compatibility.
+      Note: FreeStyle job comes with jenkins core itself, so there is no need for additional dependency for it.
+    -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,7 @@
             <hudson.agents.NodeProvisioner.MARGIN0>1.0</hudson.agents.NodeProvisioner.MARGIN0>
             <hudson.remoting.Launcher.pingIntervalSec>-1</hudson.remoting.Launcher.pingIntervalSec>
             <com.google.jenkins.plugins.computeengine.integration.ITUtil.windows>${it.windows}</com.google.jenkins.plugins.computeengine.integration.ITUtil.windows>
+            <jenkins.test.timeout>600</jenkins.test.timeout>
           </systemPropertyVariables>
           <excludes>
             <exclude>**/ITUtil.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <lombok.version>1.18.30</lombok.version>
     <delombok.output>${project.build.directory}/delombok</delombok.output>
     <spotless.check.skip>false</spotless.check.skip>
+    <jenkins.test.timeout>600</jenkins.test.timeout>
   </properties>
 
   <dependencyManagement>
@@ -374,7 +375,7 @@
             <hudson.agents.NodeProvisioner.MARGIN0>1.0</hudson.agents.NodeProvisioner.MARGIN0>
             <hudson.remoting.Launcher.pingIntervalSec>-1</hudson.remoting.Launcher.pingIntervalSec>
             <com.google.jenkins.plugins.computeengine.integration.ITUtil.windows>${it.windows}</com.google.jenkins.plugins.computeengine.integration.ITUtil.windows>
-            <jenkins.test.timeout>600</jenkins.test.timeout>
+            <jenkins.test.timeout>${jenkins.test.timeout}</jenkins.test.timeout>
           </systemPropertyVariables>
           <excludes>
             <exclude>**/ITUtil.java</exclude>
@@ -398,7 +399,7 @@
           <runOrder>balanced</runOrder>
           <reuseForks>false</reuseForks>
           <systemPropertyVariables>
-            <jenkins.test.timeout>600</jenkins.test.timeout>
+            <jenkins.test.timeout>${jenkins.test.timeout}</jenkins.test.timeout>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -268,12 +268,12 @@
       <version>${powershell.version}</version>
       <scope>test</scope>
     </dependency>
-    <!--
-    The 3 plugins `workflow-cps`, `workflow-durable-task-step`, `workflow-job` are put here
-      to assist tests to also test for `Pipeline` based jobs.
-      It is good to have tests that do test for both `FreeStyle` and `Pipeline` jobs to ensure compatibility.
-      Note: FreeStyle job comes with jenkins core itself, so there is no need for additional dependency for it.
-    -->
+    <!-- https://www.jenkins.io/doc/developer/testing/#working-with-pipeline -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientUtil.java
@@ -73,21 +73,6 @@ public class ClientUtil {
     private static GoogleRobotCredentials getRobotCredentials(
             ItemGroup itemGroup, List<DomainRequirement> domainRequirements, String credentialsId)
             throws AbortException {
-
-        /* During the integration tests, the parameter `credentialId` is equal to the `<Project-Id>` which is set
-            by the environment variable. But the actual credential created within Jenkins is having `id` as a random
-            UUID. So the `CredentialsMatchers.firstOrNull` was returning `null` due to `CredentialsMatchers.withId
-            (credentialsId)`
-        */
-        if (Main.isUnitTest) {
-            var credentialList = CredentialsProvider.lookupCredentials(
-                    GoogleOAuth2Credentials.class, itemGroup, ACL.SYSTEM, domainRequirements);
-            if (!credentialList.isEmpty()) {
-                return (GoogleRobotCredentials) credentialList.get(0);
-            }
-            return null;
-        }
-
         GoogleOAuth2Credentials credentials = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
                         GoogleOAuth2Credentials.class, itemGroup, ACL.SYSTEM, domainRequirements),

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientUtil.java
@@ -13,6 +13,7 @@ import com.google.jenkins.plugins.computeengine.ComputeEngineScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2Credentials;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import hudson.AbortException;
+import hudson.Main;
 import hudson.model.ItemGroup;
 import hudson.security.ACL;
 import java.io.IOException;
@@ -72,6 +73,20 @@ public class ClientUtil {
     private static GoogleRobotCredentials getRobotCredentials(
             ItemGroup itemGroup, List<DomainRequirement> domainRequirements, String credentialsId)
             throws AbortException {
+
+        /* During the integration tests, the parameter `credentialId` is equal to the `<Project-Id>` which is set
+            by the environment variable. But the actual credential created within Jenkins is having `id` as a random
+            UUID. So the `CredentialsMatchers.firstOrNull` was returning `null` due to `CredentialsMatchers.withId
+            (credentialsId)`
+        */
+        if (Main.isUnitTest) {
+            var credentialList = CredentialsProvider.lookupCredentials(
+                    GoogleOAuth2Credentials.class, itemGroup, ACL.SYSTEM, domainRequirements);
+            if (!credentialList.isEmpty()) {
+                return (GoogleRobotCredentials) credentialList.get(0);
+            }
+            return null;
+        }
 
         GoogleOAuth2Credentials credentials = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientUtil.java
@@ -72,6 +72,7 @@ public class ClientUtil {
     private static GoogleRobotCredentials getRobotCredentials(
             ItemGroup itemGroup, List<DomainRequirement> domainRequirements, String credentialsId)
             throws AbortException {
+
         GoogleOAuth2Credentials credentials = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
                         GoogleOAuth2Credentials.class, itemGroup, ACL.SYSTEM, domainRequirements),

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ClientUtil.java
@@ -13,7 +13,6 @@ import com.google.jenkins.plugins.computeengine.ComputeEngineScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2Credentials;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import hudson.AbortException;
-import hudson.Main;
 import hudson.model.ItemGroup;
 import hudson.security.ACL;
 import java.io.IOException;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeClientIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeClientIT.java
@@ -58,7 +58,7 @@ public class ComputeClientIT {
 
     @Test
     public void testGetImage() throws Exception {
-        Image image = client.getImage("debian-cloud", "debian-9-stretch-v20180820");
+        Image image = client.getImage("debian-cloud", "debian-12-bookworm-v20241210");
         assertNotNull(image);
         assertEquals("READY", image.getStatus());
     }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeClientIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeClientIT.java
@@ -38,7 +38,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ComputeClientIT {
     private static final Logger log = Logger.getLogger(ComputeClientIT.class.getName());
 
-    private static Map<String, String> label = getLabel(ComputeClientIT.class);
+    private static final Map<String, String> label = getLabel(ComputeClientIT.class);
     private static ComputeClient client;
 
     @ClassRule

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeClientIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeClientIT.java
@@ -36,7 +36,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 /** Integration test suite for {@link ComputeClient}. */
 public class ComputeClientIT {
-    private static Logger log = Logger.getLogger(ComputeClientIT.class.getName());
+    private static final Logger log = Logger.getLogger(ComputeClientIT.class.getName());
 
     private static Map<String, String> label = getLabel(ComputeClientIT.class);
     private static ComputeClient client;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.java
@@ -20,7 +20,6 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
-import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
@@ -31,7 +30,6 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
-import com.google.api.services.compute.model.Instance;
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
 import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
@@ -61,15 +59,13 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
     private static final String MULTIPLE_NUM_EXECUTORS = "2";
 
     @ClassRule
-    public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(5L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class);
-    private static Collection<PlannedNode> planned;
-    private static Instance instance;
+    private static final Map<String, String> label = getLabel(ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT.class);
 
     @BeforeClass
     public static void init() throws Exception {
@@ -87,10 +83,8 @@ public class ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT {
                 .googleLabels(label)
                 .build()));
 
-        planned = cloud.provision(new LabelAtom(LABEL), 2);
+        Collection<PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 2);
         planned.iterator().next().future.get();
-
-        instance = client.getInstance(PROJECT_ID, ZONE, planned.iterator().next().displayName);
     }
 
     @AfterClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudIgnoreProxyIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudIgnoreProxyIT.java
@@ -16,7 +16,6 @@
 
 package com.google.jenkins.plugins.computeengine.integration;
 
-import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
@@ -27,7 +26,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCl
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfigurationBuilder;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
@@ -38,7 +37,6 @@ import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
 import hudson.ProxyConfiguration;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
-import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import hudson.tasks.Builder;
 import java.io.IOException;
@@ -54,6 +52,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.PrefixedOutputStream;
+import org.jvnet.hudson.test.TailLog;
 
 /**
  * Integration test suite for {@link ComputeEngineCloud}. Verifies that when the ignore proxy flag
@@ -70,8 +70,6 @@ public class ComputeEngineCloudIgnoreProxyIT {
     private static ComputeClient client;
     private static Map<String, String> label = getLabel(ComputeEngineCloudIgnoreProxyIT.class);
     private static ComputeEngineCloud cloud;
-    private static FreeStyleProject project;
-    private static Node worker;
 
     @BeforeClass
     public static void init() throws Exception {
@@ -79,32 +77,11 @@ public class ComputeEngineCloudIgnoreProxyIT {
         initCredentials(jenkinsRule);
         cloud = initCloud(jenkinsRule);
         client = initClient(jenkinsRule, label, log);
-
-        InstanceConfiguration instanceConfiguration = instanceConfigurationBuilder()
-                .numExecutorsStr(NUM_EXECUTORS)
-                .labels(LABEL)
-                .template(NULL_TEMPLATE)
-                .googleLabels(label)
-                .oneShot(true)
-                .ignoreProxy(true)
-                .build();
-
         Jenkins jenkins = jenkinsRule.getInstance();
         jenkins.proxy = new ProxyConfiguration("127.0.0.1", 8080);
         jenkins.proxy.save();
         jenkins.save();
-        cloud.setConfigurations(ImmutableList.of(instanceConfiguration));
-        assertTrue(cloud.getInstanceConfigurationByDescription(instanceConfiguration.getDescription())
-                .isIgnoreProxy());
-
-        project = jenkinsRule.createFreeStyleProject();
-        Builder step = execute(Commands.ECHO, "works");
-        project.getBuildersList().add(step);
-        project.setAssignedLabel(new LabelAtom(LABEL));
-
-        FreeStyleBuild build = jenkinsRule.buildAndAssertSuccess(project);
-        worker = build.getBuiltOn();
-        assertNotNull(worker);
+        log.info("init completed");
     }
 
     @AfterClass
@@ -112,18 +89,61 @@ public class ComputeEngineCloudIgnoreProxyIT {
         teardownResources(client, label, log);
     }
 
+    private static InstanceConfiguration getConfiguration(boolean ignoreProxy, String proxyLabel) {
+        return instanceConfigurationBuilder()
+                .description("IgnoreProxy=" + ignoreProxy)
+                .numExecutorsStr(NUM_EXECUTORS)
+                .labels(proxyLabel)
+                .template(NULL_TEMPLATE)
+                .googleLabels(label)
+                .oneShot(true)
+                .ignoreProxy(ignoreProxy)
+                .build();
+    }
+
+    private static FreeStyleProject createProject(String nodeLabel) throws IOException {
+        var project = jenkinsRule.createFreeStyleProject(nodeLabel);
+        Builder step = execute(Commands.ECHO, "works");
+        project.getBuildersList().add(step);
+        project.setAssignedLabel(new LabelAtom(nodeLabel));
+        return project;
+    }
+
     @Test
-    public void testWorkerIgnoringProxy() {
-        ComputeEngineInstance node = (ComputeEngineInstance) worker;
-        assertTrue(node.isIgnoreProxy());
+    public void testWorkerIgnoringProxy() throws Exception {
+        String identifier = "ignoreProxy";
+        var instanceConfig = getConfiguration(true, identifier);
+        cloud.setConfigurations(ImmutableList.of(instanceConfig));
+        jenkinsRule.getInstance().save();
+
+        assertTrue(cloud.getInstanceConfigurationByDescription(instanceConfig.getDescription())
+                .isIgnoreProxy());
+
+        var project = createProject(identifier);
+        try (var tailLog = new TailLog(jenkinsRule, identifier, 1).withColor(PrefixedOutputStream.Color.MAGENTA)) {
+            Future<FreeStyleBuild> build = project.scheduleBuild2(0);
+            ComputeEngineInstance node = (ComputeEngineInstance) build.get().getBuiltOn();
+            assertTrue(node.isIgnoreProxy());
+            tailLog.waitForCompletion();
+        }
     }
 
     // Due to the proxy configured for Jenkins, the build fails because it is not able to connect to
     // the node through the proxy.
     @Test(expected = TimeoutException.class)
     public void testWorkerNotIgnoringProxyFails() throws Exception {
-        cloud.getConfigurations().get(0).setIgnoreProxy(false);
-        Future<FreeStyleBuild> build = project.scheduleBuild2(0);
-        build.get(100, TimeUnit.SECONDS);
+        String identifier = "notIgnoreProxy";
+        var instanceConfig = getConfiguration(false, identifier);
+        cloud.setConfigurations(ImmutableList.of(instanceConfig));
+        jenkinsRule.getInstance().save();
+
+        assertFalse(cloud.getInstanceConfigurationByDescription(instanceConfig.getDescription())
+                .isIgnoreProxy());
+
+        var project = createProject(identifier);
+        try (var tailLog = new TailLog(jenkinsRule, identifier, 1).withColor(PrefixedOutputStream.Color.YELLOW)) {
+            Future<FreeStyleBuild> build = project.scheduleBuild2(0);
+            build.get(300, TimeUnit.SECONDS);
+        }
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleLabelsIT.java
@@ -54,18 +54,18 @@ import org.jvnet.hudson.test.JenkinsRule;
  * with multiple Jenkins labels and that these labels are properly provisioned.
  */
 public class ComputeEngineCloudMultipleLabelsIT {
-    private static Logger log = Logger.getLogger(ComputeEngineCloudMultipleLabelsIT.class.getName());
+    private static final Logger log = Logger.getLogger(ComputeEngineCloudMultipleLabelsIT.class.getName());
 
     private static final String MULTIPLE_LABEL = "integration test";
 
     @ClassRule
-    public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(5L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudMultipleLabelsIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudMultipleLabelsIT.class);
     private static String name;
 
     @BeforeClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleMatchingConfigurationsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleMatchingConfigurationsIT.java
@@ -63,7 +63,7 @@ public class ComputeEngineCloudMultipleMatchingConfigurationsIT {
     private static final String DESC_2 = "type_2";
 
     @ClassRule
-    public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(5L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
@@ -106,7 +106,7 @@ public class ComputeEngineCloudMultipleMatchingConfigurationsIT {
     }
 
     @Test
-    public void testMultipleLabelsProvisionedWithLabels() throws IOException {
+    public void testRoundRobinProvisioningWhenMultipleMatchingConfigurations() throws IOException {
         assertEquals(2, planned.size());
 
         final Iterator<PlannedNode> iterator = planned.iterator();

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleMatchingConfigurationsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleMatchingConfigurationsIT.java
@@ -57,7 +57,8 @@ import org.jvnet.hudson.test.JenkinsRule;
  * with multiple matching {@link InstanceConfiguration} and that these instances are provisioned in round-robin fashion.
  */
 public class ComputeEngineCloudMultipleMatchingConfigurationsIT {
-    private static Logger log = Logger.getLogger(ComputeEngineCloudMultipleMatchingConfigurationsIT.class.getName());
+    private static final Logger log =
+            Logger.getLogger(ComputeEngineCloudMultipleMatchingConfigurationsIT.class.getName());
 
     private static final String DESC_1 = "type_1";
     private static final String DESC_2 = "type_2";
@@ -69,7 +70,7 @@ public class ComputeEngineCloudMultipleMatchingConfigurationsIT {
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudMultipleMatchingConfigurationsIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudMultipleMatchingConfigurationsIT.class);
     private static Collection<PlannedNode> planned;
 
     @BeforeClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleMatchingConfigurationsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudMultipleMatchingConfigurationsIT.java
@@ -19,15 +19,17 @@ package com.google.jenkins.plugins.computeengine.integration;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfigurationBuilder;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
@@ -52,8 +54,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * Integration test suite for {@link ComputeEngineCloud}. Verifies that instances can be created
- * with multiple matching {@link InstanceConfiguration} and that these instances are properly
- * provisioned.
+ * with multiple matching {@link InstanceConfiguration} and that these instances are provisioned in round-robin fashion.
  */
 public class ComputeEngineCloudMultipleMatchingConfigurationsIT {
     private static Logger log = Logger.getLogger(ComputeEngineCloudMultipleMatchingConfigurationsIT.class.getName());
@@ -105,16 +106,18 @@ public class ComputeEngineCloudMultipleMatchingConfigurationsIT {
     }
 
     @Test
-    public void testMultipleLabelsProvisionedWithLabels() {
+    public void testMultipleLabelsProvisionedWithLabels() throws IOException {
         assertEquals(2, planned.size());
 
         final Iterator<PlannedNode> iterator = planned.iterator();
         PlannedNode firstNode = iterator.next();
         PlannedNode secondNode = iterator.next();
         if (checkOneNode(firstNode, DESC_1)) {
-            assertTrue(checkOneNode(secondNode, DESC_2));
+            assertDescription(firstNode, DESC_1);
+            assertDescription(secondNode, DESC_2);
         } else if (checkOneNode(secondNode, DESC_1)) {
-            assertTrue(checkOneNode(firstNode, DESC_2));
+            assertDescription(secondNode, DESC_1);
+            assertDescription(firstNode, DESC_2);
         } else {
             fail("Nodes did not have expected values");
         }
@@ -124,5 +127,23 @@ public class ComputeEngineCloudMultipleMatchingConfigurationsIT {
         String name = plannedNode.displayName;
         Node node = jenkinsRule.jenkins.getNode(name);
         return desc.equals(node.getNodeDescription());
+    }
+
+    private void assertDescription(PlannedNode plannedNode, String agentDesc) throws IOException {
+        String agentName = plannedNode.displayName;
+
+        assertEquals(
+                "Jenkins agent description is incorrect",
+                agentDesc,
+                jenkinsRule.jenkins.getNode(agentName).getNodeDescription());
+
+        // verify the corresponding instance is actually provisioned in GCP
+        // and also has matching description
+        await("Instance is in running status").timeout(2, TimeUnit.MINUTES).until(() -> "RUNNING"
+                .equals(client.getInstance(PROJECT_ID, ZONE, agentName).getStatus()));
+        assertEquals(
+                "Instance description is incorrect",
+                agentDesc,
+                client.getInstance(PROJECT_ID, ZONE, agentName).getDescription());
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
@@ -51,6 +51,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**
@@ -62,13 +63,16 @@ public class ComputeEngineCloudNoSnapshotCreatedIT {
     private static final Logger log = Logger.getLogger(ComputeEngineCloudNoSnapshotCreatedIT.class.getName());
 
     @ClassRule
-    public static Timeout timeout = new Timeout(7 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(7L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudNoSnapshotCreatedIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudNoSnapshotCreatedIT.class);
     private static String name;
 
     @BeforeClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNoSnapshotCreatedIT.java
@@ -59,7 +59,7 @@ import org.jvnet.hudson.test.JenkinsRule;
  * instance is terminated but no snapshot is created.
  */
 public class ComputeEngineCloudNoSnapshotCreatedIT {
-    private static Logger log = Logger.getLogger(ComputeEngineCloudNoSnapshotCreatedIT.class.getName());
+    private static final Logger log = Logger.getLogger(ComputeEngineCloudNoSnapshotCreatedIT.class.getName());
 
     @ClassRule
     public static Timeout timeout = new Timeout(7 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNonStandardJavaIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNonStandardJavaIT.java
@@ -29,9 +29,6 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCr
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfigurationBuilder;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.windows;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeFalse;
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNonStandardJavaIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNonStandardJavaIT.java
@@ -71,7 +71,7 @@ public class ComputeEngineCloudNonStandardJavaIT {
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudNonStandardJavaIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudNonStandardJavaIT.class);
 
     @BeforeClass
     public static void init() throws Exception {

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNonStandardJavaIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudNonStandardJavaIT.java
@@ -108,10 +108,7 @@ public class ComputeEngineCloudNonStandardJavaIT {
         assertEquals(1, jenkinsRule.jenkins.getNodes().size());
         var instance = client.getInstance(
                 PROJECT_ID, ZONE, jenkinsRule.jenkins.getNodes().get(0).getNodeName());
-        assertThat(
-                "Build did not run on GCP agent",
-                JenkinsRule.getLog(r),
-                is(containsString("Running on " + instance.getName())));
+        jenkinsRule.assertLogContains("Running on " + instance.getName(), r);
         jenkinsRule.waitUntilNoActivity();
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudOneShotInstanceIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudOneShotInstanceIT.java
@@ -53,6 +53,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**
@@ -64,13 +65,16 @@ public class ComputeEngineCloudOneShotInstanceIT {
     private static final int QUIET_PERIOD_SECS = 30;
 
     @ClassRule
-    public static Timeout timeout = new Timeout(10 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(10L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudOneShotInstanceIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudOneShotInstanceIT.class);
     private static FreeStyleBuild build;
     private static String nodeName;
     private static Future<FreeStyleBuild> otherBuildFuture;

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudRestartPreemptedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudRestartPreemptedIT.java
@@ -20,6 +20,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.execute;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
@@ -56,10 +57,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.PrefixedOutputStream;
 import org.jvnet.hudson.test.TailLog;
-import org.jvnet.hudson.test.recipes.WithTimeout;
 
 /**
  * Integration test suite for {@link ComputeEngineCloud}. Verifies that the build is rescheduled and
@@ -69,6 +70,9 @@ import org.jvnet.hudson.test.recipes.WithTimeout;
  */
 @Log
 public class ComputeEngineCloudRestartPreemptedIT {
+
+    @ClassRule
+    public static Timeout timeout = new Timeout(10L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
@@ -117,7 +121,6 @@ public class ComputeEngineCloudRestartPreemptedIT {
      * It is just that in the test logs, the logs get mixed up and may seem confusing.
      */
     @Test
-    @WithTimeout(1200)
     public void testIfNodeWasPreempted() throws Exception {
         Collection<PlannedNode> planned = cloud.provision(new LabelAtom(LABEL), 1);
         Iterator<PlannedNode> iterator = planned.iterator();

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
@@ -54,6 +54,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**
@@ -70,8 +71,11 @@ public class ComputeEngineCloudSnapshotCreatedIT {
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudSnapshotCreatedIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudSnapshotCreatedIT.class);
     private static Snapshot createdSnapshot = null;
 
     @BeforeClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
@@ -21,6 +21,7 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EX
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.SNAPSHOT_LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.SNAPSHOT_TIMEOUT;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.execute;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
@@ -52,8 +53,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.recipes.WithTimeout;
 
 /**
  * Integration test suite for {@link ComputeEngineCloud}. Verifies that when configured to use one
@@ -61,7 +62,10 @@ import org.jvnet.hudson.test.recipes.WithTimeout;
  * build fails.
  */
 public class ComputeEngineCloudSnapshotCreatedIT {
-    private static Logger log = Logger.getLogger(ComputeEngineCloudSnapshotCreatedIT.class.getName());
+    private static final Logger log = Logger.getLogger(ComputeEngineCloudSnapshotCreatedIT.class.getName());
+
+    @ClassRule
+    public static Timeout timeout = new Timeout(15L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
@@ -117,19 +121,16 @@ public class ComputeEngineCloudSnapshotCreatedIT {
     }
 
     /** Tests snapshot is created when we have failure builds for given node */
-    @WithTimeout(1200)
     @Test
     public void testSnapshotCreatedNotNull() {
         assertNotNull(createdSnapshot);
     }
 
-    @WithTimeout(1200)
     @Test
     public void testSnapshotCreatedStatusReady() {
         assertEquals("READY", createdSnapshot.getStatus());
     }
 
-    @WithTimeout(1200)
     @Test
     public void testSnapshotCreatedOneShotInstanceDeleted() {
         Awaitility.await()

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudSnapshotCreatedIT.java
@@ -21,7 +21,6 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EX
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.SNAPSHOT_LABEL;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.SNAPSHOT_TIMEOUT;
-import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.execute;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
@@ -53,8 +52,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.recipes.WithTimeout;
 
 /**
  * Integration test suite for {@link ComputeEngineCloud}. Verifies that when configured to use one
@@ -63,9 +62,6 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 public class ComputeEngineCloudSnapshotCreatedIT {
     private static Logger log = Logger.getLogger(ComputeEngineCloudSnapshotCreatedIT.class.getName());
-
-    @ClassRule
-    public static Timeout timeout = new Timeout(15 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
@@ -121,16 +117,19 @@ public class ComputeEngineCloudSnapshotCreatedIT {
     }
 
     /** Tests snapshot is created when we have failure builds for given node */
+    @WithTimeout(1200)
     @Test
     public void testSnapshotCreatedNotNull() {
         assertNotNull(createdSnapshot);
     }
 
+    @WithTimeout(1200)
     @Test
     public void testSnapshotCreatedStatusReady() {
         assertEquals("READY", createdSnapshot.getStatus());
     }
 
+    @WithTimeout(1200)
     @Test
     public void testSnapshotCreatedOneShotInstanceDeleted() {
         Awaitility.await()

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateNoGoogleLabelsIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudTemplateNoGoogleLabelsIT.java
@@ -57,18 +57,18 @@ import org.jvnet.hudson.test.JenkinsRule;
  * still present on the created instance.
  */
 public class ComputeEngineCloudTemplateNoGoogleLabelsIT {
-    private static Logger log = Logger.getLogger(ComputeEngineCloudTemplateNoGoogleLabelsIT.class.getName());
+    private static final Logger log = Logger.getLogger(ComputeEngineCloudTemplateNoGoogleLabelsIT.class.getName());
 
     private static final String TEMPLATE = format("projects/%s/global/instanceTemplates/test-template-no-labels");
 
     @ClassRule
-    public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(5L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudTemplateNoGoogleLabelsIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudTemplateNoGoogleLabelsIT.class);
     private static ComputeEngineCloud cloud;
     private static Instance instance;
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -34,17 +34,17 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Metadata;
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
 import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
 import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
+import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
-import hudson.slaves.NodeProvisioner.PlannedNode;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -57,7 +57,6 @@ import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.PrefixedOutputStream;
 import org.jvnet.hudson.test.TailLog;
-import org.jvnet.hudson.test.recipes.WithTimeout;
 
 /**
  * Integration test suite for {@link ComputeEngineCloud}. This verifies the default case for an
@@ -68,7 +67,7 @@ public class ComputeEngineCloudWorkerCreatedIT {
     private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerCreatedIT.class.getName());
 
     @ClassRule
-    public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(10L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
@@ -77,8 +76,6 @@ public class ComputeEngineCloudWorkerCreatedIT {
     private static ComputeEngineCloud cloud;
     private static Map<String, String> label = getLabel(ComputeEngineCloudWorkerCreatedIT.class);
     private static InstanceConfiguration instanceConfiguration;
-    private static Collection<PlannedNode> planned;
-    private static Instance instance;
 
     @BeforeClass
     public static void init() throws Exception {
@@ -98,12 +95,6 @@ public class ComputeEngineCloudWorkerCreatedIT {
                 .build();
 
         cloud.setConfigurations(ImmutableList.of(instanceConfiguration));
-        planned = cloud.provision(new LabelAtom(LABEL), 1);
-
-        planned.iterator().next().future.get();
-
-        instance = cloud.getClient()
-                .getInstance(PROJECT_ID, ZONE, planned.iterator().next().displayName);
     }
 
     @AfterClass
@@ -112,48 +103,43 @@ public class ComputeEngineCloudWorkerCreatedIT {
     }
 
     @Test
-    public void testWorkerCreatedOnePlannedNode() {
-        assertEquals(1, planned.size());
-    }
+    public void smokes() throws IOException, ExecutionException, InterruptedException {
+        var planned = cloud.provision(new LabelAtom(LABEL), 1);
+        planned.iterator().next().future.get();
+        var instance = cloud.getClient()
+                .getInstance(PROJECT_ID, ZONE, planned.iterator().next().displayName);
 
-    @Test
-    public void testWorkerCreatedNumberOfLabels() {
-        assertEquals(3, instance.getLabels().size());
-    }
-
-    @Test
-    public void testWorkerCreatedConfigLabelKeyAndValue() {
+        assertEquals("one instance should be provisioned", 1, planned.size());
+        assertEquals("GCP VM should have 3 labels", 3, instance.getLabels().size());
         assertEquals(
-                instanceConfiguration.getNamePrefix(), instance.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
-    }
+                "GCP VM name starts with the prefix configured",
+                instanceConfiguration.getNamePrefix(),
+                instance.getLabels().get(ComputeEngineCloud.CONFIG_LABEL_KEY));
+        // This is an important label to be present on the VM as it helps in `CleanLostNodesWork`
+        assertEquals(
+                "GCP VM label has the cloud instanceId as value",
+                cloud.getInstanceId(),
+                instance.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));
+        assertEquals("GCP VM is running ", "RUNNING", instance.getStatus());
 
-    @Test
-    public void testWorkerCreatedCloudIdKeyAndValue() {
-        assertEquals(cloud.getInstanceId(), instance.getLabels().get(ComputeEngineCloud.CLOUD_ID_LABEL_KEY));
-    }
-
-    @Test
-    public void testWorkerCreatedStatusRunning() {
-        assertEquals("RUNNING", instance.getStatus());
-    }
-
-    @Test
-    public void testGuestAttributesEnabled() {
+        // Verify that the guest-attributes are enabled on the VM
         Optional<String> guestAttributes = instance.getMetadata().getItems().stream()
                 .filter(item -> item.getKey().equals(InstanceConfiguration.GUEST_ATTRIBUTES_METADATA_KEY))
-                .map(item -> item.getValue())
+                .map(Metadata.Items::getValue)
                 .findFirst();
         assertTrue(guestAttributes.isPresent());
-        assertEquals(guestAttributes.get(), "TRUE");
+        assertEquals("TRUE", guestAttributes.get());
     }
 
-    @WithTimeout(300)
     @Test
     public void testWorkerCanExecuteBuild() throws Exception {
         var p = jenkinsRule.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node('" + LABEL + "') { sh 'date' }", true));
         try (var tailLog = new TailLog(jenkinsRule, "p", 1).withColor(PrefixedOutputStream.Color.MAGENTA)) {
             var r = jenkinsRule.buildAndAssertSuccess(p);
+            assertEquals(1, jenkinsRule.jenkins.getNodes().size());
+            Node node = jenkinsRule.jenkins.getNodes().get(0);
+            var instance = client.getInstance(PROJECT_ID, ZONE, node.getNodeName());
             tailLog.waitForCompletion();
             assertThat(
                     "Build did not run on GCP agent",

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -141,9 +141,6 @@ public class ComputeEngineCloudWorkerCreatedIT {
         assertEquals(1, jenkinsRule.jenkins.getNodes().size());
         Node node = jenkinsRule.jenkins.getNodes().get(0);
         var instance = client.getInstance(PROJECT_ID, ZONE, node.getNodeName());
-        assertThat(
-                "Build did not run on GCP agent",
-                JenkinsRule.getLog(r),
-                is(containsString("Running on " + instance.getName())));
+        jenkinsRule.assertLogContains("Running on " + instance.getName(), r);
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -28,9 +28,6 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCl
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfigurationBuilder;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -64,7 +64,7 @@ import org.jvnet.hudson.test.TailLog;
  * are provisioned properly.
  */
 public class ComputeEngineCloudWorkerCreatedIT {
-    private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerCreatedIT.class.getName());
+    private static final Logger log = Logger.getLogger(ComputeEngineCloudWorkerCreatedIT.class.getName());
 
     @ClassRule
     public static Timeout timeout = new Timeout(10L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -54,9 +54,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.PrefixedOutputStream;
-import org.jvnet.hudson.test.TailLog;
 
 /**
  * Integration test suite for {@link ComputeEngineCloud}. This verifies the default case for an
@@ -72,9 +71,12 @@ public class ComputeEngineCloudWorkerCreatedIT {
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
     private static ComputeClient client;
     private static ComputeEngineCloud cloud;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudWorkerCreatedIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudWorkerCreatedIT.class);
     private static InstanceConfiguration instanceConfiguration;
 
     @BeforeClass
@@ -135,16 +137,13 @@ public class ComputeEngineCloudWorkerCreatedIT {
     public void testWorkerCanExecuteBuild() throws Exception {
         var p = jenkinsRule.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("node('" + LABEL + "') { sh 'date' }", true));
-        try (var tailLog = new TailLog(jenkinsRule, "p", 1).withColor(PrefixedOutputStream.Color.MAGENTA)) {
-            var r = jenkinsRule.buildAndAssertSuccess(p);
-            assertEquals(1, jenkinsRule.jenkins.getNodes().size());
-            Node node = jenkinsRule.jenkins.getNodes().get(0);
-            var instance = client.getInstance(PROJECT_ID, ZONE, node.getNodeName());
-            tailLog.waitForCompletion();
-            assertThat(
-                    "Build did not run on GCP agent",
-                    JenkinsRule.getLog(r),
-                    is(containsString("Running on " + instance.getName())));
-        }
+        var r = jenkinsRule.buildAndAssertSuccess(p);
+        assertEquals(1, jenkinsRule.jenkins.getNodes().size());
+        Node node = jenkinsRule.jenkins.getNodes().get(0);
+        var instance = client.getInstance(PROJECT_ID, ZONE, node.getNodeName());
+        assertThat(
+                "Build did not run on GCP agent",
+                JenkinsRule.getLog(r),
+                is(containsString("Running on " + instance.getName())));
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
@@ -61,7 +61,7 @@ public class ComputeEngineCloudWorkerFailedIT {
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ComputeEngineCloudWorkerFailedIT.class);
+    private static final Map<String, String> label = getLabel(ComputeEngineCloudWorkerFailedIT.class);
     private static Collection<PlannedNode> planned;
 
     @BeforeClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
@@ -52,7 +52,7 @@ import org.jvnet.hudson.test.JenkinsRule;
  * worker fails upon creation when Java is not installed.
  */
 public class ComputeEngineCloudWorkerFailedIT {
-    private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerFailedIT.class.getName());
+    private static final Logger log = Logger.getLogger(ComputeEngineCloudWorkerFailedIT.class.getName());
 
     @ClassRule
     public static Timeout timeout = new Timeout(7L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
@@ -74,7 +74,8 @@ public class ComputeEngineCloudWorkerFailedIT {
 
         // This configuration creates an instance with no Java installed.
         cloud.setConfigurations(ImmutableList.of(instanceConfigurationBuilder()
-                .startupScript("")
+                .bootDiskSourceImageProject("debian-cloud")
+                .bootDiskSourceImageName("projects/debian-cloud/global/images/family/debian-12")
                 .numExecutorsStr(NUM_EXECUTORS)
                 .labels(LABEL)
                 .oneShot(false)

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerFailedIT.java
@@ -55,7 +55,7 @@ public class ComputeEngineCloudWorkerFailedIT {
     private static Logger log = Logger.getLogger(ComputeEngineCloudWorkerFailedIT.class.getName());
 
     @ClassRule
-    public static Timeout timeout = new Timeout(7 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(7L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeNonStandardJavaIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeNonStandardJavaIT.java
@@ -38,7 +38,7 @@ import org.jvnet.hudson.test.JenkinsRule;
  * java path.
  */
 public class ConfigAsCodeNonStandardJavaIT {
-    private static Logger log = Logger.getLogger(ConfigAsCodeNonStandardJavaIT.class.getName());
+    private static final Logger log = Logger.getLogger(ConfigAsCodeNonStandardJavaIT.class.getName());
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeNonStandardJavaIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeNonStandardJavaIT.java
@@ -31,6 +31,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**
@@ -46,8 +47,11 @@ public class ConfigAsCodeNonStandardJavaIT {
     @ClassRule
     public static Timeout timeout = new Timeout(5L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
     private static ComputeClient client;
-    private static Map<String, String> label = getLabel(ConfigAsCodeNonStandardJavaIT.class);
+    private static final Map<String, String> label = getLabel(ConfigAsCodeNonStandardJavaIT.class);
 
     @BeforeClass
     public static void init() throws Exception {
@@ -90,6 +94,7 @@ public class ConfigAsCodeNonStandardJavaIT {
         FreeStyleProject project = jenkinsRule.createFreeStyleProject();
         Builder step = execute(Commands.ECHO, "works");
         project.getBuildersList().add(step);
+        project.setAssignedLabel(new LabelAtom("integration-non-standard-java"));
         jenkinsRule.buildAndAssertSuccess(project);
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeNonStandardJavaIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeNonStandardJavaIT.java
@@ -44,7 +44,7 @@ public class ConfigAsCodeNonStandardJavaIT {
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     @ClassRule
-    public static Timeout timeout = new Timeout(5 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(5L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     private static ComputeClient client;
     private static Map<String, String> label = getLabel(ConfigAsCodeNonStandardJavaIT.class);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeTestIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeTestIT.java
@@ -31,7 +31,7 @@ import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ConfigAsCodeTestIT {
-    private static Logger log = Logger.getLogger(ConfigAsCodeTestIT.class.getName());
+    private static final Logger log = Logger.getLogger(ConfigAsCodeTestIT.class.getName());
 
     @ClassRule
     public static JenkinsRule jenkinsRule = new JenkinsRule();

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeTestIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ConfigAsCodeTestIT.java
@@ -37,11 +37,11 @@ public class ConfigAsCodeTestIT {
     public static JenkinsRule jenkinsRule = new JenkinsRule();
 
     @ClassRule
-    public static Timeout timeout = new Timeout(10 * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(10L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
     private static ComputeClient client;
     private static Map<String, String> label = getLabel(ConfigAsCodeTestIT.class);
-    private static String DISABLE_NO_DELAY_SYSTEM_PROPERTY =
+    private static final String DISABLE_NO_DELAY_SYSTEM_PROPERTY =
             "com.google.jenkins.plugins.computeengine.disableNoDelayProvisioning";
 
     @BeforeClass

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -203,7 +203,7 @@ class ITUtil {
         JsonServiceAccountConfig sac = new JsonServiceAccountConfig();
         sac.setSecretJsonKey(bytes);
         assertNotNull(sac.getAccountId());
-        Credentials credentials = new GoogleRobotPrivateKeyCredentials(PROJECT_ID, sac, null);
+        Credentials credentials = new GoogleRobotPrivateKeyCredentials(CredentialsScope.SYSTEM, PROJECT_ID, PROJECT_ID, "integration", sac, null);
 
         CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
         assertNotNull("Credentials store can not be null", store);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -203,7 +203,8 @@ class ITUtil {
         JsonServiceAccountConfig sac = new JsonServiceAccountConfig();
         sac.setSecretJsonKey(bytes);
         assertNotNull(sac.getAccountId());
-        Credentials credentials = new GoogleRobotPrivateKeyCredentials(CredentialsScope.SYSTEM, PROJECT_ID, PROJECT_ID, "integration", sac, null);
+        Credentials credentials = new GoogleRobotPrivateKeyCredentials(
+                CredentialsScope.SYSTEM, PROJECT_ID, PROJECT_ID, "integration", sac, null);
 
         CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
         assertNotNull("Credentials store can not be null", store);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ITUtil.java
@@ -63,6 +63,7 @@ import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyCredential;
 import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyPair;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials;
 import com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig;
+import hudson.model.FreeStyleBuild;
 import hudson.model.Node;
 import hudson.plugins.powershell.PowerShell;
 import hudson.tasks.Builder;
@@ -76,24 +77,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import jenkins.util.SystemProperties;
+import lombok.extern.java.Log;
 import org.apache.commons.lang.SystemUtils;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /** Common logic and constants used throughout the integration tests. */
+@Log
 class ITUtil {
     static final boolean windows =
             Boolean.parseBoolean(SystemProperties.getString(ITUtil.class.getName() + ".windows", "false"));
     static final boolean customssh =
             Boolean.parseBoolean(SystemProperties.getString(ITUtil.class.getName() + ".customssh", "false"));
-    private static final String DEB_JAVA_STARTUP_SCRIPT = "#!/bin/bash\n"
-            + "/etc/init.d/ssh stop\n"
-            + "echo \"deb http://http.debian.net/debian stretch-backports main\" | \\\n"
-            + "      sudo tee --append /etc/apt/sources.list > /dev/null\n"
-            + "apt-get -y update\n"
-            + "apt-get -y install -t stretch-backports openjdk-8-jdk\n"
-            + "update-java-alternatives -s java-1.8.0-openjdk-amd64\n"
-            + "/etc/init.d/ssh start";
-
     static final String PROJECT_ID = System.getenv("GOOGLE_PROJECT_ID");
     private static final String CREDENTIALS = loadCredentialsString();
     static final String CLOUD_NAME = "integration";
@@ -111,13 +106,9 @@ class ITUtil {
     private static final String CONFIG_DESC = "integration";
     private static final String BOOT_DISK_TYPE = ZONE_BASE + "/diskTypes/pd-ssd";
     private static final boolean BOOT_DISK_AUTODELETE = true;
-    private static final String BOOT_DISK_PROJECT_ID =
-            windows ? System.getenv("GOOGLE_BOOT_DISK_PROJECT_ID") : "debian-cloud";
-    private static final String BOOT_DISK_IMAGE_NAME = windows
-            ? String.format(
-                    "projects/%s/global/images/%s", BOOT_DISK_PROJECT_ID, System.getenv("GOOGLE_BOOT_DISK_IMAGE_NAME"))
-            : "projects/debian-cloud/global/images/family/debian-9";
-    private static final String BOOT_DISK_SIZE_GB_STR = windows ? "50" : "10";
+    private static final String BOOT_DISK_PROJECT_ID = bootDiskProject();
+    static final String BOOT_DISK_IMAGE_NAME = bootDiskImageName();
+    private static final String BOOT_DISK_SIZE_GB_STR = windows ? "50" : "20";
     private static final Node.Mode NODE_MODE = Node.Mode.EXCLUSIVE;
     private static final String ACCELERATOR_NAME = "";
     private static final String ACCELERATOR_COUNT = "";
@@ -134,30 +125,59 @@ class ITUtil {
     static final int SNAPSHOT_TIMEOUT = windows ? 600 : 300;
     private static final GoogleKeyCredential SSH_KEY = GoogleKeyPair.generate(RUN_AS_USER);
     static final String SSH_PRIVATE_KEY = Secret.toString(SSH_KEY.getPrivateKey());
-    private static final String WINDOWS_STARTUP_SCRIPT = "Stop-Service sshd\n"
-            + "$ConfiguredPublicKey = "
-            + "\""
-            + ((GoogleKeyPair) SSH_KEY).getPublicKey().trim().substring(RUN_AS_USER.length() + 1)
-            + "\"\n"
-            + "Write-Output \"Second phase\"\n"
-            + "# We are in the second phase of startup where we need to set up authorized_keys for the specified user.\n"
-            + "# Create the .ssh folder and authorized_keys file.\n"
-            + "Set-Content -Path $env:PROGRAMDATA\\ssh\\administrators_authorized_keys -Value $ConfiguredPublicKey\n"
-            + "icacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /inheritance:r\n"
-            + "icacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /grant SYSTEM:`(F`)\n"
-            + "icacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /grant BUILTIN\\Administrators:`(F`)\n"
-            + "Restart-Service sshd";
-    private static final String STARTUP_SCRIPT = windows ? WINDOWS_STARTUP_SCRIPT : DEB_JAVA_STARTUP_SCRIPT;
     static final int TEST_TIMEOUT_MULTIPLIER = (SystemUtils.IS_OS_WINDOWS || windows) ? 3 : 1;
     static final String CONFIG_AS_CODE_PATH =
             windows ? "configuration-as-code-windows-it.yml" : "configuration-as-code-it.yml";
-
     private static String windowsPrivateKeyCredentialsId;
     private static String customsshPrivateKeyCredentialsId;
 
     static String format(String s) {
         assertNotNull("GOOGLE_PROJECT_ID env var must be set", PROJECT_ID);
         return String.format(s, PROJECT_ID);
+    }
+
+    private static String bootDiskImageName() {
+        String projectId = System.getenv("GOOGLE_BOOT_DISK_PROJECT_ID");
+        if (projectId == null) {
+            projectId = PROJECT_ID;
+        }
+
+        String imageName = System.getenv("GOOGLE_BOOT_DISK_IMAGE_NAME");
+        if (imageName == null) {
+            imageName = "jenkins-gce-integration-test-jre"; /* Image built with packer, see the `setup-gce-image.sh` */
+        }
+
+        String imageFqn = String.format("projects/%s/global/images/%s", projectId, imageName);
+        log.info("Using boot disk image: " + imageFqn);
+
+        return imageFqn;
+    }
+
+    private static String bootDiskProject() {
+        String project = System.getenv("GOOGLE_BOOT_DISK_PROJECT_ID");
+        project = project != null ? project : PROJECT_ID;
+        log.info("Using boot disk project: " + project);
+        return project;
+    }
+
+    private static String startUpScript() {
+        if (!windows) { // there is no need for a startup script in linux
+            return "";
+        }
+
+        return "Stop-Service sshd\n"
+                + "$ConfiguredPublicKey = "
+                + "\""
+                + ((GoogleKeyPair) SSH_KEY).getPublicKey().trim().substring(RUN_AS_USER.length() + 1)
+                + "\"\n"
+                + "Write-Output \"Second phase\"\n"
+                + "# We are in the second phase of startup where we need to set up authorized_keys for the specified user.\n"
+                + "# Create the .ssh folder and authorized_keys file.\n"
+                + "Set-Content -Path $env:PROGRAMDATA\\ssh\\administrators_authorized_keys -Value $ConfiguredPublicKey\n"
+                + "icacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /inheritance:r\n"
+                + "icacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /grant SYSTEM:`(F`)\n"
+                + "icacls $env:PROGRAMDATA\\ssh\\administrators_authorized_keys /grant BUILTIN\\Administrators:`(F`)\n"
+                + "Restart-Service sshd";
     }
 
     private static String loadCredentialsString() {
@@ -278,7 +298,7 @@ class ITUtil {
                                         windows
                                                 ? METADATA_WINDOWS_STARTUP_SCRIPT_KEY
                                                 : METADATA_LINUX_STARTUP_SCRIPT_KEY)
-                                .setValue(STARTUP_SCRIPT),
+                                .setValue(startUpScript()),
                         new Metadata.Items()
                                 .setKey(InstanceConfiguration.SSH_METADATA_KEY)
                                 .setValue(((GoogleKeyPair) SSH_KEY).getPublicKey()))));
@@ -329,7 +349,7 @@ class ITUtil {
                 .mode(NODE_MODE)
                 .acceleratorConfiguration(new AcceleratorConfiguration(ACCELERATOR_NAME, ACCELERATOR_COUNT))
                 .runAsUser(RUN_AS_USER)
-                .startupScript(STARTUP_SCRIPT)
+                .startupScript(startUpScript())
                 .javaExecPath("java -Dhudson.remoting.Launcher.pingIntervalSec=-1");
     }
 
@@ -358,5 +378,27 @@ class ITUtil {
         } catch (Exception e) {
             log.warning(String.format("Error deleting instance %s: %s", instanceId, e.getMessage()));
         }
+    }
+
+    public static String printLogsAndGetAgentName(Object build) throws IOException {
+        List<String> logs;
+        if (build instanceof FreeStyleBuild) {
+            logs = ((FreeStyleBuild) build).getLog(1000);
+        } else if (build instanceof WorkflowRun) {
+            logs = ((WorkflowRun) build).getLog(1000);
+        } else {
+            throw new IllegalArgumentException("Unsupported build type");
+        }
+
+        String agentName = null;
+        for (String line : logs) {
+            if (line.contains("Building remotely on")) {
+                agentName = line.split(" ")[3];
+            } else if (line.contains("Running on")) {
+                agentName = line.split(" ")[2];
+            }
+            log.info(line);
+        }
+        return agentName;
     }
 }

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-it.yml
@@ -24,7 +24,6 @@ jenkins:
             machineType:        "https://www.googleapis.com/compute/v1/projects/${env.GOOGLE_PROJECT_ID}/zones/${env.GOOGLE_ZONE}/machineTypes/n1-standard-1"
             preemptible:        false
             minCpuPlatform:     '' # tried not setting, added when 'saved' in UI
-            startupScript:      "#!/bin/bash\n/etc/init.d/ssh stop\necho \"deb http://http.debian.net/debian stretch-backports main\" | \\\n      sudo tee --append /etc/apt/sources.list > /dev/null\napt-get -y update\napt-get -y install -t stretch-backports openjdk-8-jdk\nupdate-java-alternatives -s java-1.8.0-openjdk-amd64\n/etc/init.d/ssh start" 
             networkConfiguration:
               autofilled:
                 network:        default 
@@ -34,9 +33,9 @@ jenkins:
               singleStack:
                 externalIPV4Address:    true
             useInternalAddress: false
-            bootDiskSourceImageProject: debian-cloud
-            bootDiskSourceImageName: "projects/debian-cloud/global/images/family/debian-9"
+            bootDiskSourceImageProject: ${env.GOOGLE_PROJECT_ID}
+            bootDiskSourceImageName: "projects/${env.GOOGLE_PROJECT_ID}/global/images/jenkins-gce-integration-test-jre"
             bootDiskType:       "https://www.googleapis.com/compute/v1/projects/${env.GOOGLE_PROJECT_ID}/zones/${env.GOOGLE_ZONE}/diskTypes/pd-ssd"
-            bootDiskSizeGbStr:  10
+            bootDiskSizeGbStr:  20
             bootDiskAutoDelete: true
             serviceAccountEmail: "${env.GOOGLE_SA_NAME}@${env.GOOGLE_PROJECT_ID}.iam.gserviceaccount.com"

--- a/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-non-standard-java-it.yml
+++ b/src/test/resources/com/google/jenkins/plugins/computeengine/integration/configuration-as-code-non-standard-java-it.yml
@@ -23,7 +23,6 @@ jenkins:
             machineType:        "https://www.googleapis.com/compute/v1/projects/${env.GOOGLE_PROJECT_ID}/zones/${env.GOOGLE_ZONE}/machineTypes/n1-standard-1"
             preemptible:        false
             minCpuPlatform:     '' # tried not setting, added when 'saved' in UI
-            startupScript:      "#!/bin/bash\nsudo su-\n/etc/init.d/ssh stop\necho \"deb http://http.debian.net/debian stretch-backports main\" >> /etc/apt/sources.list\napt-get -y update\napt-get -y install -t stretch-backports openjdk-8-jdk\nupdate-java-alternatives -s java-1.8.0-openjdk-amd64\nln -s /usr/bin/java /usr/bin/non-standard-java\n/etc/init.d/ssh start"
             javaExecPath:       'non-standard-java'
             networkConfiguration:
               autofilled:
@@ -34,9 +33,9 @@ jenkins:
               singleStack:
                 externalIPV4Address:    true
             useInternalAddress: false
-            bootDiskSourceImageProject: debian-cloud
-            bootDiskSourceImageName: "projects/debian-cloud/global/images/family/debian-9"
+            bootDiskSourceImageProject: ${env.GOOGLE_PROJECT_ID}
+            bootDiskSourceImageName: "projects/${env.GOOGLE_PROJECT_ID}/global/images/jenkins-gce-integration-test-jre-non-standard-java"
             bootDiskType:       "https://www.googleapis.com/compute/v1/projects/${env.GOOGLE_PROJECT_ID}/zones/${env.GOOGLE_ZONE}/diskTypes/pd-ssd"
-            bootDiskSizeGbStr:  10
+            bootDiskSizeGbStr:  20
             bootDiskAutoDelete: true
             serviceAccountEmail: "${env.GOOGLE_SA_NAME}@${env.GOOGLE_PROJECT_ID}.iam.gserviceaccount.com"

--- a/testimages/linux/install-java.sh
+++ b/testimages/linux/install-java.sh
@@ -7,7 +7,7 @@ if [ -z "$AGENT_IMAGE" ]; then
   exit 1
 fi
 
-sudo apt-get update && sudo apt-get install openjdk-17-jre-headless -y && java -version
+sudo apt-get update && sudo apt-get install openjdk-21-jre-headless -y && java -version
 
 if [[ "$AGENT_IMAGE" == *non-standard-java ]]; then
   sudo mv /usr/bin/java /usr/bin/non-standard-java

--- a/testimages/linux/install-java.sh
+++ b/testimages/linux/install-java.sh
@@ -16,6 +16,7 @@ install_java() {
   apt-get update
   # jre is sufficient in the integration tests (jdk would be required if we are building a java projects inside the agent.)
   apt-get install -y temurin-21-jre
+  java -version
 
   if [[ "$AGENT_IMAGE" == *non-standard-java ]]; then
     sudo mv /usr/bin/java /usr/bin/non-standard-java

--- a/testimages/linux/install-java.sh
+++ b/testimages/linux/install-java.sh
@@ -7,9 +7,22 @@ if [ -z "$AGENT_IMAGE" ]; then
   exit 1
 fi
 
-sudo apt-get update && sudo apt-get install openjdk-21-jre-headless -y && java -version
+install_java() {
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y wget apt-transport-https gpg
+  wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+  echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+  apt-get update
+  # jre is sufficient in the integration tests (jdk would be required if we are building a java projects inside the agent.)
+  apt-get install -y temurin-21-jre
 
-if [[ "$AGENT_IMAGE" == *non-standard-java ]]; then
-  sudo mv /usr/bin/java /usr/bin/non-standard-java
-  /usr/bin/non-standard-java -version
-fi
+  if [[ "$AGENT_IMAGE" == *non-standard-java ]]; then
+    sudo mv /usr/bin/java /usr/bin/non-standard-java
+    /usr/bin/non-standard-java -version
+  fi
+}
+
+export -f install_java
+script_block_to_run="export AGENT_IMAGE=$AGENT_IMAGE; $(declare -f install_java); install_java;"
+sudo bash -c "$script_block_to_run"

--- a/testimages/linux/install-java.sh
+++ b/testimages/linux/install-java.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euxo pipefail
+
+echo "AGENT_IMAGE value is: $AGENT_IMAGE"
+if [ -z "$AGENT_IMAGE" ]; then
+  echo "AGENT_IMAGE variable is not set"
+  exit 1
+fi
+
+sudo apt-get update && sudo apt-get install openjdk-17-jre-headless -y && java -version
+
+if [[ "$AGENT_IMAGE" == *non-standard-java ]]; then
+  sudo mv /usr/bin/java /usr/bin/non-standard-java
+  /usr/bin/non-standard-java -version
+fi

--- a/testimages/linux/jre.pkr.hcl
+++ b/testimages/linux/jre.pkr.hcl
@@ -1,0 +1,46 @@
+# https://github.com/jenkinsci/google-compute-engine-plugin/pull/186#issuecomment-1664345279
+
+packer {
+  required_plugins {
+    googlecompute = {
+      version = ">= 1.1.1"
+      source = "github.com/hashicorp/googlecompute"
+    }
+  }
+}
+
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "zone" {
+  type = string
+}
+
+variable "agent_image" {
+    type = string
+}
+
+source "googlecompute" "base" {
+  project_id = var.project
+  zone = var.zone
+  image_storage_locations = [var.region]
+  source_image_project_id = ["debian-cloud"]
+  source_image_family = "debian-12"
+  image_name = var.agent_image
+  ssh_username = "jenkins"
+}
+
+build {
+  sources = ["sources.googlecompute.base"]
+  provisioner "shell" {
+    script = "./install-java.sh"
+    environment_vars = [
+      "AGENT_IMAGE=${var.agent_image}"
+    ]
+  }
+}

--- a/testimages/linux/setup-gce-image.sh
+++ b/testimages/linux/setup-gce-image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+project=${GOOGLE_PROJECT_ID:-$(gcloud config get-value core/project)}
+region=${GOOGLE_REGION:-$(gcloud config get-value compute/region)}
+zone=${GOOGLE_ZONE:-$(gcloud config get-value compute/zone)}
+
+current_dir=$(dirname "$0")
+pushd $current_dir
+
+agent_image="jenkins-gce-integration-test-jre"
+if [ "${1:-}" == "non-standard-java" ]; then
+  agent_image="${agent_image}-non-standard-java"
+  shift
+fi
+
+case "${1:-}" in
+  --recreate)
+    if gcloud compute images describe $agent_image; then
+      gcloud compute images delete $agent_image --project=$project --quiet
+    fi
+    ;;
+  --delete)
+    if gcloud compute images describe $agent_image; then
+      gcloud compute images delete $agent_image --project=$project --quiet
+      exit 0
+    fi
+    ;;
+esac
+
+if ! gcloud compute images describe $agent_image --project=$project; then
+  packer init ./
+  packer build -var project=$project -var region=$region -var zone=$zone -var agent_image=$agent_image ./
+  gcloud compute images describe $agent_image --project=$project
+fi
+
+popd


### PR DESCRIPTION
While I was trying to execute integration tests, as part of working on the https://github.com/jenkinsci/google-compute-engine-plugin/pull/492, I faced some issues with respect to infrastructures,
Such as,

* SA credential wasn't having project id, and thus failing in the tests (it was having random uuid)
* the test images were old and deprecated
* the java installation with startup command pattern was still allowing the ssh connection from Jenkins leading to test failure because the startup command hadn't completed
* as I was executing all the tests noticed that the logs seemed hanging because the build logs weren't printing to the terminal - so improved logging a bit.
* updates to the readme.
* Fixed the `jenkins.test.timeout` configurations.

This PR is containing some of these fixes I made and associated documentation and scripts.

All integration tests are working ✅

Infrastructure creation with Windows is also not working ❌ (because the windows-2016 image is not found in the mention location in the doc anymore; will check on that in next PR)

Addresses: https://github.com/jenkinsci/google-compute-engine-plugin/issues/189


### Test logs

<details>
<summary>All integration tests passed</summary>
  ```
  [INFO]  T E S T S
  [INFO] -------------------------------------------------------
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudNoSnapshotCreatedIT
  [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 151.1 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudNoSnapshotCreatedIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT
  [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 270.8 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudSnapshotCreatedIT
  [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 340.2 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudSnapshotCreatedIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT
  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 81.11 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloud1WorkerCreatedFor2ExecutorsIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeClientIT
  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.719 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeClientIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ConfigAsCodeTestIT
  [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 262.0 s -- in com.google.jenkins.plugins.computeengine.integration.ConfigAsCodeTestIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudMultipleLabelsIT
  [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 83.16 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudMultipleLabelsIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudTemplateNoGoogleLabelsIT
  [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 80.08 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudTemplateNoGoogleLabelsIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudNonStandardJavaIT
  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 149.1 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudNonStandardJavaIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudIgnoreProxyIT
  [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 434.9 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudIgnoreProxyIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudMultipleMatchingConfigurationsIT
  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.25 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudMultipleMatchingConfigurationsIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ConfigAsCodeNonStandardJavaIT
  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 75.78 s -- in com.google.jenkins.plugins.computeengine.integration.ConfigAsCodeNonStandardJavaIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerFailedIT
  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 41.79 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerFailedIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudRestartPreemptedIT
  [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 400.2 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudRestartPreemptedIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudTemplateIT
  [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 84.15 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudTemplateIT
  [INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudOneShotInstanceIT
  [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 256.5 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudOneShotInstanceIT
  [INFO]
  [INFO] Results:
  [INFO]
  [INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
  ```

</details>

--> Unit tests are already executing as part of CI


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
