### PR TITLE
Make bootstrap auth params configurable via system property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.516</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     <skipITs>true</skipITs>
     <it.windows>false</it.windows>
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3893.v213a_42768d35</version>
+        <version>6166.va_a_8b_5eda_8ef5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -43,7 +43,6 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -85,13 +84,12 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
      * Applies to both Linux and Windows launchers.
      * <p>
      * Configurable via system property {@code com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthSleepDuration}.
-     * Bare numeric values are interpreted as seconds. Default: {@code 15s}.
+     * Default: {@code 15s}.
      *
      * @see #BOOTSTRAP_AUTH_TRIES
      */
     protected static final Duration BOOTSTRAP_AUTH_SLEEP_DURATION = SystemProperties.getDuration(
             ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthSleepDuration",
-            ChronoUnit.SECONDS,
             Duration.ofSeconds(15));
 
     @Getter

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -49,6 +49,7 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import lombok.Getter;
 
 public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
@@ -65,6 +66,28 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
     private final String insertOperationId;
     private final String zone;
     private final String cloudName;
+
+    /**
+     * Maximum number of SSH authentication attempts before giving up.
+     * Applies to both Linux and Windows launchers.
+     * <p>
+     * Configurable via system property {@code com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthTries}. Default: {@code 30}.
+     *
+     * @see #BOOT_STRAP_AUTH_SLEEP_MS
+     */
+    protected static final int BOOT_STRAP_AUTH_TRIES =
+            SystemProperties.getInteger(ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthTries", 30);
+
+    /**
+     * Delay in milliseconds between SSH authentication retries.
+     * Applies to both Linux and Windows launchers.
+     * <p>
+     * Configurable via system property {@code com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthSleepMs}. Default: {@code 15000}.
+     *
+     * @see #BOOT_STRAP_AUTH_TRIES
+     */
+    protected static final int BOOT_STRAP_AUTH_SLEEP_MS =
+            SystemProperties.getInteger(ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthSleepMs", 15000);
 
     @Getter
     protected final boolean useInternalAddress;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -42,6 +42,8 @@ import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -73,21 +75,24 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
      * <p>
      * Configurable via system property {@code com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthTries}. Default: {@code 30}.
      *
-     * @see #BOOTSTRAP_AUTH_SLEEP_MS
+     * @see #BOOTSTRAP_AUTH_SLEEP_DURATION
      */
     protected static final int BOOTSTRAP_AUTH_TRIES =
             SystemProperties.getInteger(ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthTries", 30);
 
     /**
-     * Delay in milliseconds between SSH authentication retries.
+     * Delay between SSH authentication retries.
      * Applies to both Linux and Windows launchers.
      * <p>
-     * Configurable via system property {@code com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthSleepMs}. Default: {@code 15000}.
+     * Configurable via system property {@code com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthSleepDuration}.
+     * Bare numeric values are interpreted as seconds. Default: {@code 15s}.
      *
      * @see #BOOTSTRAP_AUTH_TRIES
      */
-    protected static final int BOOTSTRAP_AUTH_SLEEP_MS =
-            SystemProperties.getInteger(ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthSleepMs", 15000);
+    protected static final Duration BOOTSTRAP_AUTH_SLEEP_DURATION = SystemProperties.getDuration(
+            ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthSleepDuration",
+            ChronoUnit.SECONDS,
+            Duration.ofSeconds(15));
 
     @Getter
     protected final boolean useInternalAddress;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -89,8 +89,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
      * @see #BOOTSTRAP_AUTH_TRIES
      */
     protected static final Duration BOOTSTRAP_AUTH_SLEEP_DURATION = SystemProperties.getDuration(
-            ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthSleepDuration",
-            Duration.ofSeconds(15));
+            ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthSleepDuration", Duration.ofSeconds(15));
 
     @Getter
     protected final boolean useInternalAddress;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -73,9 +73,9 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
      * <p>
      * Configurable via system property {@code com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthTries}. Default: {@code 30}.
      *
-     * @see #BOOT_STRAP_AUTH_SLEEP_MS
+     * @see #BOOTSTRAP_AUTH_SLEEP_MS
      */
-    protected static final int BOOT_STRAP_AUTH_TRIES =
+    protected static final int BOOTSTRAP_AUTH_TRIES =
             SystemProperties.getInteger(ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthTries", 30);
 
     /**
@@ -84,9 +84,9 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
      * <p>
      * Configurable via system property {@code com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthSleepMs}. Default: {@code 15000}.
      *
-     * @see #BOOT_STRAP_AUTH_TRIES
+     * @see #BOOTSTRAP_AUTH_TRIES
      */
-    protected static final int BOOT_STRAP_AUTH_SLEEP_MS =
+    protected static final int BOOTSTRAP_AUTH_SLEEP_MS =
             SystemProperties.getInteger(ComputeEngineComputerLauncher.class.getName() + ".bootstrapAuthSleepMs", 15000);
 
     @Getter

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -69,7 +69,7 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
         }
         Connection bootstrapConn = null;
         try {
-            int tries = BOOT_STRAP_AUTH_TRIES;
+            int tries = BOOTSTRAP_AUTH_TRIES;
             boolean isAuthenticated = false;
             if (keyCred instanceof GoogleKeyPair) {
                 logInfo(computer, listener, "Getting keypair...");
@@ -99,7 +99,7 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
                     break;
                 }
                 logWarning(computer, listener, "Authentication failed. Trying again...");
-                Thread.sleep(BOOT_STRAP_AUTH_SLEEP_MS);
+                Thread.sleep(BOOTSTRAP_AUTH_SLEEP_MS);
             }
             if (!isAuthenticated) {
                 logWarning(computer, listener, "Authentication failed");

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -99,7 +99,7 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
                     break;
                 }
                 logWarning(computer, listener, "Authentication failed. Trying again...");
-                Thread.sleep(BOOTSTRAP_AUTH_SLEEP_MS);
+                Thread.sleep(BOOTSTRAP_AUTH_SLEEP_DURATION.toMillis());
             }
             if (!isAuthenticated) {
                 logWarning(computer, listener, "Authentication failed");

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java
@@ -30,9 +30,6 @@ import java.util.logging.Logger;
 public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
     private static final Logger LOGGER = Logger.getLogger(ComputeEngineLinuxLauncher.class.getName());
 
-    private static int bootstrapAuthTries = 30;
-    private static int bootstrapAuthSleepMs = 15000;
-
     public ComputeEngineLinuxLauncher(String cloudName, Operation insertOperation, boolean useInternalAddress) {
         super(cloudName, insertOperation.getName(), insertOperation.getZone(), useInternalAddress);
     }
@@ -72,7 +69,7 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
         }
         Connection bootstrapConn = null;
         try {
-            int tries = bootstrapAuthTries;
+            int tries = BOOT_STRAP_AUTH_TRIES;
             boolean isAuthenticated = false;
             if (keyCred instanceof GoogleKeyPair) {
                 logInfo(computer, listener, "Getting keypair...");
@@ -102,7 +99,7 @@ public class ComputeEngineLinuxLauncher extends ComputeEngineComputerLauncher {
                     break;
                 }
                 logWarning(computer, listener, "Authentication failed. Trying again...");
-                Thread.sleep(bootstrapAuthSleepMs);
+                Thread.sleep(BOOT_STRAP_AUTH_SLEEP_MS);
             }
             if (!isAuthenticated) {
                 logWarning(computer, listener, "Authentication failed");

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -32,9 +32,6 @@ import java.util.logging.Logger;
 public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher {
     private static final Logger LOGGER = Logger.getLogger(ComputeEngineWindowsLauncher.class.getName());
 
-    private static int bootstrapAuthTries = 30;
-    private static int bootstrapAuthSleepMs = 15000;
-
     public ComputeEngineWindowsLauncher(String cloudName, Operation insertOperation, boolean useInternalAddress) {
         super(cloudName, insertOperation.getName(), insertOperation.getZone(), useInternalAddress);
     }
@@ -86,7 +83,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
         WindowsConfiguration windowsConfig = node.getWindowsConfig();
         Connection bootstrapConn = null;
         try {
-            int tries = bootstrapAuthTries;
+            int tries = BOOT_STRAP_AUTH_TRIES;
             boolean isAuthenticated = false;
             while (tries-- > 0) {
                 logInfo(computer, listener, "Authenticating as " + node.getSshUser());
@@ -106,7 +103,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
                     break;
                 }
                 logWarning(computer, listener, "Authentication failed. Trying again...");
-                Thread.sleep(bootstrapAuthSleepMs);
+                Thread.sleep(BOOT_STRAP_AUTH_SLEEP_MS);
             }
             if (!isAuthenticated) {
                 logWarning(computer, listener, "Authentication failed");

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -83,7 +83,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
         WindowsConfiguration windowsConfig = node.getWindowsConfig();
         Connection bootstrapConn = null;
         try {
-            int tries = BOOT_STRAP_AUTH_TRIES;
+            int tries = BOOTSTRAP_AUTH_TRIES;
             boolean isAuthenticated = false;
             while (tries-- > 0) {
                 logInfo(computer, listener, "Authenticating as " + node.getSshUser());
@@ -103,7 +103,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
                     break;
                 }
                 logWarning(computer, listener, "Authentication failed. Trying again...");
-                Thread.sleep(BOOT_STRAP_AUTH_SLEEP_MS);
+                Thread.sleep(BOOTSTRAP_AUTH_SLEEP_MS);
             }
             if (!isAuthenticated) {
                 logWarning(computer, listener, "Authentication failed");

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineWindowsLauncher.java
@@ -103,7 +103,7 @@ public class ComputeEngineWindowsLauncher extends ComputeEngineComputerLauncher 
                     break;
                 }
                 logWarning(computer, listener, "Authentication failed. Trying again...");
-                Thread.sleep(BOOTSTRAP_AUTH_SLEEP_MS);
+                Thread.sleep(BOOTSTRAP_AUTH_SLEEP_DURATION.toMillis());
             }
             if (!isAuthenticated) {
                 logWarning(computer, listener, "Authentication failed");


### PR DESCRIPTION
Proposing to make `bootstrapAuthTries` and `bootstrapAuthSleepMs` to be configurable via system property
(with renaming `bootstrapAuthSleepMs` to `bootstrapAuthSleepDuration`)
```
-Dcom.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthTries=<num-retries>
-Dcom.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthSleepDuration=<time-duration>
```
When not using the ssh keys created automatically by the controller, the ssh key management is,
* GCP VM is expected to have the public key injected via
   * embedded in the image
   * or pulled from credential store using startup script
   * configured by infrastructure management tools like ansible/puppet etc.
* private key is created as a credential in the controller

The public key setup in the VM may delay due to external setup exceeding the hard coded values,
`bootstrapAuthTries = 30` and `bootstrapAuthSleepMs = 15000` which is `30 x 15s = 7.5 minutes`

Additionally, the values `bootstrapAuthTries` and `bootstrapAuthSleepMs` are common both both Linux and Windows launchers, thus unifying the fields into the super class.

### Testing done

**Test 1**
Use custom ssh key based authentication, and don't put the public key inside the VM image yet. This way the controller will keep attempting to authenticate and it will fail in the bootstrap.

system properties config was
```
-Dcom.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthTries=5
-Dcom.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.bootstrapAuthSleepDuration=3s
```
Verify the static variable value from script console
```
println com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.BOOTSTRAP_AUTH_TRIES
println com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.BOOTSTRAP_AUTH_SLEEP_DURATION
```
script console - output
```
5
PT3S
```
Launch the VM, and observe the VM logs,
there are exactly 5 logs and also the logs per each bootstrap setup attempt until `bootstrapresult failed` - and are apart by 3s only
```
INFO: Authenticating as auth-test-user
```
as well as
```
WARNING: Authentication failed. Trying again...
```
code is https://github.com/jenkinsci/google-compute-engine-plugin/blob/0ce26579aee72030ba8906161f98962d5bf78703/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineLinuxLauncher.java#L84-L106
<details><summary>bootstrap loop logs - agent connection logs</summary>

```
Launching on mc-7d56899f65-nztbg
Mar 18, 2026 12:31:24 PM null
FINEST: Instance gbhat-28248-gce-fkojhs is running and ready...
Mar 18, 2026 12:31:24 PM null
INFO: Launching instance: gbhat-28248-gce-fkojhs
Mar 18, 2026 12:31:24 PM null
INFO: bootstrap
Mar 18, 2026 12:31:24 PM null
INFO: Getting private key...
Mar 18, 2026 12:31:24 PM null
INFO: Using custom ssh private key
Mar 18, 2026 12:31:24 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 12:31:24 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 12:31:24 PM null
INFO: Connecting to 10.142.0.73 on port 22, with timeout 10000.
Mar 18, 2026 12:31:34 PM null
INFO: Failed to connect via ssh: The kexTimeout (10000 ms) expired.
Mar 18, 2026 12:31:34 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Mar 18, 2026 12:31:39 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 12:31:39 PM null
INFO: Connecting to 10.142.0.73 on port 22, with timeout 10000.
Mar 18, 2026 12:31:49 PM null
INFO: Failed to connect via ssh: The kexTimeout (10000 ms) expired.
Mar 18, 2026 12:31:49 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Mar 18, 2026 12:31:54 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 12:31:54 PM null
INFO: Connecting to 10.142.0.73 on port 22, with timeout 10000.
Mar 18, 2026 12:31:54 PM null
WARNING: An error occured: There was a problem while connecting to 10.142.0.73:22
Mar 18, 2026 12:31:59 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 12:31:59 PM null
INFO: Connecting to 10.142.0.73 on port 22, with timeout 10000.
Mar 18, 2026 12:32:00 PM null
INFO: Connected via SSH.
Mar 18, 2026 12:32:00 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 12:32:03 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 12:32:03 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 12:32:03 PM null
INFO: Connecting to 10.142.0.73 on port 22, with timeout 10000.
Mar 18, 2026 12:32:03 PM null
INFO: Connected via SSH.
Mar 18, 2026 12:32:03 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 12:32:06 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 12:32:06 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 12:32:06 PM null
INFO: Connecting to 10.142.0.73 on port 22, with timeout 10000.
Mar 18, 2026 12:32:06 PM null
INFO: Connected via SSH.
Mar 18, 2026 12:32:06 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 12:32:09 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 12:32:09 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 12:32:09 PM null
INFO: Connecting to 10.142.0.73 on port 22, with timeout 10000.
Mar 18, 2026 12:32:10 PM null
INFO: Connected via SSH.
Mar 18, 2026 12:32:10 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 12:32:13 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 12:32:13 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 12:32:13 PM null
INFO: Connecting to 10.142.0.73 on port 22, with timeout 10000.
Mar 18, 2026 12:32:13 PM null
INFO: Connected via SSH.
Mar 18, 2026 12:32:13 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 12:32:16 PM null
WARNING: Authentication failed
Mar 18, 2026 12:32:16 PM null
WARNING: bootstrapresult failed
```
</details>

I would then manually login into the VM using `gcloud compute ssh` and run the following script to setup the public key, (assume I am the external service setting up the agent)

<details><summary>script - configure public key</summary>

```
#!/bin/bash
set -euo pipefail

USERNAME="auth-test-user"
PUBLIC_KEY="<the public key>"

# Create user with home directory and bash shell
useradd -m -s /bin/bash "$USERNAME"

# Add user to sudo group (wheel for RHEL/CentOS, sudo for Debian/Ubuntu)
if getent group sudo > /dev/null 2>&1; then
    usermod -aG sudo "$USERNAME"
elif getent group wheel > /dev/null 2>&1; then
    usermod -aG wheel "$USERNAME"
fi

# Allow passwordless sudo
echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$USERNAME"
chmod 440 "/etc/sudoers.d/$USERNAME"

# Set up SSH public key authentication
mkdir -p "/home/$USERNAME/.ssh"
echo "$PUBLIC_KEY" > "/home/$USERNAME/.ssh/authorized_keys"
chown -R "$USERNAME:$USERNAME" "/home/$USERNAME/.ssh"
chmod 700 "/home/$USERNAME/.ssh"
chmod 600 "/home/$USERNAME/.ssh/authorized_keys"

echo "User '$USERNAME' created with sudo privileges and SSH key configured."
```
</details>

**Test 2**

Same test, but now increasing the `bootstrapAuthSleepDuration` to 2m, noticing the log timestamps accordingly,
notice exact 2min difference in bootstrap auth retry logs.

<details><summary>connection logs</summary>

```
Launching on mc-b95c5fbb5-9pkrg
Mar 18, 2026 1:50:15 PM null
FINEST: Instance gbhat-28248-gce-6v3ysw is running and ready...
Mar 18, 2026 1:50:15 PM null
INFO: Launching instance: gbhat-28248-gce-6v3ysw
Mar 18, 2026 1:50:15 PM null
INFO: bootstrap
Mar 18, 2026 1:50:15 PM null
INFO: Getting private key...
Mar 18, 2026 1:50:15 PM null
INFO: Using custom ssh private key
Mar 18, 2026 1:50:15 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 1:50:15 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:50:15 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:50:25 PM null
INFO: Failed to connect via ssh: The kexTimeout (10000 ms) expired.
Mar 18, 2026 1:50:25 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Mar 18, 2026 1:50:30 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:50:30 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:50:40 PM null
INFO: Failed to connect via ssh: The kexTimeout (10000 ms) expired.
Mar 18, 2026 1:50:40 PM null
INFO: Waiting for SSH to come up. Sleeping 5.
Mar 18, 2026 1:50:45 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:50:45 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:50:45 PM null
WARNING: An error occured: There was a problem while connecting to 10.142.0.36:22
Mar 18, 2026 1:50:51 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:50:51 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:50:51 PM null
WARNING: An error occured: There was a problem while connecting to 10.142.0.36:22
Mar 18, 2026 1:50:56 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:50:56 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:50:56 PM null
INFO: Connected via SSH.
Mar 18, 2026 1:50:56 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 1:52:56 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 1:52:56 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:52:56 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:52:57 PM null
INFO: Connected via SSH.
Mar 18, 2026 1:52:57 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 1:54:57 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 1:54:57 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:54:57 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:54:57 PM null
INFO: Connected via SSH.
Mar 18, 2026 1:54:57 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 1:56:57 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 1:56:57 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:56:57 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:56:57 PM null
INFO: Connected via SSH.
Mar 18, 2026 1:56:57 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 1:58:57 PM null
INFO: Authenticating as auth-test-user
Mar 18, 2026 1:58:57 PM null
INFO: No public address found. Fall back to internal address.
Mar 18, 2026 1:58:57 PM null
INFO: Connecting to 10.142.0.36 on port 22, with timeout 10000.
Mar 18, 2026 1:58:58 PM null
INFO: Connected via SSH.
Mar 18, 2026 1:58:58 PM null
WARNING: Authentication failed. Trying again...
Mar 18, 2026 2:00:58 PM null
WARNING: Authentication failed
Mar 18, 2026 2:00:58 PM null
WARNING: bootstrapresult failed
```
</details>

**Test 3**
Tested regular ssh authentication mechanism, that is,
* controller creates the ssh key pair
* attaches the public key as the metadata to the VM (GCP will put the public key inside the VM and create the linux user)
* controller authenticates using private key.
In this flow we don't see any bootstrap delays because GCP puts the public key immediately upon the VM boot up.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
