### PR TITLE
Use only name based check for VM existence during deletion - remove label based filtering

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -16,11 +16,9 @@
 
 package com.google.jenkins.plugins.computeengine;
 
-import static com.google.jenkins.plugins.computeengine.ComputeEngineCloud.CLOUD_ID_LABEL_KEY;
-
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient.OperationException;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyCredential;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
@@ -33,7 +31,6 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.RetentionStrategy;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -137,15 +134,15 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
                         .createSnapshotSync(cloud.getProjectId(), this.zone, this.getNodeName(), createSnapshotTimeout);
             }
 
-            Map<String, String> filterLabel = ImmutableMap.of(CLOUD_ID_LABEL_KEY, cloud.getInstanceId());
-            var instanceExistsInCloud =
-                    cloud.getClient().listInstancesWithLabel(cloud.getProjectId(), filterLabel).stream()
-                            .anyMatch(instance -> instance.getName().equals(name));
+            boolean instanceExistsInCloud = instanceExistsInCloud(cloud);
 
             // If the instance exists in the cloud, attempt to terminate it. This is an async call and we
             // return immediately, hoping for the best.
             if (instanceExistsInCloud) {
                 cloud.getClient().terminateInstanceAsync(cloud.getProjectId(), zone, name);
+                LOGGER.finer(() -> "Termination request was made for " + this.getNodeName());
+            } else {
+                LOGGER.fine(() -> "Instance " + name + " not found in GCP, nothing to terminate");
             }
         } catch (CloudNotFoundException cnfe) {
             listener.error(cnfe.getMessage());
@@ -170,6 +167,21 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
     /** @return The configured Linux SSH key pair for this {@link ComputeEngineInstance}. */
     public Optional<GoogleKeyCredential> getSSHKeyCredential() {
         return Optional.ofNullable(sshKeyCredential);
+    }
+
+    private boolean instanceExistsInCloud(ComputeEngineCloud cloud) {
+        try {
+            return cloud.getClient().getInstance(cloud.getProjectId(), zone, name) != null;
+        } catch (GoogleJsonResponseException gjre) {
+            if (gjre.getStatusCode() == 404) {
+                return false;
+            }
+            LOGGER.log(Level.WARNING, "Error checking instance " + name, gjre);
+            return false;
+        } catch (IOException ioe) {
+            LOGGER.log(Level.WARNING, "Error checking instance " + name, ioe);
+            return false;
+        }
     }
 
     public ComputeEngineCloud getCloud() throws CloudNotFoundException {


### PR DESCRIPTION
In CasC based controller, if the `instanceId` is not put in configuration, will get recomputed upon reapplying CasC (such as on restart) - https://github.com/jenkinsci/google-compute-engine-plugin/blob/36345303a0c2af591d9143b0eb59770c822c2fb5/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java#L179-L186

Post such re-computation of instanceId, the VMs provisioned prior will not be deleted from the `_terminate` as the filter won't find them - https://github.com/jenkinsci/google-compute-engine-plugin/blob/36345303a0c2af591d9143b0eb59770c822c2fb5/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java#L140-L143

Those VMs are assumed to be non-existing in GCP and Jenkins node is removed, the VMs will continue to run in the cloud.

I have considered completely removing the VM existence check entirely but noticed this discussion https://github.com/jenkinsci/google-compute-engine-plugin/pull/489/changes#r1871950758

This PR propose to use `getInstance(projectId, zone, name)` to filter a VM which should also get a unique VM. When multiple Jenkins controllers are pointing to a GCP project, and if one controller is having an agent with a particular name, other controllers would not have had chance to provision that VM, would have failed during provisioning even if they had computed the same agent name.

**Investigation**

This was able to prove by adding more logs
<details><summary>diff</summary>

```
diff --git a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
index 9a394d0..96e3b38 100644
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -138,6 +138,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
             }

             Map<String, String> filterLabel = ImmutableMap.of(CLOUD_ID_LABEL_KEY, cloud.getInstanceId());
+            LOGGER.log(Level.FINE, "Filtering using cloud id: " + cloud.getInstanceId());
             var instanceExistsInCloud =
                     cloud.getClient().listInstancesWithLabel(cloud.getProjectId(), filterLabel).stream()
                             .anyMatch(instance -> instance.getName().equals(name));
@@ -146,6 +147,15 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
             // return immediately, hoping for the best.
             if (instanceExistsInCloud) {
                 cloud.getClient().terminateInstanceAsync(cloud.getProjectId(), zone, name);
+                LOGGER.finer(() -> "Termination request was made for " + this.getNodeName());
+            } else {
+                LOGGER.finer(() -> "Instance " + name + " does not exist");
+                try {
+                    var instance = cloud.getClient().getInstance(cloud.getProjectId(), zone, name);
+                    LOGGER.finer(() -> "Got the instance " + instance.getName());
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Error getting instance " + name, e);
+                }
             }
         } catch (CloudNotFoundException cnfe) {
             listener.error(cnfe.getMessage());
```
</details>

logs were,
```
2026-03-31 17:20:58.308+0000 [id=1287]      FINE    c.g.j.p.c.ComputeEngineInstance#_terminate: Filtering using cloud id: 5592ce99-f477-48bc-b0ee-e399e2c6f920
2026-03-31 17:20:58.784+0000 [id=1287]      FINER   c.g.j.p.c.ComputeEngineInstance#_terminate: Instance gbhat-15708-gce-pqvxjx does not exist
2026-03-31 17:20:58.872+0000 [id=1287]      FINER   c.g.j.p.c.ComputeEngineInstance#_terminate: Got the instance gbhat-15708-gce-pqvxjx
```
Instance had label as,
```
→ gcloud compute instances describe gbhat-15708-gce-pqvxjx --zone=us-east1-b --format='json(labels)'
{
  "labels": {
    "jenkins_cloud_id": "2ed0b892-fb9c-4ec2-b0c0-bf990fe25043",
    "jenkins_config_name": "gbhat-15708-gce",
    "jenkins_node_last_refresh": "2026_03_31t17_12_47_010z"
  }
}
```
Jenkins `config.xml` showed the id as,
```
bash-5.1$ cat config.xml | grep instanceId
      <instanceId>5592ce99-f477-48bc-b0ee-e399e2c6f920</instanceId>
```

### Testing done

Automated Testing
* Ran the existing integration test `ComputeEngineCloudOneShotInstanceIT` - which has some VM deletion related assertions.

Manual Testing
* verified issue no more happens - in the context of CloudBees CI CasC controller where the problem observed.
* manually killed off VMs in GCP and observed no log noise

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed