### PR TITLE
Support disk mapping for agent VMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-input-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -262,11 +262,6 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>pipeline-input-step</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
       <scope>test</scope>
     </dependency>
@@ -295,6 +290,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -575,12 +575,17 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         disks.add(boot);
 
         var zoneName = nameFromSelfLink(zone);
+        var projectId = cloud != null ? nameFromSelfLink(cloud.getProjectId()) : null;
         for (var mapped : DiskMappingParser.parse(diskMapping)) {
             if (mapped.getInitializeParams() != null) {
                 var params = mapped.getInitializeParams();
                 params.setDiskType(DiskMappingParser.normalizeDiskType(params.getDiskType(), zoneName));
-            } else {
-                mapped.setSource(DiskMappingParser.normalizeDiskSource(mapped.getSource(), zoneName));
+                if (projectId != null) {
+                    params.setSourceSnapshot(
+                            DiskMappingParser.normalizeSnapshotSource(params.getSourceSnapshot(), projectId));
+                }
+            } else if (projectId != null) {
+                mapped.setSource(DiskMappingParser.normalizeDiskSource(mapped.getSource(), projectId, zoneName));
             }
             disks.add(mapped);
         }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -46,6 +46,7 @@ import com.google.jenkins.plugins.computeengine.config.Standard;
 import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyCredential;
 import com.google.jenkins.plugins.computeengine.ssh.GoogleKeyPair;
 import com.google.jenkins.plugins.computeengine.ssh.GooglePrivateKey;
+import com.google.jenkins.plugins.computeengine.util.DiskMappingParser;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
@@ -166,6 +167,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     private List<CustomMetadataItem> customMetadata;
 
     private boolean createSnapshot;
+    private String diskMapping;
     private String remoteFs;
     private String javaExecPath;
     private GoogleKeyCredential sshKeyCredential;
@@ -558,6 +560,8 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         return scheduling;
     }
 
+    /** Builds the list of disks for the instance: the boot disk followed by any additional
+     *  disks parsed from the {@link #diskMapping} field. */
     private List<AttachedDisk> disks() {
         AttachedDisk boot = new AttachedDisk();
         boot.setBoot(true);
@@ -569,6 +573,18 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
 
         List<AttachedDisk> disks = new ArrayList<>();
         disks.add(boot);
+
+        var zoneName = nameFromSelfLink(zone);
+        for (var mapped : DiskMappingParser.parse(diskMapping)) {
+            if (mapped.getInitializeParams() != null) {
+                var params = mapped.getInitializeParams();
+                params.setDiskType(DiskMappingParser.normalizeDiskType(params.getDiskType(), zoneName));
+            } else {
+                mapped.setSource(DiskMappingParser.normalizeDiskSource(mapped.getSource(), zoneName));
+            }
+            disks.add(mapped);
+        }
+
         return disks;
     }
 
@@ -1137,6 +1153,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                     this.minimumNumberOfInstancesTimeRangeConfig);
             instanceConfiguration.setTemplate(this.template);
             instanceConfiguration.setCreateSnapshot(this.createSnapshot);
+            instanceConfiguration.setDiskMapping(this.diskMapping);
             instanceConfiguration.setTerminateIdleDuringShutdown(this.terminateIdleDuringShutdown);
             instanceConfiguration.setCustomMetadata(this.customMetadata);
             instanceConfiguration.setRemoteFs(this.remoteFs);

--- a/src/main/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParser.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParser.java
@@ -238,19 +238,37 @@ public class DiskMappingParser {
     }
 
     /**
-     * Expands short disk names to zone-qualified resource paths
-     * ({@code zones/{zone}/disks/{name}}). Full URLs and relative paths that already
-     * contain a {@code /} are returned unchanged.
+     * Expands short disk names to project- and zone-qualified resource paths
+     * ({@code projects/{project}/zones/{zone}/disks/{name}}). Full URLs and relative paths
+     * that already contain a {@code /} are returned unchanged.
      *
      * @param diskSource the disk name or path from the mapping, or null
+     * @param project the project ID (e.g. {@code my-project})
      * @param zone the zone name (e.g. {@code us-east1-b})
      * @return the qualified disk source, or null if input is null
      */
     @Nullable
-    public static String normalizeDiskSource(@Nullable String diskSource, String zone) {
+    public static String normalizeDiskSource(@Nullable String diskSource, String project, String zone) {
         if (diskSource == null || diskSource.contains("/")) {
             return diskSource;
         }
-        return "zones/" + zone + "/disks/" + diskSource;
+        return "projects/" + project + "/zones/" + zone + "/disks/" + diskSource;
+    }
+
+    /**
+     * Expands short snapshot names to project-qualified resource paths
+     * ({@code projects/{project}/global/snapshots/{name}}). Full URLs and relative paths
+     * that already contain a {@code /} are returned unchanged.
+     *
+     * @param snapshotSource the snapshot name or path from the mapping, or null
+     * @param project the project ID (e.g. {@code my-project})
+     * @return the qualified snapshot source, or null if input is null
+     */
+    @Nullable
+    public static String normalizeSnapshotSource(@Nullable String snapshotSource, String project) {
+        if (snapshotSource == null || snapshotSource.contains("/")) {
+            return snapshotSource;
+        }
+        return "projects/" + project + "/global/snapshots/" + snapshotSource;
     }
 }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParser.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParser.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine.util;
+
+import com.google.api.services.compute.model.AttachedDisk;
+import com.google.api.services.compute.model.AttachedDiskInitializeParams;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Parses disk mapping strings in GCP key=value format into {@link AttachedDisk} objects.
+ *
+ * <p>Supports two modes in the same textarea. Both modes support {@code device-name},
+ * {@code mode}, {@code interface}, and {@code auto-delete}.
+ * <ul>
+ *   <li><b>Create disk</b>
+ *       (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk">{@code --create-disk}</a>
+ *       semantics) &mdash; when the line contains {@code source-snapshot}, {@code size}, or {@code type}.
+ *       A new disk is created and attached.</li>
+ *   <li><b>Attach existing disk</b>
+ *       (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--disk">{@code --disk}</a>
+ *       semantics) &mdash; when the line contains only {@code name} (without any create-disk keys).
+ *       An existing disk is attached by reference.</li>
+ * </ul>
+ */
+public class DiskMappingParser {
+
+    private DiskMappingParser() {}
+
+    /** Keys that indicate a create-disk line (as opposed to attach-existing). */
+    private static final Set<String> CREATE_DISK_KEYS = Set.of("source-snapshot", "size", "type", "description");
+
+    /**
+     * Parses a multi-line disk mapping string into a list of {@link AttachedDisk} objects.
+     * Each non-blank line is parsed as a separate disk specification.
+     *
+     * @param diskMapping the disk mapping string (one disk per line), or null/empty
+     * @return a list of configured {@link AttachedDisk} objects, empty if input is null/blank
+     * @throws IllegalArgumentException if a line fails validation
+     */
+    public static List<AttachedDisk> parse(@Nullable String diskMapping) {
+        if (diskMapping == null || diskMapping.trim().isEmpty()) {
+            return List.of();
+        }
+
+        var disks = new ArrayList<AttachedDisk>();
+        for (var line : diskMapping.split("\n")) {
+            if (line.trim().isEmpty()) {
+                continue;
+            }
+            disks.add(parseLine(line.trim()));
+        }
+        return disks;
+    }
+
+    private static Map<String, String> parseKeyValues(String line) {
+        var map = new LinkedHashMap<String, String>();
+        for (var pair : line.split(",")) {
+            var kv = pair.trim().split("=", 2);
+            if (kv.length == 2) {
+                map.put(kv[0].trim(), kv[1].trim());
+            }
+        }
+        return map;
+    }
+
+    private static boolean isCreateDisk(Map<String, String> kv) {
+        return kv.keySet().stream().anyMatch(CREATE_DISK_KEYS::contains);
+    }
+
+    private static AttachedDisk parseLine(String line) {
+        var kv = parseKeyValues(line);
+
+        if (isCreateDisk(kv)) {
+            return buildCreateDisk(kv);
+        }
+        return buildAttachExistingDisk(kv);
+    }
+
+    /**
+     * Builds an {@link AttachedDisk} that creates a new disk.
+     *
+     * <p>Mode-specific keys:
+     * <ul>
+     *   <li>{@code source-snapshot} &mdash; snapshot name, relative path, or full URL</li>
+     *   <li>{@code size} &mdash; disk size in GB</li>
+     *   <li>{@code type} &mdash; disk type (e.g. {@code pd-ssd})</li>
+     *   <li>{@code name} &mdash; name for the new disk</li>
+     *   <li>{@code description} &mdash; optional description</li>
+     * </ul>
+     *
+     * <p>Also supports the common keys ({@code device-name}, {@code mode}, {@code interface},
+     * {@code auto-delete}) described in the {@linkplain DiskMappingParser class javadoc}.
+     *
+     * <p>At least one of {@code source-snapshot} or {@code size} must be specified.
+     *
+     * @see <a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk">
+     *     gcloud compute instances create --create-disk</a>
+     */
+    private static AttachedDisk buildCreateDisk(Map<String, String> kv) {
+        var sourceSnapshot = kv.get("source-snapshot");
+        var diskName = kv.get("name");
+        var deviceName = kv.get("device-name");
+        var description = kv.get("description");
+        var sizeStr = kv.get("size");
+        var diskType = kv.get("type");
+        var modeStr = kv.get("mode");
+        var diskInterface = kv.get("interface");
+        var autoDeleteStr = kv.get("auto-delete");
+
+        boolean hasSource = sourceSnapshot != null && !sourceSnapshot.isEmpty();
+        Long sizeGb = sizeStr != null ? Long.parseLong(sizeStr) : null;
+
+        if (!hasSource && sizeGb == null) {
+            throw new IllegalArgumentException(
+                    "Create-disk mapping must include at least one of: source-snapshot or size");
+        }
+
+        var params = new AttachedDiskInitializeParams();
+        if (hasSource) {
+            params.setSourceSnapshot(sourceSnapshot);
+        }
+        if (diskName != null && !diskName.isEmpty()) {
+            params.setDiskName(diskName);
+        }
+        if (description != null && !description.isEmpty()) {
+            params.setDescription(description);
+        }
+        if (sizeGb != null) {
+            params.setDiskSizeGb(sizeGb);
+        }
+        if (diskType != null && !diskType.isEmpty()) {
+            params.setDiskType(diskType);
+        }
+
+        var disk = new AttachedDisk();
+        disk.setBoot(false);
+        disk.setAutoDelete(autoDeleteStr == null || "yes".equalsIgnoreCase(autoDeleteStr));
+        disk.setInitializeParams(params);
+        if (deviceName != null && !deviceName.isEmpty()) {
+            disk.setDeviceName(deviceName);
+        }
+        if (modeStr != null && !modeStr.isEmpty()) {
+            disk.setMode(normalizeMode(modeStr));
+        }
+        if (diskInterface != null && !diskInterface.isEmpty()) {
+            disk.setInterface(diskInterface);
+        }
+        return disk;
+    }
+
+    /**
+     * Builds an {@link AttachedDisk} that attaches an existing disk.
+     *
+     * <p>Mode-specific keys:
+     * <ul>
+     *   <li>{@code name} &mdash; existing disk name, relative path, or full URL (required)</li>
+     * </ul>
+     *
+     * <p>Also supports the common keys ({@code device-name}, {@code mode}, {@code interface},
+     * {@code auto-delete}) described in the {@linkplain DiskMappingParser class javadoc}.
+     *
+     * @see <a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--disk">
+     *     gcloud compute instances create --disk</a>
+     */
+    private static AttachedDisk buildAttachExistingDisk(Map<String, String> kv) {
+        var name = kv.get("name");
+        var deviceName = kv.get("device-name");
+        var modeStr = kv.get("mode");
+        var diskInterface = kv.get("interface");
+        var autoDeleteStr = kv.get("auto-delete");
+
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Attach-disk mapping must include 'name' referring to an existing disk");
+        }
+
+        var disk = new AttachedDisk();
+        disk.setSource(name);
+        disk.setBoot(false);
+        disk.setAutoDelete(autoDeleteStr == null || "yes".equalsIgnoreCase(autoDeleteStr));
+        if (deviceName != null && !deviceName.isEmpty()) {
+            disk.setDeviceName(deviceName);
+        }
+        if (modeStr != null && !modeStr.isEmpty()) {
+            disk.setMode(normalizeMode(modeStr));
+        }
+        if (diskInterface != null && !diskInterface.isEmpty()) {
+            disk.setInterface(diskInterface);
+        }
+        return disk;
+    }
+
+    /**
+     * Normalizes short mode values ({@code ro}, {@code rw}) to GCP API constants
+     * ({@code READ_ONLY}, {@code READ_WRITE}).
+     */
+    private static String normalizeMode(String mode) {
+        return switch (mode.toLowerCase()) {
+            case "ro" -> "READ_ONLY";
+            case "rw" -> "READ_WRITE";
+            default -> mode;
+        };
+    }
+
+    /**
+     * Expands short disk type names (e.g. {@code pd-ssd}) to zone-qualified resource paths
+     * ({@code zones/{zone}/diskTypes/pd-ssd}). Full URLs and relative paths that already
+     * contain a {@code /} are returned unchanged.
+     *
+     * @param diskType the disk type value from the mapping, or null
+     * @param zone the zone name (e.g. {@code us-east1-b})
+     * @return the qualified disk type, or null if input is null
+     */
+    @Nullable
+    public static String normalizeDiskType(@Nullable String diskType, String zone) {
+        if (diskType == null || diskType.contains("/")) {
+            return diskType;
+        }
+        return "zones/" + zone + "/diskTypes/" + diskType;
+    }
+
+    /**
+     * Expands short disk names to zone-qualified resource paths
+     * ({@code zones/{zone}/disks/{name}}). Full URLs and relative paths that already
+     * contain a {@code /} are returned unchanged.
+     *
+     * @param diskSource the disk name or path from the mapping, or null
+     * @param zone the zone name (e.g. {@code us-east1-b})
+     * @return the qualified disk source, or null if input is null
+     */
+    @Nullable
+    public static String normalizeDiskSource(@Nullable String diskSource, String zone) {
+        if (diskSource == null || diskSource.contains("/")) {
+            return diskSource;
+        }
+        return "zones/" + zone + "/disks/" + diskSource;
+    }
+}

