### PR TITLE
Last refresh label should be put during VM provisioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Steps to execute integration test
 * Export these mandatory environment variable   
   ```bash
   export GOOGLE_PROJECT_ID=your-project-id
-  export GOOGLE_CREDENTIALS=/path/to/sa-key.json
+  export GOOGLE_CREDENTIALS_FILE=/path/to/sa-key.json
   export GOOGLE_REGION=us-central1
   export GOOGLE_ZONE=us-central1-a
   export GOOGLE_SA_NAME=jenkins-agent-sa

--- a/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/CleanLostNodesWork.java
@@ -56,7 +56,9 @@ public class CleanLostNodesWork extends PeriodicWork {
      * "The value can only contain lowercase letters, numeric characters, underscores and dashes.
      * The value can be at most 63 characters long. International characters are allowed".
      */
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy_MM_dd't'HH_mm_ss_SSS'z'");
+    @VisibleForTesting
+    public static final DateTimeFormatter LAST_REFRESH_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy_MM_dd't'HH_mm_ss_SSS'z'");
 
     /** {@inheritDoc} */
     @Override
@@ -65,7 +67,7 @@ public class CleanLostNodesWork extends PeriodicWork {
     }
 
     public static String getLastRefreshLabelVal() {
-        return formatter.format(OffsetDateTime.now(ZoneOffset.UTC));
+        return LAST_REFRESH_FORMATTER.format(OffsetDateTime.now(ZoneOffset.UTC));
     }
 
     /** {@inheritDoc} */
@@ -107,7 +109,7 @@ public class CleanLostNodesWork extends PeriodicWork {
             return false;
         }
         OffsetDateTime lastRefresh =
-                LocalDateTime.parse(nodeLastRefresh, formatter).atOffset(ZoneOffset.UTC);
+                LocalDateTime.parse(nodeLastRefresh, LAST_REFRESH_FORMATTER).atOffset(ZoneOffset.UTC);
         boolean isOrphan = lastRefresh
                 .plus(RECURRENCE_PERIOD * LOST_MULTIPLIER, ChronoUnit.MILLIS)
                 .isBefore(OffsetDateTime.now(ZoneOffset.UTC));

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -164,8 +164,6 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
 
                 // Apply a label that identifies the name of this instance configuration
                 configuration.appendLabel(CONFIG_LABEL_KEY, configuration.getNamePrefix());
-                configuration.appendLabel(
-                        CleanLostNodesWork.NODE_IN_USE_LABEL_KEY, CleanLostNodesWork.getLastRefreshLabelVal());
             }
         }
         setInstanceId(instanceId);

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -406,6 +406,13 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             }
         }
 
+        Map<String, String> effectiveGoogleLabels = new HashMap<>();
+        if (googleLabels != null) { // some tests don't set the labels, but comes as null
+            effectiveGoogleLabels.putAll(googleLabels);
+        }
+        effectiveGoogleLabels.put(
+                CleanLostNodesWork.NODE_IN_USE_LABEL_KEY, CleanLostNodesWork.getLastRefreshLabelVal());
+
         if (StringUtils.isNotEmpty(template)) {
             InstanceTemplate instanceTemplate =
                     cloud.getClient().getTemplate(nameFromSelfLink(cloud.getProjectId()), nameFromSelfLink(template));
@@ -420,23 +427,15 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                 instance.getMetadata().setItems(mergeMetadataItems(instanceItems, instanceTemplateItems));
             }
 
-            Map<String, String> mergedLabels = new HashMap<>(googleLabels);
             if (instanceTemplate.getProperties().getLabels() != null) {
                 Map<String, String> templateLabels =
                         instanceTemplate.getProperties().getLabels();
-                mergedLabels.putAll(templateLabels);
+                effectiveGoogleLabels.putAll(templateLabels);
             }
-            mergedLabels.put(CleanLostNodesWork.NODE_IN_USE_LABEL_KEY, CleanLostNodesWork.getLastRefreshLabelVal());
-            instance.setLabels(mergedLabels);
+            instance.setLabels(effectiveGoogleLabels);
         } else {
             configureStartupScript(instance);
-            Map<String, String> labelsWithLastRefresh = new HashMap<>();
-            if (googleLabels != null) { // some tests don't set the labels
-                labelsWithLastRefresh.putAll(googleLabels);
-            }
-            labelsWithLastRefresh.put(
-                    CleanLostNodesWork.NODE_IN_USE_LABEL_KEY, CleanLostNodesWork.getLastRefreshLabelVal());
-            instance.setLabels(labelsWithLastRefresh);
+            instance.setLabels(effectiveGoogleLabels);
             instance.setMachineType(stripSelfLinkPrefix(machineType));
             instance.setTags(tags());
             instance.setScheduling(scheduling());

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -426,10 +426,14 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                         instanceTemplate.getProperties().getLabels();
                 mergedLabels.putAll(templateLabels);
             }
+            mergedLabels.put(CleanLostNodesWork.NODE_IN_USE_LABEL_KEY, CleanLostNodesWork.getLastRefreshLabelVal());
             instance.setLabels(mergedLabels);
         } else {
             configureStartupScript(instance);
-            instance.setLabels(googleLabels);
+            var labelsWithLastRefresh = new HashMap<>(googleLabels);
+            labelsWithLastRefresh.put(
+                    CleanLostNodesWork.NODE_IN_USE_LABEL_KEY, CleanLostNodesWork.getLastRefreshLabelVal());
+            instance.setLabels(labelsWithLastRefresh);
             instance.setMachineType(stripSelfLinkPrefix(machineType));
             instance.setTags(tags());
             instance.setScheduling(scheduling());

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -430,7 +430,10 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             instance.setLabels(mergedLabels);
         } else {
             configureStartupScript(instance);
-            var labelsWithLastRefresh = new HashMap<>(googleLabels);
+            Map<String, String> labelsWithLastRefresh = new HashMap<>();
+            if (googleLabels != null) { // some tests don't set the labels
+                labelsWithLastRefresh.putAll(googleLabels);
+            }
             labelsWithLastRefresh.put(
                     CleanLostNodesWork.NODE_IN_USE_LABEL_KEY, CleanLostNodesWork.getLastRefreshLabelVal());
             instance.setLabels(labelsWithLastRefresh);

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -28,22 +28,32 @@ import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCl
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfigurationBuilder;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.Metadata;
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
 import com.google.common.collect.ImmutableList;
+import com.google.jenkins.plugins.computeengine.CleanLostNodesWork;
 import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
 import com.google.jenkins.plugins.computeengine.InstanceConfiguration;
 import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.AfterClass;
@@ -139,5 +149,64 @@ public class ComputeEngineCloudWorkerCreatedIT {
         Node node = jenkinsRule.jenkins.getNodes().get(0);
         var instance = client.getInstance(PROJECT_ID, ZONE, node.getNodeName());
         jenkinsRule.assertLogContains("Running on " + instance.getName(), r);
+    }
+
+    @Test
+    public void testWorkerCreatedWithLatestLastRefresh() throws Exception {
+        // create node without running any job
+        var planned = cloud.provision(new LabelAtom(LABEL), 1);
+        planned.iterator().next().future.get();
+        var instance = client.getInstance(PROJECT_ID, ZONE, planned.iterator().next().displayName);
+        var lastRefreshInstance1 = getLastRefresh(instance);
+        // remove the node from jenkins
+        Jenkins.get().removeNode(Jenkins.get().getNode(instance.getName()));
+
+        // run a job, creates another instance
+        var p = jenkinsRule.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("node('" + LABEL + "') { sh 'date' }", true));
+        var r = jenkinsRule.buildAndAssertSuccess(p);
+        assertEquals(1, jenkinsRule.jenkins.getNodes().size());
+        var instance2 = client.getInstance(
+                PROJECT_ID, ZONE, jenkinsRule.jenkins.getNodes().get(0).getNodeName());
+        assertNotEquals(instance.getName(), instance2.getName());
+        var lastRefreshInstance2 = getLastRefresh(instance2);
+        assertThat(lastRefreshInstance2, isAfter(lastRefreshInstance1));
+
+        // stop the instance
+        Jenkins.get().removeNode(Jenkins.get().getNode(instance2.getName()));
+
+        // create one more instance manually
+        planned = cloud.provision(new LabelAtom(LABEL), 1);
+        planned.iterator().next().future.get();
+        var instance3 = client.getInstance(PROJECT_ID, ZONE, planned.iterator().next().displayName);
+        var lastRefreshInstance3 = getLastRefresh(instance3);
+        assertThat(lastRefreshInstance3, isAfter(lastRefreshInstance2));
+    }
+
+    private OffsetDateTime getLastRefresh(Instance instance) {
+        return LocalDateTime.parse(
+                        instance.getLabels().get(CleanLostNodesWork.NODE_IN_USE_LABEL_KEY),
+                        CleanLostNodesWork.LAST_REFRESH_FORMATTER)
+                .atOffset(ZoneOffset.UTC);
+    }
+
+    // Custom isAfter matcher for OffsetDateTime
+    public static TypeSafeMatcher<OffsetDateTime> isAfter(OffsetDateTime expected) {
+        return new TypeSafeMatcher<>() {
+            @Override
+            protected boolean matchesSafely(OffsetDateTime actual) {
+                return actual.isAfter(expected);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("a date-time that is after ").appendValue(expected);
+            }
+
+            @Override
+            protected void describeMismatchSafely(OffsetDateTime actual, Description mismatchDescription) {
+                mismatchDescription.appendText("was ").appendValue(actual);
+            }
+        };
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -62,6 +62,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /**
@@ -151,6 +152,7 @@ public class ComputeEngineCloudWorkerCreatedIT {
         jenkinsRule.assertLogContains("Running on " + instance.getName(), r);
     }
 
+    @Issue("https://github.com/jenkinsci/google-compute-engine-plugin/issues/512")
     @Test
     public void testWorkerCreatedWithLatestLastRefresh() throws Exception {
         // create node without running any job

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudWorkerCreatedIT.java
@@ -56,9 +56,10 @@ import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -74,10 +75,10 @@ public class ComputeEngineCloudWorkerCreatedIT {
     private static final Logger log = Logger.getLogger(ComputeEngineCloudWorkerCreatedIT.class.getName());
 
     @ClassRule
-    public static Timeout timeout = new Timeout(10L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+    public static Timeout timeout = new Timeout(15L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
 
-    @ClassRule
-    public static JenkinsRule jenkinsRule = new JenkinsRule();
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
 
     @ClassRule
     public static BuildWatcher bw = new BuildWatcher();
@@ -87,8 +88,8 @@ public class ComputeEngineCloudWorkerCreatedIT {
     private static final Map<String, String> label = getLabel(ComputeEngineCloudWorkerCreatedIT.class);
     private static InstanceConfiguration instanceConfiguration;
 
-    @BeforeClass
-    public static void init() throws Exception {
+    @Before
+    public void init() throws Exception {
         log.info("init");
         initCredentials(jenkinsRule);
         cloud = initCloud(jenkinsRule);
@@ -107,8 +108,8 @@ public class ComputeEngineCloudWorkerCreatedIT {
         cloud.setConfigurations(ImmutableList.of(instanceConfiguration));
     }
 
-    @AfterClass
-    public static void teardown() throws IOException {
+    @After
+    public void teardown() throws IOException {
         teardownResources(client, label, log);
     }
 
@@ -120,7 +121,12 @@ public class ComputeEngineCloudWorkerCreatedIT {
                 .getInstance(PROJECT_ID, ZONE, planned.iterator().next().displayName);
 
         assertEquals("one instance should be provisioned", 1, planned.size());
-        assertEquals("GCP VM should have 3 labels", 3, instance.getLabels().size());
+        /* There are 5 labels,
+         * actual code: jenkins_cloud_id, jenkins_config_name, jenkins_node_last_refresh
+         * test code: <current class name>, user
+         * Total 5 labels here.
+         * */
+        assertEquals("GCP VM should have 5 labels", 5, instance.getLabels().size());
         assertEquals(
                 "GCP VM name starts with the prefix configured",
                 instanceConfiguration.getNamePrefix(),


### PR DESCRIPTION
**Problem**
The [PR #503](https://github.com/jenkinsci/google-compute-engine-plugin/pull/503) introduced a bug in the CleanLostNodesWork logic, where the jenkins_last_refresh_time value became static as a result of being stored in the instance configuration. This issue can be observed in the following code snippet:

https://github.com/jenkinsci/google-compute-engine-plugin/blob/03300ceb5e7e9a67f41fd886f76260a6c85a8263/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java#L167-L168

Due to this behavior, the `jenkins_last_refresh_time` value remains unchanged for newly provisioned VMs. It only updates when a new configuration is created or an existing configuration is reloaded. Once a configuration has been initialized, the `jenkins_last_refresh_time` remains static until the controller is restarted.

This creates a significant problem in scenarios where multiple Jenkins controllers are connected to the same GCP project. In such cases, both controllers will misinterpret agent nodes created by the other and attempt to terminate them, leading to unexpected and undesirable behavior.

**Discovery**
This problem was discovered by https://github.com/jenkinsci/google-compute-engine-plugin/issues/512, (thanks to @russtaylor for discovering and debugging the issue).

**Fix proposed**

The submitted test is able to reproduce the issue and demonstrates the fix,

<details>
<summary>logs showing test failure before the fix</summary>

```
[INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT
Jan 31, 2025 12:09:17 PM com.google.jenkins.plugins.computeengine.integration.ITUtil bootDiskProject
INFO: Using boot disk project: tiger-team-testing
Jan 31, 2025 12:09:17 PM com.google.jenkins.plugins.computeengine.integration.ITUtil bootDiskImageName
INFO: Using boot disk image: projects/tiger-team-testing/global/images/jenkins-gce-integration-test-jre
=== Starting com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT
   0.043 [id=25]	INFO	o.jvnet.hudson.test.WarExploder#explode: Exploding /Users/gbhat/.m2/repository/org/jenkins-ci/main/jenkins-war/2.452.3/jenkins-war-2.452.3.war into /Users/gbhat/CBProjects/google-compute-engine-plugin/target/jenkins-for-test
   1.386 [id=25]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:62436/jenkins/
   1.610 [id=40]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   2.323 [id=47]	WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/powershell/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
   2.335 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/matrix-auth.jpi
   2.358 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/echarts-api.jpi
   2.633 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/junit.jpi
   2.642 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/jquery3-api.jpi
   2.650 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/matrix-project.jpi
   2.661 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/checks-api.jpi
   2.669 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/command-launcher.jpi
   2.675 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/jdk-tool.jpi
   2.685 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/mina-sshd-api-common.jpi
   2.697 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/mina-sshd-api-core.jpi
   2.709 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/sshd.jpi
   2.718 [id=47]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins17782272699792266921/plugins/javax-mail-api.jpi
   3.007 [id=41]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   3.016 [id=55]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/google-compute-engine-plugin/target/tmp/j h6090961780737304770/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   3.911 [id=44]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   3.915 [id=59]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   3.916 [id=53]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   4.636 [id=39]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   4.669 [id=39]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   4.669 [id=59]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   4.672 [id=39]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   4.749 [id=46]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   4.798 [id=25]	INFO	c.g.j.p.c.i.ComputeEngineCloudWorkerCreatedIT#init: init
  13.713 [id=25]	INFO	c.g.j.p.c.integration.ITUtil#deleteIntegrationInstances: Cleaning up old instances; found 0 instances to delete, it may take a while for this deletion
  20.916 [id=25]	INFO	c.g.j.p.c.ComputeEngineCloud#provision: Provisioning node from configs [com.google.jenkins.plugins.computeengine.InstanceConfiguration@4f895bdc] for excess workload of 1 units of label 'integration'
  22.302 [id=25]	INFO	c.g.j.p.c.ComputeEngineCloud#availableNodeCapacity: Found capacity for 10 nodes in cloud integration
  22.307 [id=25]	INFO	c.g.j.p.c.InstanceConfiguration#instance: User selected to use an autogenerated ssh key pair
  24.787 [id=25]	INFO	c.g.j.p.c.InstanceConfiguration#provision: Sent insert request for instance configuration [integration]
  24.809 [id=107]	INFO	c.g.j.p.c.ComputeEngineComputerLauncher#launch: Launch will wait 300000 for operation operation-1738305582733-62cfacec5174c-953cb00d-ae9037d5 to complete...
  24.831 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: Waiting 300000ms for node integration-e82g0j to connect
  39.849 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching instance: integration-e82g0j
  39.850 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: bootstrap
  39.851 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Getting keypair...
  39.853 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Using autogenerated ssh keypair
  39.854 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Authenticating as jenkins
  41.344 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 34.23.188.98 on port 22, with timeout 10000.
  46.636 [id=107]	WARNING	c.g.j.p.c.ComputeEngineCloud#log: An error occured: There was a problem while connecting to 34.23.188.98:22
  53.250 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 34.23.188.98 on port 22, with timeout 10000.
  56.327 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connected via SSH.
  57.424 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Verifying: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -fullversion
  58.278 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Copying agent.jar to: /tmp
  61.382 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching Jenkins agent via plugin SSH: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -jar /tmp/agent.jar
  88.381 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: 63550ms elapsed waiting for node integration-e82g0j to connect
  90.057 [p #1] Started
  90.331 [p #1] [Pipeline] Start of Pipeline
  90.386 [p #1] [Pipeline] node
 104.708 [id=70]	INFO	c.g.j.p.c.ComputeEngineCloud#provision: Provisioning node from configs [com.google.jenkins.plugins.computeengine.InstanceConfiguration@4f895bdc] for excess workload of 1 units of label 'integration'
 105.439 [p #1] Still waiting to schedule task
 105.440 [p #1] ‘Jenkins’ doesn’t have label ‘integration’
 105.589 [id=70]	INFO	c.g.j.p.c.ComputeEngineCloud#availableNodeCapacity: Found capacity for 9 nodes in cloud integration
 105.589 [id=70]	INFO	c.g.j.p.c.InstanceConfiguration#instance: User selected to use an autogenerated ssh key pair
 107.899 [id=70]	INFO	c.g.j.p.c.InstanceConfiguration#provision: Sent insert request for instance configuration [integration]
 107.904 [id=110]	INFO	c.g.j.p.c.ComputeEngineComputerLauncher#launch: Launch will wait 300000 for operation operation-1738305665976-62cfad3bb4a51-bb6be045-ae145013 to complete...
 107.926 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: Waiting 300000ms for node integration-lo23zu to connect
 107.927 [id=70]	INFO	h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning integration-lo23zu from gce-integration with 1 executors. Remaining excess workload: 0
 130.582 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching instance: integration-lo23zu
 130.585 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: bootstrap
 130.585 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Getting keypair...
 130.586 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Using autogenerated ssh keypair
 130.586 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Authenticating as jenkins
 132.068 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 35.196.251.234 on port 22, with timeout 10000.
 132.338 [id=110]	WARNING	c.g.j.p.c.ComputeEngineCloud#log: An error occured: There was a problem while connecting to 35.196.251.234:22
 138.899 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 35.196.251.234 on port 22, with timeout 10000.
 141.836 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connected via SSH.
 142.952 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Verifying: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -fullversion
 143.827 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Copying agent.jar to: /tmp
 146.919 [id=110]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching Jenkins agent via plugin SSH: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -jar /tmp/agent.jar
 171.764 [id=107]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: 63838ms elapsed waiting for node integration-lo23zu to connect
 173.966 [p #1] Running on integration-lo23zu in /tmp/workspace/p
 173.966 [p #1] [Pipeline] {
 174.021 [p #1] [Pipeline] sh
 228.666 [p #1] + date
 228.668 [p #1] Fri Jan 31 06:43:01 UTC 2025
 229.741 [p #1] [Pipeline] }
 229.797 [p #1] [Pipeline] // node
 229.798 [p #1] [Pipeline] End of Pipeline
 229.865 [p #1] Finished: SUCCESS
 278.070 [id=25]	INFO	c.g.j.p.c.integration.ITUtil#teardownResources: teardown
 279.391 [id=25]	INFO	c.g.j.p.c.integration.ITUtil#deleteIntegrationInstances: Cleaning up old instances; found 2 instances to delete, it may take a while for this deletion
 279.391 [id=25]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deleting instance: integration-e82g0j
 280.042 [id=25]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deleting instance: integration-lo23zu
 282.088 [id=25]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
 282.135 [id=25]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
 282.177 [id=25]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/google-compute-engine-plugin/target/tmp/j h6090961780737304770
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 283.1 s <<< FAILURE! -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT
[ERROR] com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT.testWorkerCreatedWithLatestLastRefresh -- Time elapsed: 257.2 s <<< FAILURE!
java.lang.AssertionError:

Expected: a date-time that is after <2025-01-31T06:39:32.627Z>
     but: was <2025-01-31T06:39:32.627Z>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT.testWorkerCreatedWithLatestLastRefresh(ComputeEngineCloudWorkerCreatedIT.java:176)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:655)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:833)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   ComputeEngineCloudWorkerCreatedIT.testWorkerCreatedWithLatestLastRefresh:176
Expected: a date-time that is after <2025-01-31T06:39:32.627Z>
     but: was <2025-01-31T06:39:32.627Z>
[INFO]
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
</details>

<details>
<summary>logs showing test succeeding after the fix</summary>

```
[INFO] Running com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT
Jan 31, 2025 12:39:16 PM com.google.jenkins.plugins.computeengine.integration.ITUtil bootDiskProject
INFO: Using boot disk project: tiger-team-testing
Jan 31, 2025 12:39:16 PM com.google.jenkins.plugins.computeengine.integration.ITUtil bootDiskImageName
INFO: Using boot disk image: projects/tiger-team-testing/global/images/jenkins-gce-integration-test-jre
=== Starting com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT
   0.036 [id=21]	INFO	o.jvnet.hudson.test.WarExploder#explode: Exploding /Users/gbhat/.m2/repository/org/jenkins-ci/main/jenkins-war/2.452.3/jenkins-war-2.452.3.war into /Users/gbhat/CBProjects/google-compute-engine-plugin/target/jenkins-for-test
   1.139 [id=21]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:49187/jenkins/
   1.328 [id=36]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
   1.932 [id=35]	WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/powershell/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
   1.944 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/matrix-auth.jpi
   1.964 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/echarts-api.jpi
   2.182 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/junit.jpi
   2.190 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/jquery3-api.jpi
   2.197 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/matrix-project.jpi
   2.207 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/checks-api.jpi
   2.214 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/command-launcher.jpi
   2.220 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/jdk-tool.jpi
   2.230 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/mina-sshd-api-common.jpi
   2.243 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/mina-sshd-api-core.jpi
   2.255 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/sshd.jpi
   2.263 [id=35]	INFO	hudson.PluginManager#considerDetachedPlugin: Loading a detached plugin as a dependency: /var/folders/80/w8mmdy513sb3y9fp5fr7vvqc0000gn/T/jenkins12492434977062588232/plugins/javax-mail-api.jpi
   2.530 [id=45]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
   2.537 [id=50]	INFO	j.b.api.BouncyCastlePlugin#start: /Users/gbhat/CBProjects/google-compute-engine-plugin/target/tmp/j h3669180892468087546/plugins/bouncycastle-api/WEB-INF/optional-lib not found; for non RealJenkinsRule this is fine and can be ignored.
   3.359 [id=40]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
   3.363 [id=53]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
   3.364 [id=41]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
   3.640 [id=38]	INFO	jenkins.InitReactorRunner$1#onAttained: System config loaded
   3.669 [id=38]	INFO	jenkins.InitReactorRunner$1#onAttained: System config adapted
   3.670 [id=43]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
   3.672 [id=42]	INFO	jenkins.InitReactorRunner$1#onAttained: Configuration for all jobs updated
   3.740 [id=48]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
   3.790 [id=21]	INFO	c.g.j.p.c.i.ComputeEngineCloudWorkerCreatedIT#init: init
   5.551 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#deleteIntegrationInstances: Cleaning up old instances; found 2 instances to delete, it may take a while for this deletion
   5.551 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deleting instance: integration-77w2lg
  59.096 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deletion complete
  59.102 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deleting instance: integration-pss5xo
 117.571 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deletion complete
 117.612 [id=21]	INFO	c.g.j.p.c.ComputeEngineCloud#provision: Provisioning node from configs [com.google.jenkins.plugins.computeengine.InstanceConfiguration@7ae5e6d3] for excess workload of 1 units of label 'integration'
 118.837 [id=21]	INFO	c.g.j.p.c.ComputeEngineCloud#availableNodeCapacity: Found capacity for 10 nodes in cloud integration
 118.841 [id=21]	INFO	c.g.j.p.c.InstanceConfiguration#instance: User selected to use an autogenerated ssh key pair
 120.317 [id=21]	INFO	c.g.j.p.c.InstanceConfiguration#provision: Sent insert request for instance configuration [integration]
 120.351 [id=133]	INFO	c.g.j.p.c.ComputeEngineComputerLauncher#launch: Launch will wait 300000 for operation operation-1738307476002-62cfb3f9e1826-9170f5ee-ba115e44 to complete...
 120.383 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: Waiting 300000ms for node integration-dqzi1f to connect
 141.835 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching instance: integration-dqzi1f
 141.836 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: bootstrap
 141.836 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Getting keypair...
 141.837 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Using autogenerated ssh keypair
 141.838 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Authenticating as jenkins
 143.334 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 34.73.57.240 on port 22, with timeout 10000.
 144.627 [id=133]	WARNING	c.g.j.p.c.ComputeEngineCloud#log: An error occured: There was a problem while connecting to 34.73.57.240:22
 151.278 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 34.73.57.240 on port 22, with timeout 10000.
 153.135 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connected via SSH.
 154.342 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Verifying: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -fullversion
 155.193 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Copying agent.jar to: /tmp
 158.813 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching Jenkins agent via plugin SSH: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -jar /tmp/agent.jar
 184.480 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: 64097ms elapsed waiting for node integration-dqzi1f to connect
 186.148 [p #1] Started
 186.365 [p #1] [Pipeline] Start of Pipeline
 186.476 [p #1] [Pipeline] node
 193.687 [id=62]	INFO	c.g.j.p.c.ComputeEngineCloud#provision: Provisioning node from configs [com.google.jenkins.plugins.computeengine.InstanceConfiguration@7ae5e6d3] for excess workload of 1 units of label 'integration'
 194.908 [id=62]	INFO	c.g.j.p.c.ComputeEngineCloud#availableNodeCapacity: Found capacity for 9 nodes in cloud integration
 194.910 [id=62]	INFO	c.g.j.p.c.InstanceConfiguration#instance: User selected to use an autogenerated ssh key pair
 197.471 [id=62]	INFO	c.g.j.p.c.InstanceConfiguration#provision: Sent insert request for instance configuration [integration]
 197.473 [id=136]	INFO	c.g.j.p.c.ComputeEngineComputerLauncher#launch: Launch will wait 300000 for operation operation-1738307553054-62cfb4435cf55-a3f19555-fb096871 to complete...
 197.483 [id=62]	INFO	h.s.NodeProvisioner$StandardStrategyImpl#apply: Started provisioning integration-86l1b3 from gce-integration with 1 executors. Remaining excess workload: 0
 197.488 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: Waiting 300000ms for node integration-86l1b3 to connect
 201.498 [p #1] Still waiting to schedule task
 201.499 [p #1] ‘integration-86l1b3’ is offline
 219.055 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching instance: integration-86l1b3
 219.057 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: bootstrap
 219.058 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Getting keypair...
 219.059 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Using autogenerated ssh keypair
 219.060 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Authenticating as jenkins
 220.531 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 34.23.188.98 on port 22, with timeout 10000.
 221.793 [id=136]	WARNING	c.g.j.p.c.ComputeEngineCloud#log: An error occured: There was a problem while connecting to 34.23.188.98:22
 228.345 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 34.23.188.98 on port 22, with timeout 10000.
 231.296 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connected via SSH.
 232.419 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Verifying: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -fullversion
 233.269 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Copying agent.jar to: /tmp
 236.468 [id=136]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching Jenkins agent via plugin SSH: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -jar /tmp/agent.jar
 262.735 [id=133]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: 65251ms elapsed waiting for node integration-86l1b3 to connect
 264.957 [p #1] Running on integration-86l1b3 in /tmp/workspace/p
 264.958 [p #1] [Pipeline] {
 265.061 [p #1] [Pipeline] sh
 317.852 [p #1] + date
 317.853 [p #1] Fri Jan 31 07:14:28 UTC 2025
 319.001 [p #1] [Pipeline] }
 319.056 [p #1] [Pipeline] // node
 319.057 [p #1] [Pipeline] End of Pipeline
 319.111 [p #1] Finished: SUCCESS
 320.770 [id=21]	INFO	c.g.j.p.c.ComputeEngineCloud#provision: Provisioning node from configs [com.google.jenkins.plugins.computeengine.InstanceConfiguration@7ae5e6d3] for excess workload of 1 units of label 'integration'
 320.780 [id=155]	INFO	hudson.remoting.Request$2#run: Failed to send back a reply to the request RPCRequest:hudson.remoting.RemoteClassLoader$IClassLoader.fetch3[java.lang.String](2): hudson.remoting.ChannelClosedException: Channel "hudson.remoting.Channel@14eed563:integration-86l1b3": channel is already closed
 321.569 [id=21]	INFO	c.g.j.p.c.ComputeEngineCloud#availableNodeCapacity: Found capacity for 8 nodes in cloud integration
 321.569 [id=21]	INFO	c.g.j.p.c.InstanceConfiguration#instance: User selected to use an autogenerated ssh key pair
 324.227 [id=21]	INFO	c.g.j.p.c.InstanceConfiguration#provision: Sent insert request for instance configuration [integration]
 324.229 [id=154]	INFO	c.g.j.p.c.ComputeEngineComputerLauncher#launch: Launch will wait 300000 for operation operation-1738307679735-62cfb4bc2ce82-93336a2b-4dfc4371 to complete...
 324.243 [id=155]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: Waiting 300000ms for node integration-x4mkoh to connect
 340.343 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching instance: integration-x4mkoh
 340.344 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: bootstrap
 340.345 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Getting keypair...
 340.345 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Using autogenerated ssh keypair
 340.346 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Authenticating as jenkins
 341.829 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 35.196.251.234 on port 22, with timeout 10000.
 343.091 [id=154]	WARNING	c.g.j.p.c.ComputeEngineCloud#log: An error occured: There was a problem while connecting to 35.196.251.234:22
 349.637 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connecting to 35.196.251.234 on port 22, with timeout 10000.
 351.473 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Connected via SSH.
 352.572 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Verifying: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -fullversion
 353.439 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Copying agent.jar to: /tmp
 356.599 [id=154]	INFO	c.g.j.p.c.ComputeEngineCloud#log: Launching Jenkins agent via plugin SSH: java -Dhudson.remoting.Launcher.pingIntervalSec=-1 -jar /tmp/agent.jar
 382.386 [id=155]	INFO	c.g.j.p.c.ComputeEngineCloud#lambda$getPlannedNodeFuture$0: 58143ms elapsed waiting for node integration-x4mkoh to connect
 382.921 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#teardownResources: teardown
 384.108 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#deleteIntegrationInstances: Cleaning up old instances; found 3 instances to delete, it may take a while for this deletion
 384.109 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deleting instance: integration-86l1b3
 385.805 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deleting instance: integration-dqzi1f
 386.440 [id=21]	INFO	c.g.j.p.c.integration.ITUtil#safeDelete: deleting instance: integration-x4mkoh
 388.458 [id=21]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Stopping Jenkins
 388.523 [id=21]	INFO	hudson.lifecycle.Lifecycle#onStatusUpdate: Jenkins stopped
 388.625 [id=21]	INFO	o.j.h.t.TemporaryDirectoryAllocator#dispose: deleting /Users/gbhat/CBProjects/google-compute-engine-plugin/target/tmp/j h3669180892468087546
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 389.2 s -- in com.google.jenkins.plugins.computeengine.integration.ComputeEngineCloudWorkerCreatedIT
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```
</details>


**Additional manual testing**

<details><summary>before</summary>

before shows difference of 30min between VM creation to jenkins_node_last_refresh
```bash
gcloud compute instances list --format="table(name,creationTimestamp.date(tz=UTC),labels.jenkins_node_last_refresh)"

NAME                                                 CREATION_TIMESTAMP   JENKINS_NODE_LAST_REFRESH
xxxx-xx-xxx-gbhat-11989-gce-66mjj6                   2025-01-31T09:47:53  2025_01_31t09_13_44_383z
```
</details>

<details>
<summary>After</summary>

There is 1-2 second difference between GCP vm creation and the value computed by the plugin.
As the plugin computes the `jenkins_node_last_refresh` and then sends an API request to GCP, the `jenkins_node_last_refresh` is older by 1-2 seconds. But should never be more than this API delay..

example1 (difference 2 seconds)
```bash
gcloud compute instances list --format="table(name,creationTimestamp.date(tz=UTC),labels.jenkins_node_last_refresh)"

NAME                                                 CREATION_TIMESTAMP   JENKINS_NODE_LAST_REFRESH
xxxx-xx-xxx-gbhat-5223-gce-ptvnhg                    2025-01-31T10:38:25  2025_01_31t10_38_23_683z
```


example2 (difference 1 seconds)
```bash
gcloud compute instances list --format="table(name,creationTimestamp.date(tz=UTC),labels.jenkins_node_last_refresh)"

NAME                                                 CREATION_TIMESTAMP   JENKINS_NODE_LAST_REFRESH
xxxx-xxx-xxx-gbhat-5223-gce-ar1vwz                    2025-01-31T10:41:52  2025_01_31t10_41_51_398z
```


example3 (difference 1 seconds)
```bash
gcloud compute instances list --format="table(name,creationTimestamp.date(tz=UTC),labels.jenkins_node_last_refresh)"

NAME                                                 CREATION_TIMESTAMP   JENKINS_NODE_LAST_REFRESH
xxxx-xx-xxx-gbhat-5223-gce-zjucpe                    2025-01-31T10:45:04  2025_01_31t10_45_03_545z
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
