### PR TITLE
Bump jenkins version to 2.516.3 and plugin parent pom to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.7</version>
+    <version>6.2138.v03274d462c13</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3893.v213a_42768d35</version>
+        <version>6146.vc53a_0edb_e986</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.516</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
     <skipITs>true</skipITs>
     <it.windows>false</it.windows>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>6146.vc53a_0edb_e986</version>
+        <version>6166.va_a_8b_5eda_8ef5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -198,8 +198,8 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
                                 listener,
                                 String.format("Instance %s is being shut down...", computer.getName()));
                         break;
-                        // TODO: Although the plugin doesn't put instances in the STOPPED or SUSPENDED states,
-                        // it should handle them if they are placed in that state out-of-band.
+                    // TODO: Although the plugin doesn't put instances in the STOPPED or SUSPENDED states,
+                    // it should handle them if they are placed in that state out-of-band.
                     case "STOPPED":
                     case "SUSPENDED":
                         cloud.log(


### PR DESCRIPTION
Version `2.516.3` is recommended via https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions. The configured jenkins version https://www.jenkins.io/changelog/2.479.1/ is Oct 2024 release which is quite old.

This bump was thought of while thinking of using `SystemProperties.getDuration` from Jenkins core which wasn't available in `2.479.1`. 
Discussion https://github.com/jenkinsci/google-compute-engine-plugin/pull/529#discussion_r2954407548

The plugin parent pom version 5.7 (https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-5.7) is also bumped to the latest (https://github.com/jenkinsci/plugin-pom/releases/tag/6.2138.v03274d462c13) available to consume the newer version of jenkins-test-harness and other common dev dependencies.

### Testing done

Relying on automated tests.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