--- a/src/main/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParser.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParser.java
@@ -33,11 +33,11 @@ import java.util.Set;
  * <ul>
  *   <li><b>Create disk</b>
  *       (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk">{@code --create-disk}</a>
- *       semantics) &mdash; when the line contains {@code source-snapshot}, {@code size}, or {@code type}.
+ *       semantics) — when the line contains {@code source-snapshot}, {@code size}, or {@code type}.
  *       A new disk is created and attached.</li>
  *   <li><b>Attach existing disk</b>
  *       (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--disk">{@code --disk}</a>
- *       semantics) &mdash; when the line contains only {@code name} (without any create-disk keys).
+ *       semantics) — when the line contains only {@code name} (without any create-disk keys).
  *       An existing disk is attached by reference.</li>
  * </ul>
  */
@@ -100,11 +100,11 @@ public class DiskMappingParser {
      *
      * <p>Mode-specific keys:
      * <ul>
-     *   <li>{@code source-snapshot} &mdash; snapshot name, relative path, or full URL</li>
-     *   <li>{@code size} &mdash; disk size in GB</li>
-     *   <li>{@code type} &mdash; disk type (e.g. {@code pd-ssd})</li>
-     *   <li>{@code name} &mdash; name for the new disk</li>
-     *   <li>{@code description} &mdash; optional description</li>
+     *   <li>{@code source-snapshot} — snapshot name, relative path, or full URL</li>
+     *   <li>{@code size} — disk size in GB</li>
+     *   <li>{@code type} — disk type (e.g. {@code pd-ssd})</li>
+     *   <li>{@code name} — name for the new disk</li>
+     *   <li>{@code description} — optional description</li>
      * </ul>
      *
      * <p>Also supports the common keys ({@code device-name}, {@code mode}, {@code interface},
@@ -172,7 +172,7 @@ public class DiskMappingParser {
      *
      * <p>Mode-specific keys:
      * <ul>
-     *   <li>{@code name} &mdash; existing disk name, relative path, or full URL (required)</li>
+     *   <li>{@code name} — existing disk name, relative path, or full URL (required)</li>
      * </ul>
      *
      * <p>Also supports the common keys ({@code device-name}, {@code mode}, {@code interface},

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -172,6 +172,12 @@
                     </f:entry>
                 </f:section>
 
+                <f:section title="Disk Mapping">
+                    <f:entry field="diskMapping" title="${%Disk Mapping}">
+                        <f:textarea/>
+                    </f:entry>
+                </f:section>
+
                 <f:section title="IAM">
                     <f:entry field="serviceAccountEmail" title="${%Service Account E-mail}">
                         <f:textbox/>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-diskMapping.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-diskMapping.html
@@ -24,21 +24,21 @@
         <code>size</code> is required.
     </p>
     <ul>
-        <li><code>source-snapshot</code> &mdash; Snapshot name, relative path
+        <li><code>source-snapshot</code> — Snapshot name, relative path
             (e.g. <code>projects/{project}/global/snapshots/{name}</code>),
             or full resource URI (e.g. <code>https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots/{name}</code>).
             Use just the name for snapshots in the same project.</li>
-        <li><code>size</code> &mdash; Disk size in GB. Required for blank disks; optional when a
+        <li><code>size</code> — Disk size in GB. Required for blank disks; optional when a
             source is specified (defaults to the source snapshot size).</li>
-        <li><code>type</code> &mdash; Disk type: short name (e.g. <code>pd-ssd</code>), relative path
+        <li><code>type</code> — Disk type: short name (e.g. <code>pd-ssd</code>), relative path
             (e.g. <code>zones/us-east1-b/diskTypes/pd-ssd</code>), or full resource URI.
             Short names are automatically qualified to the instance's zone. Defaults to <code>pd-standard</code>.</li>
-        <li><code>name</code> &mdash; Name for the new disk. If omitted, GCP generates a name automatically.</li>
-        <li><code>device-name</code> &mdash; Device name shown in the guest OS.</li>
-        <li><code>description</code> &mdash; Optional description for the disk.</li>
-        <li><code>mode</code> &mdash; <code>ro</code> for read-only or <code>rw</code> for read-write (default: <code>rw</code>).</li>
-        <li><code>interface</code> &mdash; <code>SCSI</code> or <code>NVME</code>.</li>
-        <li><code>auto-delete</code> &mdash; <code>yes</code> or <code>no</code> (default: <code>yes</code>).</li>
+        <li><code>name</code> — Name for the new disk. If omitted, GCP generates a name automatically.</li>
+        <li><code>device-name</code> — Device name shown in the guest OS.</li>
+        <li><code>description</code> — Optional description for the disk.</li>
+        <li><code>mode</code> — <code>ro</code> for read-only or <code>rw</code> for read-write (default: <code>rw</code>).</li>
+        <li><code>interface</code> — <code>SCSI</code> or <code>NVME</code>.</li>
+        <li><code>auto-delete</code> — <code>yes</code> or <code>no</code> (default: <code>yes</code>).</li>
     </ul>
 
     <h4>Attach existing disk (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--disk"><code>--disk</code></a> semantics)</h4>
@@ -47,14 +47,14 @@
         disk is attached by reference.
     </p>
     <ul>
-        <li><code>name</code> &mdash; Existing disk name, relative path, or full resource URI (required).
+        <li><code>name</code> — Existing disk name, relative path, or full resource URI (required).
             Use just the name for zonal disks in the same zone; use a relative path or full resource URI for regional or
             cross-project disks (e.g. <code>projects/myproject/regions/us-central1/disks/my-regional-disk</code>).</li>
-        <li><code>device-name</code> &mdash; Device name shown in the guest OS.</li>
-        <li><code>mode</code> &mdash; <code>ro</code> for read-only or <code>rw</code> for read-write (default: <code>rw</code>).
+        <li><code>device-name</code> — Device name shown in the guest OS.</li>
+        <li><code>mode</code> — <code>ro</code> for read-only or <code>rw</code> for read-write (default: <code>rw</code>).
             Use <code>ro</code> when multiple instances may attach the same disk.</li>
-        <li><code>interface</code> &mdash; <code>SCSI</code> or <code>NVME</code>.</li>
-        <li><code>auto-delete</code> &mdash; <code>yes</code> or <code>no</code> (default: <code>yes</code>).</li>
+        <li><code>interface</code> — <code>SCSI</code> or <code>NVME</code>.</li>
+        <li><code>auto-delete</code> — <code>yes</code> or <code>no</code> (default: <code>yes</code>).</li>
     </ul>
 
     <p>Examples:</p>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-diskMapping.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-diskMapping.html
@@ -1,0 +1,80 @@
+<!--
+ Copyright 2026 CloudBees, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<div>
+    <p>
+        Specify additional disks to attach to the instance, using GCP key=value format.
+        One disk per line. Supports both creating new disks and attaching existing disks.
+    </p>
+
+    <h4>Create new disk (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk"><code>--create-disk</code></a> semantics)</h4>
+    <p>
+        When the line contains <code>source-snapshot</code>, <code>size</code>, or <code>type</code>,
+        a new disk is created and attached. At least one of <code>source-snapshot</code> or
+        <code>size</code> is required.
+    </p>
+    <ul>
+        <li><code>source-snapshot</code> &mdash; Snapshot name, relative path
+            (e.g. <code>projects/{project}/global/snapshots/{name}</code>),
+            or full resource URI (e.g. <code>https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots/{name}</code>).
+            Use just the name for snapshots in the same project.</li>
+        <li><code>size</code> &mdash; Disk size in GB. Required for blank disks; optional when a
+            source is specified (defaults to the source snapshot size).</li>
+        <li><code>type</code> &mdash; Disk type: short name (e.g. <code>pd-ssd</code>), relative path
+            (e.g. <code>zones/us-east1-b/diskTypes/pd-ssd</code>), or full resource URI.
+            Short names are automatically qualified to the instance's zone. Defaults to <code>pd-standard</code>.</li>
+        <li><code>name</code> &mdash; Name for the new disk. If omitted, GCP generates a name automatically.</li>
+        <li><code>device-name</code> &mdash; Device name shown in the guest OS.</li>
+        <li><code>description</code> &mdash; Optional description for the disk.</li>
+        <li><code>mode</code> &mdash; <code>ro</code> for read-only or <code>rw</code> for read-write (default: <code>rw</code>).</li>
+        <li><code>interface</code> &mdash; <code>SCSI</code> or <code>NVME</code>.</li>
+        <li><code>auto-delete</code> &mdash; <code>yes</code> or <code>no</code> (default: <code>yes</code>).</li>
+    </ul>
+
+    <h4>Attach existing disk (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--disk"><code>--disk</code></a> semantics)</h4>
+    <p>
+        When the line contains only <code>name</code> (without any create-disk keys), an existing
+        disk is attached by reference.
+    </p>
+    <ul>
+        <li><code>name</code> &mdash; Existing disk name, relative path, or full resource URI (required).
+            Use just the name for zonal disks in the same zone; use a relative path or full resource URI for regional or
+            cross-project disks (e.g. <code>projects/myproject/regions/us-central1/disks/my-regional-disk</code>).</li>
+        <li><code>device-name</code> &mdash; Device name shown in the guest OS.</li>
+        <li><code>mode</code> &mdash; <code>ro</code> for read-only or <code>rw</code> for read-write (default: <code>rw</code>).
+            Use <code>ro</code> when multiple instances may attach the same disk.</li>
+        <li><code>interface</code> &mdash; <code>SCSI</code> or <code>NVME</code>.</li>
+        <li><code>auto-delete</code> &mdash; <code>yes</code> or <code>no</code> (default: <code>yes</code>).</li>
+    </ul>
+
+    <p>Examples:</p>
+    <pre>source-snapshot=my-cache-snapshot
+source-snapshot=my-data-snapshot,size=100,type=pd-ssd,auto-delete=no
+source-snapshot=https://compute.googleapis.com/compute/v1/projects/other-project/global/snapshots/shared-cache,size=50,type=pd-balanced
+size=200,type=pd-ssd,name=scratch-disk
+name=shared-data-disk,mode=ro
+name=projects/other-project/zones/us-east1-b/disks/team-data,mode=ro,auto-delete=no</pre>
+
+    <p>
+        <strong>Cross-project resources:</strong> Snapshots are global resources in GCP.
+        To use a snapshot from a different project, specify a relative path
+        (e.g. <code>projects/{project}/global/snapshots/{name}</code>) or the full resource URI
+        from the Compute API (e.g. <code>https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots/{name}</code>).
+        To attach an existing disk from a different project or region, use its relative path or full resource URI.
+        The configured service account must have appropriate IAM permissions on the source project.
+    </p>
+    <p>
+        Mounting disks inside the VM must be done via the startup script.
+        Leave empty to not attach any additional disks.
+    </p>
+</div>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-diskMapping.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-diskMapping.html
@@ -13,68 +13,46 @@
 -->
 <div>
     <p>
-        Specify additional disks to attach to the instance, using GCP key=value format.
-        One disk per line. Supports both creating new disks and attaching existing disks.
+        Additional disks to attach to the instance. One disk per line, using comma-separated
+        <code>key=value</code> pairs. Three modes are supported:
     </p>
 
-    <h4>Create new disk (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk"><code>--create-disk</code></a> semantics)</h4>
-    <p>
-        When the line contains <code>source-snapshot</code>, <code>size</code>, or <code>type</code>,
-        a new disk is created and attached. At least one of <code>source-snapshot</code> or
-        <code>size</code> is required.
-    </p>
-    <ul>
-        <li><code>source-snapshot</code> — Snapshot name, relative path
-            (e.g. <code>projects/{project}/global/snapshots/{name}</code>),
-            or full resource URI (e.g. <code>https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots/{name}</code>).
-            Use just the name for snapshots in the same project.</li>
-        <li><code>size</code> — Disk size in GB. Required for blank disks; optional when a
-            source is specified (defaults to the source snapshot size).</li>
-        <li><code>type</code> — Disk type: short name (e.g. <code>pd-ssd</code>), relative path
-            (e.g. <code>zones/us-east1-b/diskTypes/pd-ssd</code>), or full resource URI.
-            Short names are automatically qualified to the instance's zone. Defaults to <code>pd-standard</code>.</li>
-        <li><code>name</code> — Name for the new disk. If omitted, GCP generates a name automatically.</li>
-        <li><code>device-name</code> — Device name shown in the guest OS.</li>
-        <li><code>description</code> — Optional description for the disk.</li>
-        <li><code>mode</code> — <code>ro</code> for read-only or <code>rw</code> for read-write (default: <code>rw</code>).</li>
-        <li><code>interface</code> — <code>SCSI</code> or <code>NVME</code>.</li>
-        <li><code>auto-delete</code> — <code>yes</code> or <code>no</code> (default: <code>yes</code>).</li>
-    </ul>
-
-    <h4>Attach existing disk (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--disk"><code>--disk</code></a> semantics)</h4>
-    <p>
-        When the line contains only <code>name</code> (without any create-disk keys), an existing
-        disk is attached by reference.
-    </p>
-    <ul>
-        <li><code>name</code> — Existing disk name, relative path, or full resource URI (required).
-            Use just the name for zonal disks in the same zone; use a relative path or full resource URI for regional or
-            cross-project disks (e.g. <code>projects/myproject/regions/us-central1/disks/my-regional-disk</code>).</li>
-        <li><code>device-name</code> — Device name shown in the guest OS.</li>
-        <li><code>mode</code> — <code>ro</code> for read-only or <code>rw</code> for read-write (default: <code>rw</code>).
-            Use <code>ro</code> when multiple instances may attach the same disk.</li>
-        <li><code>interface</code> — <code>SCSI</code> or <code>NVME</code>.</li>
-        <li><code>auto-delete</code> — <code>yes</code> or <code>no</code> (default: <code>yes</code>).</li>
-    </ul>
-
-    <p>Examples:</p>
-    <pre>source-snapshot=my-cache-snapshot
-source-snapshot=my-data-snapshot,size=100,type=pd-ssd,auto-delete=no
-source-snapshot=https://compute.googleapis.com/compute/v1/projects/other-project/global/snapshots/shared-cache,size=50,type=pd-balanced
-size=200,type=pd-ssd,name=scratch-disk
-name=shared-data-disk,mode=ro
-name=projects/other-project/zones/us-east1-b/disks/team-data,mode=ro,auto-delete=no</pre>
+    <ol>
+        <li><strong>Create from snapshot</strong>
+            (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk"><code>--create-disk</code></a>)
+            — line contains <code>source-snapshot</code>.
+            Keys: <code>source-snapshot</code> (required), <code>size</code>, <code>type</code>,
+            <code>name</code>, <code>description</code>.</li>
+        <li><strong>Create blank disk</strong>
+            (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk"><code>--create-disk</code></a>)
+            — line contains <code>size</code> or <code>type</code>
+            but no <code>source-snapshot</code>.
+            Keys: <code>size</code> (required), <code>type</code>, <code>name</code>,
+            <code>description</code>.</li>
+        <li><strong>Attach existing disk</strong>
+            (<a href="https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--disk"><code>--disk</code></a>)
+            — line contains only <code>name</code>.
+            Keys: <code>name</code> (required).</li>
+    </ol>
 
     <p>
-        <strong>Cross-project resources:</strong> Snapshots are global resources in GCP.
-        To use a snapshot from a different project, specify a relative path
-        (e.g. <code>projects/{project}/global/snapshots/{name}</code>) or the full resource URI
-        from the Compute API (e.g. <code>https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots/{name}</code>).
-        To attach an existing disk from a different project or region, use its relative path or full resource URI.
-        The configured service account must have appropriate IAM permissions on the source project.
+        <strong>Common keys</strong> (all modes):
+        <code>device-name</code>,
+        <code>mode</code> (<code>ro</code> | <code>rw</code>, default <code>rw</code>),
+        <code>interface</code> (<code>SCSI</code> | <code>NVME</code>),
+        <code>auto-delete</code> (<code>yes</code> | <code>no</code>, default <code>yes</code>).
     </p>
+
+    <p><strong>Examples:</strong></p>
+    <pre>source-snapshot=my-data-snapshot,size=100,type=pd-ssd,auto-delete=yes
+size=200,type=pd-ssd,name=scratch-disk,auto-delete=yes
+name=shared-data-disk,mode=ro,auto-delete=no</pre>
+
     <p>
+        Short names for <code>source-snapshot</code>, <code>type</code>, and <code>name</code> are
+        automatically qualified to the instance's project and zone. For cross-project resources, use a
+        relative path (e.g. <code>projects/{project}/global/snapshots/{name}</code>) or full resource URI
+        (e.g. <code>https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots/{name}</code>).
         Mounting disks inside the VM must be done via the startup script.
-        Leave empty to not attach any additional disks.
     </p>
 </div>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -206,7 +206,7 @@ public class InstanceConfigurationTest {
         r.assertEqualBeans(
                 want,
                 got,
-                "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,acceleratorConfiguration,networkConfiguration,networkInterfaceIpStackMode,networkTags,serviceAccountEmail,minimumNumberOfInstances,minimumNumberOfSpareInstances");
+                "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,diskMapping,acceleratorConfiguration,networkConfiguration,networkInterfaceIpStackMode,networkTags,serviceAccountEmail,minimumNumberOfInstances,minimumNumberOfSpareInstances");
     }
 
     @Test
@@ -268,6 +268,7 @@ public class InstanceConfigurationTest {
         assertEquals(SERVICE_ACCOUNT_EMAIL, instance.getServiceAccounts().get(0).getEmail());
 
         // Disks
+        assertEquals(1, instance.getDisks().size());
         assertEquals(BOOT_DISK_AUTODELETE, instance.getDisks().get(0).getAutoDelete());
         assertTrue(instance.getDisks().get(0).getBoot());
         assertEquals(
@@ -371,6 +372,40 @@ public class InstanceConfigurationTest {
                 .runAsUser(RUN_AS_USER)
                 .oneShot(false)
                 .template(null);
+    }
+
+    @Test
+    public void testDiskMappingAttachesDisks() throws Exception {
+        var instance = instanceConfigurationBuilder()
+                .diskMapping("source-snapshot=snap-a,size=50,type=pd-ssd,auto-delete=yes\n"
+                        + "source-snapshot=snap-b,size=100,auto-delete=no")
+                .build()
+                .instance();
+
+        assertEquals(3, instance.getDisks().size());
+        assertTrue(instance.getDisks().get(0).getBoot());
+
+        var diskA = instance.getDisks().get(1);
+        assertFalse(diskA.getBoot());
+        assertTrue(diskA.getAutoDelete());
+        assertEquals("snap-a", diskA.getInitializeParams().getSourceSnapshot());
+        assertEquals(
+                "zones/" + ZONE + "/diskTypes/pd-ssd",
+                diskA.getInitializeParams().getDiskType());
+        assertEquals(Long.valueOf(50), diskA.getInitializeParams().getDiskSizeGb());
+
+        var diskB = instance.getDisks().get(2);
+        assertFalse(diskB.getBoot());
+        assertFalse(diskB.getAutoDelete());
+        assertEquals("snap-b", diskB.getInitializeParams().getSourceSnapshot());
+        assertEquals(Long.valueOf(100), diskB.getInitializeParams().getDiskSizeGb());
+    }
+
+    @Test
+    public void testNoDiskMappingOnlyBootDisk() throws Exception {
+        var instance = instanceConfigurationBuilder().build().instance();
+        assertEquals(1, instance.getDisks().size());
+        assertTrue(instance.getDisks().get(0).getBoot());
     }
 
     @Test

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -377,6 +377,7 @@ public class InstanceConfigurationTest {
     @Test
     public void testDiskMappingAttachesDisks() throws Exception {
         var instance = instanceConfigurationBuilder()
+                .cloud(cloud)
                 .diskMapping("source-snapshot=snap-a,size=50,type=pd-ssd,auto-delete=yes\n"
                         + "source-snapshot=snap-b,size=100,auto-delete=no")
                 .build()
@@ -388,7 +389,9 @@ public class InstanceConfigurationTest {
         var diskA = instance.getDisks().get(1);
         assertFalse(diskA.getBoot());
         assertTrue(diskA.getAutoDelete());
-        assertEquals("snap-a", diskA.getInitializeParams().getSourceSnapshot());
+        assertEquals(
+                "projects/" + PROJECT_ID + "/global/snapshots/snap-a",
+                diskA.getInitializeParams().getSourceSnapshot());
         assertEquals(
                 "zones/" + ZONE + "/diskTypes/pd-ssd",
                 diskA.getInitializeParams().getDiskType());
@@ -397,7 +400,9 @@ public class InstanceConfigurationTest {
         var diskB = instance.getDisks().get(2);
         assertFalse(diskB.getBoot());
         assertFalse(diskB.getAutoDelete());
-        assertEquals("snap-b", diskB.getInitializeParams().getSourceSnapshot());
+        assertEquals(
+                "projects/" + PROJECT_ID + "/global/snapshots/snap-b",
+                diskB.getInitializeParams().getSourceSnapshot());
         assertEquals(Long.valueOf(100), diskB.getInitializeParams().getDiskSizeGb());
     }
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudDiskMappingIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudDiskMappingIT.java
@@ -346,6 +346,7 @@ public class ComputeEngineCloudDiskMappingIT {
         Awaitility.await()
                 .timeout(CLEANUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .pollInterval(10, TimeUnit.SECONDS)
+                // GCP API throws 404 (wrapped in IOException) when the instance no longer exists
                 .until(() -> {
                     try {
                         client.getInstance(PROJECT_ID, ZONE, workerNodeName);
@@ -361,6 +362,7 @@ public class ComputeEngineCloudDiskMappingIT {
         Awaitility.await()
                 .timeout(CLEANUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .pollInterval(10, TimeUnit.SECONDS)
+                // GCP API throws 404 (wrapped in IOException) when the disk no longer exists
                 .until(() -> {
                     try {
                         compute.disks().get(PROJECT_ID, ZONE, diskName).execute();

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudDiskMappingIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudDiskMappingIT.java
@@ -50,7 +50,7 @@ import java.util.logging.Logger;
 import org.awaitility.Awaitility;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -84,8 +84,6 @@ public class ComputeEngineCloudDiskMappingIT {
     private static final String SNAPSHOT_SOURCE_DISK = "it-disk-mapping-snap-source";
 
     private static final String TEST_EXISTING_DISK = "it-disk-mapping-existing";
-
-    private static final String INPUT_MESSAGE = "disk-mapping-assertions-checkpoint";
 
     /** Timeout in seconds for waiting on GCP resource cleanup (instance/disk deletion). */
     private static final int CLEANUP_TIMEOUT_SECONDS = 300;
@@ -162,12 +160,12 @@ public class ComputeEngineCloudDiskMappingIT {
                 "node('" + GCE_LABEL + "') {\n"
                         + "  sh 'cat /mnt/disk-a/marker.txt'\n"
                         + "  sh 'cat /mnt/disk-b/marker.txt'\n"
-                        + "  input message: '" + INPUT_MESSAGE + "'\n"
+                        + "  semaphore 'snapshotDisk'\n"
                         + "}",
                 true));
 
         var build = p.scheduleBuild2(0).waitForStart();
-        j.waitForMessage(INPUT_MESSAGE, build);
+        SemaphoreStep.waitForStart("snapshotDisk/1", build);
         var buildLog = JenkinsRule.getLog(build);
 
         var workerNodeName = extractWorkerNodeName(buildLog);
@@ -190,7 +188,7 @@ public class ComputeEngineCloudDiskMappingIT {
             log.info("Snapshot disk " + i + " name: " + diskName);
         }
 
-        build.getAction(InputAction.class).getExecutions().get(0).proceed(null);
+        SemaphoreStep.success("snapshotDisk/1", null);
         j.waitForCompletion(build);
         j.assertBuildStatusSuccess(build);
 
@@ -233,12 +231,12 @@ public class ComputeEngineCloudDiskMappingIT {
         p.setDefinition(new CpsFlowDefinition(
                 "node('" + GCE_LABEL + "') {\n"
                         + "  sh 'cat /mnt/scratch/marker.txt'\n"
-                        + "  input message: '" + INPUT_MESSAGE + "'\n"
+                        + "  semaphore 'blankDisk'\n"
                         + "}",
                 true));
 
         var build = p.scheduleBuild2(0).waitForStart();
-        j.waitForMessage(INPUT_MESSAGE, build);
+        SemaphoreStep.waitForStart("blankDisk/1", build);
         var buildLog = JenkinsRule.getLog(build);
 
         var workerNodeName = extractWorkerNodeName(buildLog);
@@ -255,7 +253,7 @@ public class ComputeEngineCloudDiskMappingIT {
         var blankDiskName = blankDiskSource.substring(blankDiskSource.lastIndexOf("/") + 1);
         log.info("Blank disk name: " + blankDiskName);
 
-        build.getAction(InputAction.class).getExecutions().get(0).proceed(null);
+        SemaphoreStep.success("blankDisk/1", null);
         j.waitForCompletion(build);
         j.assertBuildStatusSuccess(build);
 
@@ -297,12 +295,12 @@ public class ComputeEngineCloudDiskMappingIT {
         p.setDefinition(new CpsFlowDefinition(
                 "node('" + GCE_LABEL + "') {\n"
                         + "  sh 'cat /mnt/data/marker.txt'\n"
-                        + "  input message: '" + INPUT_MESSAGE + "'\n"
+                        + "  semaphore 'existingDisk'\n"
                         + "}",
                 true));
 
         var build = p.scheduleBuild2(0).waitForStart();
-        j.waitForMessage(INPUT_MESSAGE, build);
+        SemaphoreStep.waitForStart("existingDisk/1", build);
         var buildLog = JenkinsRule.getLog(build);
 
         var workerNodeName = extractWorkerNodeName(buildLog);
@@ -314,7 +312,7 @@ public class ComputeEngineCloudDiskMappingIT {
         assertThat("Instance should exist while build is paused", instance, is(notNullValue()));
         assertThat("Instance should have 2 disks (boot + existing)", instance.getDisks(), hasSize(2));
 
-        build.getAction(InputAction.class).getExecutions().get(0).proceed(null);
+        SemaphoreStep.success("existingDisk/1", null);
         j.waitForCompletion(build);
         j.assertBuildStatusSuccess(build);
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudDiskMappingIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudDiskMappingIT.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine.integration;
+
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.TEST_TIMEOUT_MULTIPLIER;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.ZONE;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.format;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.getLabel;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initClient;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCloud;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.initCredentials;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.instanceConfigurationBuilder;
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.teardownResources;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Disk;
+import com.google.api.services.compute.model.Operation;
+import com.google.api.services.compute.model.Snapshot;
+import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
+import com.google.common.collect.ImmutableList;
+import com.google.jenkins.plugins.computeengine.ComputeEngineCloud;
+import hudson.model.Node;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.awaitility.Awaitility;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Integration tests for the disk mapping feature, covering all three disk attachment modes:
+ * <ol>
+ *   <li>Create disks from snapshots ({@code --create-disk} with {@code source-snapshot})</li>
+ *   <li>Create blank disks ({@code --create-disk} with {@code size} only)</li>
+ *   <li>Attach existing disks ({@code --disk} semantics with {@code name})</li>
+ * </ol>
+ *
+ * <p><b>Limitation:</b> Snapshot-based tests create snapshots from blank disks, so the startup
+ * script formats them before writing marker files. This verifies that the disk mapping plumbing
+ * works (parsing, GCP API call, device attachment, auto-delete) but not that pre-existing
+ * snapshot data is used by the build &mdash; which would require a prep instance to write data before
+ * snapshotting.
+ */
+public class ComputeEngineCloudDiskMappingIT {
+    private static final Logger log = Logger.getLogger(ComputeEngineCloudDiskMappingIT.class.getName());
+
+    private static final String GCE_LABEL = "gce";
+
+    private static final String TEST_SNAPSHOT_A = "it-disk-mapping-snap-a";
+    private static final String TEST_SNAPSHOT_B = "it-disk-mapping-snap-b";
+    private static final String SNAPSHOT_SOURCE_DISK = "it-disk-mapping-snap-source";
+
+    private static final String TEST_EXISTING_DISK = "it-disk-mapping-existing";
+
+    private static final String INPUT_MESSAGE = "disk-mapping-assertions-checkpoint";
+
+    /** Timeout in seconds for waiting on GCP resource cleanup (instance/disk deletion). */
+    private static final int CLEANUP_TIMEOUT_SECONDS = 300;
+
+    @ClassRule
+    public static Timeout timeout = new Timeout(25L * TEST_TIMEOUT_MULTIPLIER, TimeUnit.MINUTES);
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
+    private ComputeClient client;
+    private ComputeEngineCloud cloud;
+    private Compute compute;
+    private final Map<String, String> label = getLabel(ComputeEngineCloudDiskMappingIT.class);
+    private final List<String> snapshotsToDelete = new ArrayList<>();
+    private final List<String> disksToDelete = new ArrayList<>();
+
+    @Before
+    public void init() throws Exception {
+        log.info("init");
+        initCredentials(j);
+        cloud = initCloud(j);
+        client = initClient(j, label, log);
+        compute = cloud.getClientV2().getCompute();
+    }
+
+    @After
+    public void teardown() throws IOException {
+        log.info("teardown");
+        teardownResources(client, label, log);
+        snapshotsToDelete.forEach(this::deleteTestSnapshot);
+        disksToDelete.forEach(this::deleteTestDisk);
+    }
+
+    /**
+     * Verifies that multiple disks (2 during the test) created from snapshots are attached to a one-shot instance,
+     * mountable via startup script, readable from a build step, and auto-deleted with the instance.
+     */
+    @Test
+    public void testSnapshotDisksAttachedMountedAndAutoDeleted() throws Exception {
+        createTestSnapshots();
+
+        var diskMapping = String.format(
+                "source-snapshot=%s,auto-delete=yes\nsource-snapshot=%s,auto-delete=yes",
+                snapshotSelfLink(TEST_SNAPSHOT_A), snapshotSelfLink(TEST_SNAPSHOT_B));
+
+        var startupScript = """
+                #!/bin/bash
+                mkfs.ext4 -F /dev/sdb
+                mkdir -p /mnt/disk-a
+                mount /dev/sdb /mnt/disk-a
+                echo 'snapshot-disk-a' > /mnt/disk-a/marker.txt
+                mkfs.ext4 -F /dev/sdc
+                mkdir -p /mnt/disk-b
+                mount /dev/sdc /mnt/disk-b
+                echo 'snapshot-disk-b' > /mnt/disk-b/marker.txt""";
+
+        cloud.setConfigurations(ImmutableList.of(instanceConfigurationBuilder()
+                .numExecutorsStr(NUM_EXECUTORS)
+                .labels(GCE_LABEL)
+                .oneShot(true)
+                .createSnapshot(false)
+                .template(NULL_TEMPLATE)
+                .googleLabels(label)
+                .diskMapping(diskMapping)
+                .startupScript(startupScript)
+                .build()));
+
+        var p = j.createProject(WorkflowJob.class, "snapshot-disk-test");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('" + GCE_LABEL + "') {\n"
+                        + "  sh 'cat /mnt/disk-a/marker.txt'\n"
+                        + "  sh 'cat /mnt/disk-b/marker.txt'\n"
+                        + "  input message: '" + INPUT_MESSAGE + "'\n"
+                        + "}",
+                true));
+
+        var build = p.scheduleBuild2(0).waitForStart();
+        j.waitForMessage(INPUT_MESSAGE, build);
+        var buildLog = JenkinsRule.getLog(build);
+
+        var workerNodeName = extractWorkerNodeName(buildLog);
+        log.info("Build paused on node: " + workerNodeName);
+
+        j.assertLogContains("snapshot-disk-a", build);
+        j.assertLogContains("snapshot-disk-b", build);
+
+        var instance = client.getInstance(PROJECT_ID, ZONE, workerNodeName);
+        assertThat("Instance should exist while build is paused", instance, is(notNullValue()));
+        assertThat("Instance should have 3 disks (boot + 2 snapshot)", instance.getDisks(), hasSize(3));
+        assertThat("First disk should be boot", instance.getDisks().get(0).getBoot(), is(true));
+
+        var snapshotDiskNames = new ArrayList<String>();
+        for (int i = 1; i <= 2; i++) {
+            var diskSource = instance.getDisks().get(i).getSource();
+            assertThat("Snapshot disk " + i + " should have a source", diskSource, is(notNullValue()));
+            var diskName = diskSource.substring(diskSource.lastIndexOf("/") + 1);
+            snapshotDiskNames.add(diskName);
+            log.info("Snapshot disk " + i + " name: " + diskName);
+        }
+
+        build.getAction(InputAction.class).getExecutions().get(0).proceed(null);
+        j.waitForCompletion(build);
+        j.assertBuildStatusSuccess(build);
+
+        waitForOneShotCleanup(workerNodeName);
+
+        for (var diskName : snapshotDiskNames) {
+            waitForDiskDeletion(diskName);
+            log.info("Snapshot disk auto-deleted: " + diskName);
+        }
+    }
+
+    /**
+     * Verifies that a blank disk (no snapshot, no existing disk) is created from just
+     * {@code size} and {@code device-name}, formatted and mounted via startup script,
+     * readable from a build step, and auto-deleted with the instance.
+     */
+    @Test
+    public void testBlankDiskCreatedAndMounted() throws Exception {
+        var diskMapping = "size=10,type=pd-standard,device-name=scratch,auto-delete=yes";
+
+        var startupScript = """
+                #!/bin/bash
+                mkfs.ext4 -F /dev/disk/by-id/google-scratch
+                mkdir -p /mnt/scratch
+                mount /dev/disk/by-id/google-scratch /mnt/scratch
+                echo 'blank-disk-ok' > /mnt/scratch/marker.txt""";
+
+        cloud.setConfigurations(ImmutableList.of(instanceConfigurationBuilder()
+                .numExecutorsStr(NUM_EXECUTORS)
+                .labels(GCE_LABEL)
+                .oneShot(true)
+                .createSnapshot(false)
+                .template(NULL_TEMPLATE)
+                .googleLabels(label)
+                .diskMapping(diskMapping)
+                .startupScript(startupScript)
+                .build()));
+
+        var p = j.createProject(WorkflowJob.class, "blank-disk-test");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('" + GCE_LABEL + "') {\n"
+                        + "  sh 'cat /mnt/scratch/marker.txt'\n"
+                        + "  input message: '" + INPUT_MESSAGE + "'\n"
+                        + "}",
+                true));
+
+        var build = p.scheduleBuild2(0).waitForStart();
+        j.waitForMessage(INPUT_MESSAGE, build);
+        var buildLog = JenkinsRule.getLog(build);
+
+        var workerNodeName = extractWorkerNodeName(buildLog);
+        log.info("Build paused on node: " + workerNodeName);
+
+        j.assertLogContains("blank-disk-ok", build);
+
+        var instance = client.getInstance(PROJECT_ID, ZONE, workerNodeName);
+        assertThat("Instance should exist while build is paused", instance, is(notNullValue()));
+        assertThat("Instance should have 2 disks (boot + blank)", instance.getDisks(), hasSize(2));
+
+        var blankDiskSource = instance.getDisks().get(1).getSource();
+        assertThat("Blank disk should have a source", blankDiskSource, is(notNullValue()));
+        var blankDiskName = blankDiskSource.substring(blankDiskSource.lastIndexOf("/") + 1);
+        log.info("Blank disk name: " + blankDiskName);
+
+        build.getAction(InputAction.class).getExecutions().get(0).proceed(null);
+        j.waitForCompletion(build);
+        j.assertBuildStatusSuccess(build);
+
+        waitForOneShotCleanup(workerNodeName);
+
+        waitForDiskDeletion(blankDiskName);
+        log.info("Blank disk auto-deleted: " + blankDiskName);
+    }
+
+    /**
+     * Verifies that an existing disk is attached to a one-shot instance using {@code --disk}
+     * semantics ({@code name=...}), mountable via startup script, and readable from a build step.
+     */
+    @Test
+    public void testAttachExistingDiskMountedAndReadable() throws Exception {
+        createTestExistingDisk();
+
+        var diskMapping = String.format("name=%s,device-name=data,auto-delete=no", existingDiskSelfLink());
+
+        var startupScript = """
+                #!/bin/bash
+                mkfs.ext4 -F /dev/disk/by-id/google-data
+                mkdir -p /mnt/data
+                mount /dev/disk/by-id/google-data /mnt/data
+                echo 'existing-disk-ok' > /mnt/data/marker.txt""";
+
+        cloud.setConfigurations(ImmutableList.of(instanceConfigurationBuilder()
+                .numExecutorsStr(NUM_EXECUTORS)
+                .labels(GCE_LABEL)
+                .oneShot(true)
+                .createSnapshot(false)
+                .template(NULL_TEMPLATE)
+                .googleLabels(label)
+                .diskMapping(diskMapping)
+                .startupScript(startupScript)
+                .build()));
+
+        var p = j.createProject(WorkflowJob.class, "attach-existing-disk-test");
+        p.setDefinition(new CpsFlowDefinition(
+                "node('" + GCE_LABEL + "') {\n"
+                        + "  sh 'cat /mnt/data/marker.txt'\n"
+                        + "  input message: '" + INPUT_MESSAGE + "'\n"
+                        + "}",
+                true));
+
+        var build = p.scheduleBuild2(0).waitForStart();
+        j.waitForMessage(INPUT_MESSAGE, build);
+        var buildLog = JenkinsRule.getLog(build);
+
+        var workerNodeName = extractWorkerNodeName(buildLog);
+        log.info("Build paused on node: " + workerNodeName);
+
+        j.assertLogContains("existing-disk-ok", build);
+
+        var instance = client.getInstance(PROJECT_ID, ZONE, workerNodeName);
+        assertThat("Instance should exist while build is paused", instance, is(notNullValue()));
+        assertThat("Instance should have 2 disks (boot + existing)", instance.getDisks(), hasSize(2));
+
+        build.getAction(InputAction.class).getExecutions().get(0).proceed(null);
+        j.waitForCompletion(build);
+        j.assertBuildStatusSuccess(build);
+
+        waitForOneShotCleanup(workerNodeName);
+
+        // Verify the existing disk was NOT deleted (auto-delete=no)
+        var disk = compute.disks().get(PROJECT_ID, ZONE, TEST_EXISTING_DISK).execute();
+        assertThat("Existing disk should survive instance deletion", disk, is(notNullValue()));
+        log.info("Existing disk survived instance deletion: " + TEST_EXISTING_DISK);
+    }
+
+    private String extractWorkerNodeName(String buildLog) {
+        return j.jenkins.getNodes().stream()
+                .map(Node::getNodeName)
+                .filter(name -> buildLog.contains("Running on " + name))
+                .findFirst()
+                .orElseThrow(
+                        () -> new AssertionError("Build log does not contain 'Running on <agent>'. Log:\n" + buildLog));
+    }
+
+    private void waitForOneShotCleanup(String workerNodeName) {
+        Awaitility.await()
+                .timeout(CLEANUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(10, TimeUnit.SECONDS)
+                .until(() -> j.jenkins.getNode(workerNodeName) == null);
+        log.info("One-shot node removed from Jenkins: " + workerNodeName);
+
+        Awaitility.await()
+                .timeout(CLEANUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(10, TimeUnit.SECONDS)
+                .until(() -> {
+                    try {
+                        client.getInstance(PROJECT_ID, ZONE, workerNodeName);
+                        return false;
+                    } catch (IOException e) {
+                        return true;
+                    }
+                });
+        log.info("GCP instance deleted: " + workerNodeName);
+    }
+
+    private void waitForDiskDeletion(String diskName) {
+        Awaitility.await()
+                .timeout(CLEANUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(10, TimeUnit.SECONDS)
+                .until(() -> {
+                    try {
+                        compute.disks().get(PROJECT_ID, ZONE, diskName).execute();
+                        return false;
+                    } catch (IOException e) {
+                        return true;
+                    }
+                });
+    }
+
+    private void createTestSnapshots() throws Exception {
+        // Clean up stale resources from previous failed runs
+        deleteTestSnapshot(TEST_SNAPSHOT_A);
+        deleteTestSnapshot(TEST_SNAPSHOT_B);
+        deleteTestDisk(SNAPSHOT_SOURCE_DISK);
+
+        log.info("Creating source disk " + SNAPSHOT_SOURCE_DISK);
+        var disk = new Disk();
+        disk.setName(SNAPSHOT_SOURCE_DISK);
+        disk.setSizeGb(10L);
+
+        var diskOp = compute.disks().insert(PROJECT_ID, ZONE, disk).execute();
+        disksToDelete.add(SNAPSHOT_SOURCE_DISK);
+        waitForZoneOperation(diskOp);
+        log.info("Source disk created");
+
+        for (var snapshotName : new String[] {TEST_SNAPSHOT_A, TEST_SNAPSHOT_B}) {
+            log.info("Creating snapshot " + snapshotName);
+            var snapshot = new Snapshot();
+            snapshot.setName(snapshotName);
+            var snapOp = compute.disks()
+                    .createSnapshot(PROJECT_ID, ZONE, SNAPSHOT_SOURCE_DISK, snapshot)
+                    .execute();
+            snapshotsToDelete.add(snapshotName);
+            waitForZoneOperation(snapOp);
+            log.info("Snapshot created: " + snapshotName);
+        }
+
+        log.info("Deleting source disk " + SNAPSHOT_SOURCE_DISK);
+        var deleteOp =
+                compute.disks().delete(PROJECT_ID, ZONE, SNAPSHOT_SOURCE_DISK).execute();
+        waitForZoneOperation(deleteOp);
+        disksToDelete.remove(SNAPSHOT_SOURCE_DISK);
+        log.info("Source disk deleted");
+    }
+
+    private void createTestExistingDisk() throws Exception {
+        // Clean up stale resource from previous failed runs
+        deleteTestDisk(TEST_EXISTING_DISK);
+
+        log.info("Creating existing disk " + TEST_EXISTING_DISK);
+        var disk = new Disk();
+        disk.setName(TEST_EXISTING_DISK);
+        disk.setSizeGb(10L);
+
+        var diskOp = compute.disks().insert(PROJECT_ID, ZONE, disk).execute();
+        disksToDelete.add(TEST_EXISTING_DISK);
+        waitForZoneOperation(diskOp);
+        log.info("Existing disk created: " + TEST_EXISTING_DISK);
+    }
+
+    private void deleteTestSnapshot(String snapshotName) {
+        try {
+            compute.snapshots().get(PROJECT_ID, snapshotName).execute();
+        } catch (IOException e) {
+            return;
+        }
+        try {
+            log.info("Deleting snapshot " + snapshotName);
+            compute.snapshots().delete(PROJECT_ID, snapshotName).execute();
+        } catch (IOException e) {
+            log.warning("Failed to delete snapshot: " + e.getMessage());
+        }
+    }
+
+    private void deleteTestDisk(String diskName) {
+        try {
+            compute.disks().get(PROJECT_ID, ZONE, diskName).execute();
+        } catch (IOException e) {
+            return;
+        }
+        try {
+            log.info("Deleting disk " + diskName);
+            compute.disks().delete(PROJECT_ID, ZONE, diskName).execute();
+        } catch (IOException e) {
+            log.warning("Failed to delete disk: " + e.getMessage());
+        }
+    }
+
+    private static String snapshotSelfLink(String snapshotName) {
+        return format("projects/%s/global/snapshots/" + snapshotName);
+    }
+
+    private static String existingDiskSelfLink() {
+        return format("projects/%s/zones/" + ZONE + "/disks/" + TEST_EXISTING_DISK);
+    }
+
+    private void waitForZoneOperation(Operation operation) throws Exception {
+        client.waitForOperationCompletion(PROJECT_ID, operation.getName(), operation.getZone(), 5 * 60 * 1000);
+    }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudDiskMappingIT.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/integration/ComputeEngineCloudDiskMappingIT.java
@@ -16,6 +16,7 @@
 
 package com.google.jenkins.plugins.computeengine.integration;
 
+import static com.google.jenkins.plugins.computeengine.integration.ITUtil.BOOT_DISK_IMAGE_NAME;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NULL_TEMPLATE;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.NUM_EXECUTORS;
 import static com.google.jenkins.plugins.computeengine.integration.ITUtil.PROJECT_ID;
@@ -34,7 +35,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.AttachedDisk;
+import com.google.api.services.compute.model.AttachedDiskInitializeParams;
 import com.google.api.services.compute.model.Disk;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Metadata;
+import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Snapshot;
 import com.google.cloud.graphite.platforms.plugin.client.ComputeClient;
@@ -68,11 +75,8 @@ import org.jvnet.hudson.test.JenkinsRule;
  *   <li>Attach existing disks ({@code --disk} semantics with {@code name})</li>
  * </ol>
  *
- * <p><b>Limitation:</b> Snapshot-based tests create snapshots from blank disks, so the startup
- * script formats them before writing marker files. This verifies that the disk mapping plumbing
- * works (parsing, GCP API call, device attachment, auto-delete) but not that pre-existing
- * snapshot data is used by the build &mdash; which would require a prep instance to write data before
- * snapshotting.
+ * <p>Snapshot and existing-disk tests use a throwaway <em>prep VM</em> to write marker data to the
+ * disk before snapshotting or attaching.
  */
 public class ComputeEngineCloudDiskMappingIT {
     private static final Logger log = Logger.getLogger(ComputeEngineCloudDiskMappingIT.class.getName());
@@ -81,9 +85,12 @@ public class ComputeEngineCloudDiskMappingIT {
 
     private static final String TEST_SNAPSHOT_A = "it-disk-mapping-snap-a";
     private static final String TEST_SNAPSHOT_B = "it-disk-mapping-snap-b";
-    private static final String SNAPSHOT_SOURCE_DISK = "it-disk-mapping-snap-source";
+    private static final String SNAPSHOT_SOURCE_DISK_A = "it-disk-mapping-snap-source-a";
+    private static final String SNAPSHOT_SOURCE_DISK_B = "it-disk-mapping-snap-source-b";
 
     private static final String TEST_EXISTING_DISK = "it-disk-mapping-existing";
+
+    private static final String PREP_VM_NAME = "it-disk-mapping-prep-vm";
 
     /** Timeout in seconds for waiting on GCP resource cleanup (instance/disk deletion). */
     private static final int CLEANUP_TIMEOUT_SECONDS = 300;
@@ -117,6 +124,7 @@ public class ComputeEngineCloudDiskMappingIT {
     public void teardown() throws IOException {
         log.info("teardown");
         teardownResources(client, label, log);
+        deletePrepVm();
         snapshotsToDelete.forEach(this::deleteTestSnapshot);
         disksToDelete.forEach(this::deleteTestDisk);
     }
@@ -130,19 +138,16 @@ public class ComputeEngineCloudDiskMappingIT {
         createTestSnapshots();
 
         var diskMapping = String.format(
-                "source-snapshot=%s,auto-delete=yes\nsource-snapshot=%s,auto-delete=yes",
+                "source-snapshot=%s,device-name=snap-a,auto-delete=yes\nsource-snapshot=%s,device-name=snap-b,auto-delete=yes",
                 snapshotSelfLink(TEST_SNAPSHOT_A), snapshotSelfLink(TEST_SNAPSHOT_B));
 
         var startupScript = """
                 #!/bin/bash
-                mkfs.ext4 -F /dev/sdb
+                set -euo pipefail
                 mkdir -p /mnt/disk-a
-                mount /dev/sdb /mnt/disk-a
-                echo 'snapshot-disk-a' > /mnt/disk-a/marker.txt
-                mkfs.ext4 -F /dev/sdc
+                mount /dev/disk/by-id/google-snap-a /mnt/disk-a
                 mkdir -p /mnt/disk-b
-                mount /dev/sdc /mnt/disk-b
-                echo 'snapshot-disk-b' > /mnt/disk-b/marker.txt""";
+                mount /dev/disk/by-id/google-snap-b /mnt/disk-b""";
 
         cloud.setConfigurations(ImmutableList.of(instanceConfigurationBuilder()
                 .numExecutorsStr(NUM_EXECUTORS)
@@ -171,8 +176,8 @@ public class ComputeEngineCloudDiskMappingIT {
         var workerNodeName = extractWorkerNodeName(buildLog);
         log.info("Build paused on node: " + workerNodeName);
 
-        j.assertLogContains("snapshot-disk-a", build);
-        j.assertLogContains("snapshot-disk-b", build);
+        j.assertLogContains("SNAPSHOT_MARKER_A", build);
+        j.assertLogContains("SNAPSHOT_MARKER_B", build);
 
         var instance = client.getInstance(PROJECT_ID, ZONE, workerNodeName);
         assertThat("Instance should exist while build is paused", instance, is(notNullValue()));
@@ -275,10 +280,8 @@ public class ComputeEngineCloudDiskMappingIT {
 
         var startupScript = """
                 #!/bin/bash
-                mkfs.ext4 -F /dev/disk/by-id/google-data
                 mkdir -p /mnt/data
-                mount /dev/disk/by-id/google-data /mnt/data
-                echo 'existing-disk-ok' > /mnt/data/marker.txt""";
+                mount /dev/disk/by-id/google-data /mnt/data""";
 
         cloud.setConfigurations(ImmutableList.of(instanceConfigurationBuilder()
                 .numExecutorsStr(NUM_EXECUTORS)
@@ -306,7 +309,7 @@ public class ComputeEngineCloudDiskMappingIT {
         var workerNodeName = extractWorkerNodeName(buildLog);
         log.info("Build paused on node: " + workerNodeName);
 
-        j.assertLogContains("existing-disk-ok", build);
+        j.assertLogContains("EXISTING_DISK_MARKER", build);
 
         var instance = client.getInstance(PROJECT_ID, ZONE, workerNodeName);
         assertThat("Instance should exist while build is paused", instance, is(notNullValue()));
@@ -370,42 +373,56 @@ public class ComputeEngineCloudDiskMappingIT {
 
     private void createTestSnapshots() throws Exception {
         // Clean up stale resources from previous failed runs
+        deletePrepVm();
         deleteTestSnapshot(TEST_SNAPSHOT_A);
         deleteTestSnapshot(TEST_SNAPSHOT_B);
-        deleteTestDisk(SNAPSHOT_SOURCE_DISK);
+        deleteTestDisk(SNAPSHOT_SOURCE_DISK_A);
+        deleteTestDisk(SNAPSHOT_SOURCE_DISK_B);
 
-        log.info("Creating source disk " + SNAPSHOT_SOURCE_DISK);
-        var disk = new Disk();
-        disk.setName(SNAPSHOT_SOURCE_DISK);
-        disk.setSizeGb(10L);
-
-        var diskOp = compute.disks().insert(PROJECT_ID, ZONE, disk).execute();
-        disksToDelete.add(SNAPSHOT_SOURCE_DISK);
-        waitForZoneOperation(diskOp);
-        log.info("Source disk created");
-
-        for (var snapshotName : new String[] {TEST_SNAPSHOT_A, TEST_SNAPSHOT_B}) {
-            log.info("Creating snapshot " + snapshotName);
-            var snapshot = new Snapshot();
-            snapshot.setName(snapshotName);
-            var snapOp = compute.disks()
-                    .createSnapshot(PROJECT_ID, ZONE, SNAPSHOT_SOURCE_DISK, snapshot)
-                    .execute();
-            snapshotsToDelete.add(snapshotName);
-            waitForZoneOperation(snapOp);
-            log.info("Snapshot created: " + snapshotName);
+        // Create two source disks so each snapshot gets unique marker content
+        for (var diskName : new String[] {SNAPSHOT_SOURCE_DISK_A, SNAPSHOT_SOURCE_DISK_B}) {
+            log.info("Creating source disk " + diskName);
+            var disk = new Disk();
+            disk.setName(diskName);
+            disk.setSizeGb(10L);
+            var diskOp = compute.disks().insert(PROJECT_ID, ZONE, disk).execute();
+            disksToDelete.add(diskName);
+            waitForZoneOperation(diskOp);
+            log.info("Source disk created: " + diskName);
         }
 
-        log.info("Deleting source disk " + SNAPSHOT_SOURCE_DISK);
-        var deleteOp =
-                compute.disks().delete(PROJECT_ID, ZONE, SNAPSHOT_SOURCE_DISK).execute();
-        waitForZoneOperation(deleteOp);
-        disksToDelete.remove(SNAPSHOT_SOURCE_DISK);
-        log.info("Source disk deleted");
+        // Boot a single prep VM with both disks attached, writing different markers to each
+        populateSnapshotDisksViaPrepVm();
+
+        // Snapshot each source disk
+        var sourceAndSnapshot = Map.of(
+                SNAPSHOT_SOURCE_DISK_A, TEST_SNAPSHOT_A,
+                SNAPSHOT_SOURCE_DISK_B, TEST_SNAPSHOT_B);
+        for (var entry : sourceAndSnapshot.entrySet()) {
+            log.info("Creating snapshot " + entry.getValue() + " from " + entry.getKey());
+            var snapshot = new Snapshot();
+            snapshot.setName(entry.getValue());
+            var snapOp = compute.disks()
+                    .createSnapshot(PROJECT_ID, ZONE, entry.getKey(), snapshot)
+                    .execute();
+            snapshotsToDelete.add(entry.getValue());
+            waitForZoneOperation(snapOp);
+            log.info("Snapshot created: " + entry.getValue());
+        }
+
+        // Delete source disks (no longer needed once snapshots exist)
+        for (var diskName : new String[] {SNAPSHOT_SOURCE_DISK_A, SNAPSHOT_SOURCE_DISK_B}) {
+            log.info("Deleting source disk " + diskName);
+            var deleteOp = compute.disks().delete(PROJECT_ID, ZONE, diskName).execute();
+            waitForZoneOperation(deleteOp);
+            disksToDelete.remove(diskName);
+            log.info("Source disk deleted: " + diskName);
+        }
     }
 
     private void createTestExistingDisk() throws Exception {
-        // Clean up stale resource from previous failed runs
+        // Clean up stale resources from previous failed runs
+        deletePrepVm();
         deleteTestDisk(TEST_EXISTING_DISK);
 
         log.info("Creating existing disk " + TEST_EXISTING_DISK);
@@ -417,6 +434,139 @@ public class ComputeEngineCloudDiskMappingIT {
         disksToDelete.add(TEST_EXISTING_DISK);
         waitForZoneOperation(diskOp);
         log.info("Existing disk created: " + TEST_EXISTING_DISK);
+
+        populateDiskViaPrepVm(TEST_EXISTING_DISK, "EXISTING_DISK_MARKER: data written before attach");
+    }
+
+    /**
+     * Boots a prep VM with both snapshot source disks attached, writes a distinct marker file
+     * to each, then shuts down. One prep VM boot populates both disks.
+     */
+    private void populateSnapshotDisksViaPrepVm() throws Exception {
+        log.info("Booting prep VM to populate both snapshot source disks");
+
+        var startupScript = """
+                #!/bin/bash
+                set -euo pipefail
+                mkfs.ext4 -F /dev/disk/by-id/google-prep-disk-a
+                mkdir -p /mnt/disk-a
+                mount /dev/disk/by-id/google-prep-disk-a /mnt/disk-a
+                echo 'SNAPSHOT_MARKER_A: data written to disk-a before snapshotting' > /mnt/disk-a/marker.txt
+                umount /mnt/disk-a
+                mkfs.ext4 -F /dev/disk/by-id/google-prep-disk-b
+                mkdir -p /mnt/disk-b
+                mount /dev/disk/by-id/google-prep-disk-b /mnt/disk-b
+                echo 'SNAPSHOT_MARKER_B: data written to disk-b before snapshotting' > /mnt/disk-b/marker.txt
+                umount /mnt/disk-b
+                shutdown -h now
+                """;
+
+        bootPrepVmAndWait(
+                startupScript,
+                List.of(
+                        new AttachedDisk()
+                                .setSource(format("projects/%s/zones/" + ZONE + "/disks/" + SNAPSHOT_SOURCE_DISK_A))
+                                .setDeviceName("prep-disk-a")
+                                .setBoot(false)
+                                .setAutoDelete(false),
+                        new AttachedDisk()
+                                .setSource(format("projects/%s/zones/" + ZONE + "/disks/" + SNAPSHOT_SOURCE_DISK_B))
+                                .setDeviceName("prep-disk-b")
+                                .setBoot(false)
+                                .setAutoDelete(false)));
+    }
+
+    /**
+     * Boots a prep VM with a single data disk, writes a marker file, then shuts down.
+     */
+    private void populateDiskViaPrepVm(String diskName, String markerContent) throws Exception {
+        log.info("Booting prep VM to populate disk " + diskName);
+
+        var startupScript = """
+                #!/bin/bash
+                set -euo pipefail
+                mkfs.ext4 -F /dev/disk/by-id/google-prep-data
+                mkdir -p /mnt/data
+                mount /dev/disk/by-id/google-prep-data /mnt/data
+                echo '%s' > /mnt/data/marker.txt
+                umount /mnt/data
+                shutdown -h now
+                """.formatted(markerContent);
+
+        bootPrepVmAndWait(
+                startupScript,
+                List.of(new AttachedDisk()
+                        .setSource(format("projects/%s/zones/" + ZONE + "/disks/" + diskName))
+                        .setDeviceName("prep-data")
+                        .setBoot(false)
+                        .setAutoDelete(false)));
+    }
+
+    /**
+     * Boots a throwaway VM with the given startup script and data disks attached. Blocks until
+     * the VM reaches TERMINATED status (startup script called {@code shutdown -h now}), then
+     * deletes the VM.
+     */
+    private void bootPrepVmAndWait(String startupScript, List<AttachedDisk> dataDisks) throws Exception {
+        var bootDisk = new AttachedDisk()
+                .setBoot(true)
+                .setAutoDelete(true)
+                .setInitializeParams(new AttachedDiskInitializeParams()
+                        .setSourceImage(BOOT_DISK_IMAGE_NAME)
+                        .setDiskSizeGb(20L));
+
+        var allDisks = new ArrayList<AttachedDisk>();
+        allDisks.add(bootDisk);
+        allDisks.addAll(dataDisks);
+
+        var network = new NetworkInterface()
+                .setNetwork(format("projects/%s/global/networks/default"))
+                .setAccessConfigs(List.of(new AccessConfig().setType("ONE_TO_ONE_NAT")));
+
+        var metadata = new Metadata()
+                .setItems(List.of(new Metadata.Items().setKey("startup-script").setValue(startupScript)));
+
+        var instance = new Instance()
+                .setName(PREP_VM_NAME)
+                .setMachineType("zones/" + ZONE + "/machineTypes/e2-small")
+                .setDisks(allDisks)
+                .setNetworkInterfaces(List.of(network))
+                .setMetadata(metadata);
+
+        var insertOp = compute.instances().insert(PROJECT_ID, ZONE, instance).execute();
+        waitForZoneOperation(insertOp);
+        log.info("Prep VM created, waiting for startup script to complete (TERMINATED status)");
+
+        Awaitility.await()
+                .timeout(CLEANUP_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .pollInterval(10, TimeUnit.SECONDS)
+                .until(() -> {
+                    var vm = compute.instances()
+                            .get(PROJECT_ID, ZONE, PREP_VM_NAME)
+                            .execute();
+                    return "TERMINATED".equals(vm.getStatus());
+                });
+        log.info("Prep VM terminated (startup script complete)");
+
+        var deleteOp =
+                compute.instances().delete(PROJECT_ID, ZONE, PREP_VM_NAME).execute();
+        waitForZoneOperation(deleteOp);
+        log.info("Prep VM deleted");
+    }
+
+    private void deletePrepVm() {
+        try {
+            compute.instances().get(PROJECT_ID, ZONE, PREP_VM_NAME).execute();
+        } catch (IOException e) {
+            return;
+        }
+        try {
+            log.info("Deleting stale prep VM " + PREP_VM_NAME);
+            var op = compute.instances().delete(PROJECT_ID, ZONE, PREP_VM_NAME).execute();
+            waitForZoneOperation(op);
+        } catch (Exception e) {
+            log.warning("Failed to delete prep VM: " + e.getMessage());
+        }
     }
 
     private void deleteTestSnapshot(String snapshotName) {

--- a/src/test/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParserTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParserTest.java
@@ -59,7 +59,7 @@ public class DiskMappingParserTest {
         var disk = DiskMappingParser.parse(" source-snapshot = my-snapshot , size = 50 , type = pd-ssd ")
                 .get(0);
         assertEquals("my-snapshot", disk.getInitializeParams().getSourceSnapshot());
-        assertEquals(Long.valueOf(50), disk.getInitializeParams().getDiskSizeGb());
+        assertThat(disk.getInitializeParams().getDiskSizeGb(), is(50L));
         assertEquals("pd-ssd", disk.getInitializeParams().getDiskType());
     }
 

--- a/src/test/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParserTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParserTest.java
@@ -301,23 +301,49 @@ public class DiskMappingParserTest {
 
     @Test
     public void testNormalizeDiskSourceShortName() {
-        assertEquals("zones/us-east1-b/disks/my-disk", DiskMappingParser.normalizeDiskSource("my-disk", "us-east1-b"));
+        assertEquals(
+                "projects/my-project/zones/us-east1-b/disks/my-disk",
+                DiskMappingParser.normalizeDiskSource("my-disk", "my-project", "us-east1-b"));
     }
 
     @Test
     public void testNormalizeDiskSourceRelativePath() {
         var relativePath = "projects/myproject/zones/us-east1-b/disks/my-disk";
-        assertEquals(relativePath, DiskMappingParser.normalizeDiskSource(relativePath, "us-west1-a"));
+        assertEquals(relativePath, DiskMappingParser.normalizeDiskSource(relativePath, "other-project", "us-west1-a"));
     }
 
     @Test
     public void testNormalizeDiskSourceFullUrl() {
         var fullUrl = "https://compute.googleapis.com/compute/v1/projects/myproject/zones/us-east1-b/disks/my-disk";
-        assertEquals(fullUrl, DiskMappingParser.normalizeDiskSource(fullUrl, "us-west1-a"));
+        assertEquals(fullUrl, DiskMappingParser.normalizeDiskSource(fullUrl, "other-project", "us-west1-a"));
     }
 
     @Test
     public void testNormalizeDiskSourceNull() {
-        assertNull(DiskMappingParser.normalizeDiskSource(null, "us-east1-b"));
+        assertNull(DiskMappingParser.normalizeDiskSource(null, "my-project", "us-east1-b"));
+    }
+
+    @Test
+    public void testNormalizeSnapshotSourceShortName() {
+        assertEquals(
+                "projects/my-project/global/snapshots/my-snapshot",
+                DiskMappingParser.normalizeSnapshotSource("my-snapshot", "my-project"));
+    }
+
+    @Test
+    public void testNormalizeSnapshotSourceRelativePath() {
+        var relativePath = "projects/other-project/global/snapshots/my-snapshot";
+        assertEquals(relativePath, DiskMappingParser.normalizeSnapshotSource(relativePath, "my-project"));
+    }
+
+    @Test
+    public void testNormalizeSnapshotSourceFullUrl() {
+        var fullUrl = "https://compute.googleapis.com/compute/v1/projects/other-project/global/snapshots/my-snapshot";
+        assertEquals(fullUrl, DiskMappingParser.normalizeSnapshotSource(fullUrl, "my-project"));
+    }
+
+    @Test
+    public void testNormalizeSnapshotSourceNull() {
+        assertNull(DiskMappingParser.normalizeSnapshotSource(null, "my-project"));
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParserTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParserTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class DiskMappingParserTest {
+
+    @Test
+    public void testNullInput() {
+        assertTrue(DiskMappingParser.parse(null).isEmpty());
+    }
+
+    @Test
+    public void testEmptyInput() {
+        assertTrue(DiskMappingParser.parse("").isEmpty());
+    }
+
+    @Test
+    public void testBlankInput() {
+        assertTrue(DiskMappingParser.parse("   ").isEmpty());
+    }
+
+    @Test
+    public void testMultipleDisksWithBlankLines() {
+        var disks = DiskMappingParser.parse("\nsource-snapshot=snap-a\n\nname=existing-disk\n");
+        assertEquals(2, disks.size());
+    }
+
+    @Test
+    public void testUnknownKeysIgnored() {
+        var disk = DiskMappingParser.parse("source-snapshot=snap,unknown-key=value,foo=bar")
+                .get(0);
+        assertEquals("snap", disk.getInitializeParams().getSourceSnapshot());
+    }
+
+    @Test
+    public void testWhitespaceAroundKeysAndValues() {
+        var disk = DiskMappingParser.parse(" source-snapshot = my-snapshot , size = 50 , type = pd-ssd ")
+                .get(0);
+        assertEquals("my-snapshot", disk.getInitializeParams().getSourceSnapshot());
+        assertEquals(Long.valueOf(50), disk.getInitializeParams().getDiskSizeGb());
+        assertEquals("pd-ssd", disk.getInitializeParams().getDiskType());
+    }
+
+    @Test
+    public void testCreateDiskAllFields() {
+        var disks = DiskMappingParser.parse(
+                "source-snapshot=my-snapshot,size=100,type=pd-ssd,name=my-disk,device-name=data,description=test disk,mode=ro,interface=NVME,auto-delete=no");
+        assertEquals(1, disks.size());
+        var disk = disks.get(0);
+        assertFalse(disk.getBoot());
+        assertFalse(disk.getAutoDelete());
+        assertEquals("READ_ONLY", disk.getMode());
+        assertEquals("data", disk.getDeviceName());
+        assertEquals("NVME", disk.getInterface());
+        var params = disk.getInitializeParams();
+        assertNotNull(params);
+        assertEquals("my-snapshot", params.getSourceSnapshot());
+        assertEquals(Long.valueOf(100), params.getDiskSizeGb());
+        assertEquals("pd-ssd", params.getDiskType());
+        assertEquals("my-disk", params.getDiskName());
+        assertEquals("test disk", params.getDescription());
+    }
+
+    @Test
+    public void testCreateDiskSnapshotOnly() {
+        var disk = DiskMappingParser.parse("source-snapshot=my-snapshot").get(0);
+        assertFalse(disk.getBoot());
+        assertTrue(disk.getAutoDelete());
+        assertNotNull(disk.getInitializeParams());
+        assertEquals("my-snapshot", disk.getInitializeParams().getSourceSnapshot());
+        assertNull(disk.getInitializeParams().getDiskSizeGb());
+        assertNull(disk.getInitializeParams().getDiskType());
+    }
+
+    @Test
+    public void testCreateDiskWithFullSnapshotUrl() {
+        var fullUrl = "https://compute.googleapis.com/compute/v1/projects/my-project/global/snapshots/my-snapshot";
+        var disk = DiskMappingParser.parse("source-snapshot=" + fullUrl).get(0);
+        assertEquals(fullUrl, disk.getInitializeParams().getSourceSnapshot());
+    }
+
+    @Test
+    public void testCreateDiskWithRelativeSnapshotPath() {
+        var relativePath = "projects/other-project/global/snapshots/my-snapshot";
+        var disk = DiskMappingParser.parse("source-snapshot=" + relativePath).get(0);
+        assertEquals(relativePath, disk.getInitializeParams().getSourceSnapshot());
+    }
+
+    @Test
+    public void testCreateBlankDiskWithSizeOnly() {
+        var disk = DiskMappingParser.parse("size=100").get(0);
+        assertFalse(disk.getBoot());
+        assertTrue(disk.getAutoDelete());
+        assertNotNull(disk.getInitializeParams());
+        assertEquals(Long.valueOf(100), disk.getInitializeParams().getDiskSizeGb());
+        assertNull(disk.getInitializeParams().getSourceSnapshot());
+    }
+
+    @Test
+    public void testCreateBlankDiskWithSizeAndType() {
+        var disk = DiskMappingParser.parse("size=200,type=pd-ssd").get(0);
+        assertEquals(Long.valueOf(200), disk.getInitializeParams().getDiskSizeGb());
+        assertEquals("pd-ssd", disk.getInitializeParams().getDiskType());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateDiskMissingRequiredKeys() {
+        DiskMappingParser.parse("type=pd-ssd,auto-delete=no");
+    }
+
+    @Test
+    public void testCreateDiskAutoDeleteDefaultsToTrue() {
+        var disk = DiskMappingParser.parse("source-snapshot=snap,size=50").get(0);
+        assertTrue(disk.getAutoDelete());
+    }
+
+    @Test
+    public void testCreateDiskAutoDeleteYes() {
+        var disk =
+                DiskMappingParser.parse("source-snapshot=snap,auto-delete=yes").get(0);
+        assertTrue(disk.getAutoDelete());
+    }
+
+    @Test
+    public void testCreateDiskAutoDeleteNo() {
+        var disk =
+                DiskMappingParser.parse("source-snapshot=snap,auto-delete=no").get(0);
+        assertFalse(disk.getAutoDelete());
+    }
+
+    @Test
+    public void testCreateDiskModeReadOnly() {
+        var disk = DiskMappingParser.parse("source-snapshot=snap,mode=ro").get(0);
+        assertEquals("READ_ONLY", disk.getMode());
+    }
+
+    @Test
+    public void testCreateDiskModeReadWrite() {
+        var disk = DiskMappingParser.parse("source-snapshot=snap,mode=rw").get(0);
+        assertEquals("READ_WRITE", disk.getMode());
+    }
+
+    @Test
+    public void testCreateDiskModeDefaultNull() {
+        var disk = DiskMappingParser.parse("source-snapshot=snap").get(0);
+        assertNull(disk.getMode());
+    }
+
+    @Test
+    public void testCreateDiskInterfaceNvme() {
+        var disk =
+                DiskMappingParser.parse("source-snapshot=snap,interface=NVME").get(0);
+        assertEquals("NVME", disk.getInterface());
+    }
+
+    @Test
+    public void testCreateDiskInterfaceScsi() {
+        var disk =
+                DiskMappingParser.parse("source-snapshot=snap,interface=SCSI").get(0);
+        assertEquals("SCSI", disk.getInterface());
+    }
+
+    @Test
+    public void testCreateDiskDeviceName() {
+        var disk = DiskMappingParser.parse("source-snapshot=snap,device-name=data-disk")
+                .get(0);
+        assertEquals("data-disk", disk.getDeviceName());
+    }
+
+    @Test
+    public void testCreateDiskDescription() {
+        var disk = DiskMappingParser.parse("source-snapshot=snap,description=cache volume")
+                .get(0);
+        assertEquals("cache volume", disk.getInitializeParams().getDescription());
+    }
+
+    @Test
+    public void testMultipleCreateDisks() {
+        var disks = DiskMappingParser.parse(
+                "source-snapshot=snap-a,size=50,type=pd-ssd\nsource-snapshot=snap-b,size=100,auto-delete=no");
+        assertEquals(2, disks.size());
+        assertEquals("snap-a", disks.get(0).getInitializeParams().getSourceSnapshot());
+        assertEquals("pd-ssd", disks.get(0).getInitializeParams().getDiskType());
+        assertEquals("snap-b", disks.get(1).getInitializeParams().getSourceSnapshot());
+        assertFalse(disks.get(1).getAutoDelete());
+    }
+
+    @Test
+    public void testAttachExistingDiskByName() {
+        var disk = DiskMappingParser.parse("name=my-data-disk").get(0);
+        assertFalse(disk.getBoot());
+        assertTrue(disk.getAutoDelete());
+        assertNull(disk.getInitializeParams());
+        assertEquals("my-data-disk", disk.getSource());
+    }
+
+    @Test
+    public void testAttachExistingDiskAllFields() {
+        var disk = DiskMappingParser.parse("name=my-data-disk,mode=ro,device-name=data,interface=NVME,auto-delete=no")
+                .get(0);
+        assertFalse(disk.getBoot());
+        assertFalse(disk.getAutoDelete());
+        assertEquals("my-data-disk", disk.getSource());
+        assertEquals("READ_ONLY", disk.getMode());
+        assertEquals("data", disk.getDeviceName());
+        assertEquals("NVME", disk.getInterface());
+        assertNull(disk.getInitializeParams());
+    }
+
+    @Test
+    public void testAttachExistingDiskByFullUrl() {
+        var fullUrl = "projects/myproject/zones/us-east1-b/disks/shared-data";
+        var disk = DiskMappingParser.parse("name=" + fullUrl + ",mode=ro").get(0);
+        assertEquals(fullUrl, disk.getSource());
+        assertEquals("READ_ONLY", disk.getMode());
+        assertNull(disk.getInitializeParams());
+    }
+
+    @Test
+    public void testAttachExistingDiskRegionalUri() {
+        var uri = "projects/myproject/regions/us-central1/disks/my-regional-disk";
+        var disk = DiskMappingParser.parse("name=" + uri + ",mode=ro").get(0);
+        assertEquals(uri, disk.getSource());
+    }
+
+    @Test
+    public void testAttachExistingDiskAutoDeleteDefaultsToTrue() {
+        var disk = DiskMappingParser.parse("name=my-disk").get(0);
+        assertTrue(disk.getAutoDelete());
+    }
+
+    @Test
+    public void testAttachExistingDiskAutoDeleteNo() {
+        var disk = DiskMappingParser.parse("name=my-disk,auto-delete=no").get(0);
+        assertFalse(disk.getAutoDelete());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAttachExistingDiskMissingName() {
+        DiskMappingParser.parse("mode=ro,auto-delete=no");
+    }
+
+    @Test
+    public void testMixedCreateAndAttachDisks() {
+        var disks = DiskMappingParser.parse("source-snapshot=snap-a,size=50,type=pd-ssd\nname=existing-disk,mode=ro");
+        assertEquals(2, disks.size());
+
+        var created = disks.get(0);
+        assertNotNull(created.getInitializeParams());
+        assertEquals("snap-a", created.getInitializeParams().getSourceSnapshot());
+
+        var attached = disks.get(1);
+        assertNull(attached.getInitializeParams());
+        assertEquals("existing-disk", attached.getSource());
+        assertEquals("READ_ONLY", attached.getMode());
+    }
+
+    @Test
+    public void testNormalizeDiskTypeShortName() {
+        assertEquals("zones/us-east1-b/diskTypes/pd-ssd", DiskMappingParser.normalizeDiskType("pd-ssd", "us-east1-b"));
+    }
+
+    @Test
+    public void testNormalizeDiskTypeRelativePath() {
+        var relativePath = "zones/us-east1-b/diskTypes/pd-balanced";
+        assertEquals(relativePath, DiskMappingParser.normalizeDiskType(relativePath, "us-west1-a"));
+    }
+
+    @Test
+    public void testNormalizeDiskTypeFullUrl() {
+        var fullUrl = "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-east1-b/diskTypes/pd-ssd";
+        assertEquals(fullUrl, DiskMappingParser.normalizeDiskType(fullUrl, "us-west1-a"));
+    }
+
+    @Test
+    public void testNormalizeDiskTypeNull() {
+        assertNull(DiskMappingParser.normalizeDiskType(null, "us-east1-b"));
+    }
+
+    @Test
+    public void testNormalizeDiskSourceShortName() {
+        assertEquals("zones/us-east1-b/disks/my-disk", DiskMappingParser.normalizeDiskSource("my-disk", "us-east1-b"));
+    }
+
+    @Test
+    public void testNormalizeDiskSourceRelativePath() {
+        var relativePath = "projects/myproject/zones/us-east1-b/disks/my-disk";
+        assertEquals(relativePath, DiskMappingParser.normalizeDiskSource(relativePath, "us-west1-a"));
+    }
+
+    @Test
+    public void testNormalizeDiskSourceFullUrl() {
+        var fullUrl = "https://compute.googleapis.com/compute/v1/projects/myproject/zones/us-east1-b/disks/my-disk";
+        assertEquals(fullUrl, DiskMappingParser.normalizeDiskSource(fullUrl, "us-west1-a"));
+    }
+
+    @Test
+    public void testNormalizeDiskSourceNull() {
+        assertNull(DiskMappingParser.normalizeDiskSource(null, "us-east1-b"));
+    }
+}

--- a/src/test/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParserTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/util/DiskMappingParserTest.java
@@ -16,6 +16,8 @@
 
 package com.google.jenkins.plugins.computeengine.util;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
Adding support for disk mapping for Agent VM creation; three capabilities come with it,
* a snapshot can be configured, when an agent VM is created, automatically a disk gets created and gets attached.
* an existing disk can be attached to the agent VM
* a new blank disk can be created and attached to the VM.
The disk formatting and mounting needs to be done by other mechanisms (example - startup script can be configured to do that).
All three options support deletion of the disk automatically as part of the agent VM deletion if `auto-delete=yes` is selected.

This feature will help to utilize pre-built caches in builds, or a build can dump certain cache data that can be used for other means etc.

The feature is analogous that existed in the EC2 plugin named as — Block Device Mapping. The naming is used in accordance with the GCP library apis here to just call it — Disk Mapping.
Reference links to ec2-plugin,
* parser: https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/util/DeviceMappingParser.java
* help text: https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/resources/hudson/plugins/ec2/SlaveTemplate/help-customDeviceMapping.html
* device mapping configured to ec2 launch library method: https://github.com/jenkinsci/ec2-plugin/blob/9c48b882174fe2131e7fe9611e3e03ecc68326f0/src/main/java/hudson/plugins/ec2/SlaveTemplate.java#L2743

All 3 of the disk mapping features can be used simultaneously as well. Essentially these follow the semantics of the GCP vm creation's `--create-disk` (https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--create-disk)  and `--disk` (https://docs.cloud.google.com/sdk/gcloud/reference/compute/instances/create#--disk) options.

|Description|Screenshot Jenkins|
|---|---|
|Help text rendering|<img width="1888" height="995" alt="image" src="https://github.com/user-attachments/assets/ad3d80fa-742b-4105-a206-6dd9b7b0cc2e" />|

### Testing done

**Automated testing**
* Integration tests are added ensuring the full lifecycle of disk mapping is functioning.
* Unit tests are added to check the nuances of the disk mapping parser.

**Manual testing**

Both the below manual testing use the following setup, one test uses forms to setup, another uses casc to setup.
Disk mapping,
```
source-snapshot=disk-mapping-test-snapshot,name=snapshot-created-disk,device-name=snapshot-created-disk,type=pd-balanced,auto-delete=yes
name=disk-mapping-persistent,device-name=existing-disk,mode=ro,auto-delete=no
size=100,name=new-blank-disk,device-name=new-blank-disk,mode=rw,type=pd-ssd,auto-delete=yes
```
Startup script,
```bash
#!/bin/bash
set -euo pipefail

# snapshot-created-disk (from snapshot, already formatted)
mkdir -p /mnt/snapshot-created-disk
mount /dev/disk/by-id/google-snapshot-created-disk /mnt/snapshot-created-disk

# existing-disk (read-only, already formatted)
mkdir -p /mnt/existing-disk
mount -o ro /dev/disk/by-id/google-existing-disk /mnt/existing-disk

# new-blank-disk (blank — needs formatting)
mkfs.ext4 -F /dev/disk/by-id/google-new-blank-disk
mkdir -p /mnt/new-blank-disk
mount /dev/disk/by-id/google-new-blank-disk /mnt/new-blank-disk
chmod 1777 /mnt/new-blank-disk
```
Pipeline script
```
node('gce') {
    sh '''
      cat /mnt/snapshot-created-disk/MARKER.txt
      cat /mnt/existing-disk/MARKER.txt
      echo "writing to the blank disk" > /mnt/new-blank-disk/MARKER.txt
      cat /mnt/new-blank-disk/MARKER.txt
      df -h
      lsblk
    '''
}
```
Build log output
```
Started by user Administrator
[Pipeline] Start of Pipeline
[Pipeline] node
Still waiting to schedule task
All nodes of label ‘gce’ are offline
Running on gbhat-26019-gce-h4dz46 in /tmp/workspace/using-gce
[Pipeline] {
[Pipeline] sh
+ cat /mnt/snapshot-created-disk/MARKER.txt
SNAPSHOT_MARKER: This file proves the snapshot contains data. Created 2026-04-02T16:58:46Z
+ cat /mnt/existing-disk/MARKER.txt
PERSISTENT_DISK_MARKER: This file proves the disk contains data. Created 2026-04-02T17:01:14Z
+ echo 'writing to the blank disk'
+ cat /mnt/new-blank-disk/MARKER.txt
writing to the blank disk
+ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        3.5G     0  3.5G   0% /dev
tmpfs           3.6G     0  3.6G   0% /dev/shm
tmpfs           1.5G  8.5M  1.4G   1% /run
efivarfs        256K   27K  225K  11% /sys/firmware/efi/efivars
/dev/sda2        50G  3.4G   47G   7% /
/dev/sda1       200M  7.3M  193M   4% /boot/efi
/dev/sdb        9.8G   28K  9.3G   1% /mnt/snapshot-created-disk
/dev/sdc        9.8G   28K  9.3G   1% /mnt/existing-disk
/dev/sdd         98G   28K   93G   1% /mnt/new-blank-disk
tmpfs           718M     0  718M   0% /run/user/1005
+ lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sda      8:0    0   50G  0 disk 
├─sda1   8:1    0  200M  0 part /boot/efi
└─sda2   8:2    0 49.8G  0 part /
sdb      8:16   0   10G  0 disk /mnt/snapshot-created-disk
sdc      8:32   0   10G  1 disk /mnt/existing-disk
sdd      8:48   0  100G  0 disk /mnt/new-blank-disk
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```
VM Disks
|Description|Screenshot|
|---|---|
|GCP VM Disk list|<img width="1492" height="780" alt="image" src="https://github.com/user-attachments/assets/bb7d45bd-773a-494a-bbf4-596c2a38daaa" />|

* Tested manually by attaching a snapshot, an existing disk, a new disk simultaneously, mounted them using a start-up, and seeing all 3 are appearing in the agent VM. (SSHed into the VM to check)
   ```bash
    [gbhat@gbhat-disk-test-zjqj97 ~]$ df -h
    Filesystem      Size  Used Avail Use% Mounted on
    devtmpfs        7.7G     0  7.7G   0% /dev
    tmpfs           7.7G     0  7.7G   0% /dev/shm
    tmpfs           3.1G  8.5M  3.1G   1% /run
    efivarfs        256K   27K  225K  11% /sys/firmware/efi/efivars
    /dev/sda2       200G  4.5G  196G   3% /
    /dev/sda1       200M  7.3M  193M   4% /boot/efi
    /dev/sdb        9.8G   28K  9.3G   1% /mnt/snapshot-created-disk
    /dev/sdc        9.8G   28K  9.3G   1% /mnt/existing-disk
    /dev/sdd         98G   28K   93G   1% /mnt/new-blank-disk
    tmpfs           1.6G     0  1.6G   0% /run/user/1005
    tmpfs           1.6G     0  1.6G   0% /run/user/1003
    [gbhat@gbhat-disk-test-zjqj97 ~]$ 
   ```
* Tested the CasC configuration in the context of CloudBees CI controller,
   configuration block, agent VM came with 3 disks as expected,

   ```yaml
   diskMapping: |
      source-snapshot=projects/{project}/global/snapshots/disk-mapping-test-snapshot,name=snapshot-created-disk,device-name=snapshot-created-disk,type=pd-balanced,auto-delete=yes
      name=projects/{project}/zones/us-central1-a/disks/disk-mapping-persistent,device-name=existing-disk,mode=ro,auto-delete=no
      size=100,name=new-blank-disk,device-name=new-blank-disk,mode=rw,type=pd-ssd,auto-delete=yes
   ```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
