### PR TITLE
Instance configurations should be a blank list instead of null

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -231,7 +231,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
      */
     @DataBoundSetter
     public void setConfigurations(List<InstanceConfiguration> configurations) {
-        this.configurations = configurations != null ? configurations : new ArrayList<>();
+        this.configurations = configurations;
         readResolve();
     }
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -231,7 +231,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
      */
     @DataBoundSetter
     public void setConfigurations(List<InstanceConfiguration> configurations) {
-        this.configurations = configurations;
+        this.configurations = configurations != null ? configurations : new ArrayList<>();
         readResolve();
     }
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -154,17 +154,18 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
     }
 
     protected Object readResolve() {
-        if (configurations != null) {
-            for (InstanceConfiguration configuration : configurations) {
-                configuration.setCloud(this);
-                configuration.readResolve();
-                // Apply a label that associates an instance configuration with
-                // this cloud provider
-                configuration.appendLabel(CLOUD_ID_LABEL_KEY, getInstanceId());
+        if (configurations == null) {
+            configurations = new ArrayList<>();
+        }
+        for (InstanceConfiguration configuration : configurations) {
+            configuration.setCloud(this);
+            configuration.readResolve();
+            // Apply a label that associates an instance configuration with
+            // this cloud provider
+            configuration.appendLabel(CLOUD_ID_LABEL_KEY, getInstanceId());
 
-                // Apply a label that identifies the name of this instance configuration
-                configuration.appendLabel(CONFIG_LABEL_KEY, configuration.getNamePrefix());
-            }
+            // Apply a label that identifies the name of this instance configuration
+            configuration.appendLabel(CONFIG_LABEL_KEY, configuration.getNamePrefix());
         }
         setInstanceId(instanceId);
         return this;
@@ -417,7 +418,7 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
 
     /** Gets all instances of {@link InstanceConfiguration} that has the matching {@link Label}. */
     public List<InstanceConfiguration> getInstanceConfigurations(Label label) throws NoConfigurationException {
-        if (configurations == null) {
+        if (configurations.isEmpty()) {
             throw new NoConfigurationException(
                     String.format("Cloud %s does not have any defined instance configurations.", this.getCloudName()));
         }

--- a/src/main/java/com/google/jenkins/plugins/computeengine/MinimumInstanceChecker.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/MinimumInstanceChecker.java
@@ -261,6 +261,7 @@ public class MinimumInstanceChecker {
         jenkins.clouds.stream()
                 .filter(ComputeEngineCloud.class::isInstance)
                 .map(ComputeEngineCloud.class::cast)
+                .filter(cloud -> cloud.getConfigurations() != null)
                 .forEach(cloud -> cloud.getConfigurations().forEach(config -> {
                     if (isMinimumInstancesInactive(config)) {
                         return;

--- a/src/main/java/com/google/jenkins/plugins/computeengine/MinimumInstanceChecker.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/MinimumInstanceChecker.java
@@ -261,7 +261,6 @@ public class MinimumInstanceChecker {
         jenkins.clouds.stream()
                 .filter(ComputeEngineCloud.class::isInstance)
                 .map(ComputeEngineCloud.class::cast)
-                .filter(cloud -> cloud.getConfigurations() != null)
                 .forEach(cloud -> cloud.getConfigurations().forEach(config -> {
                     if (isMinimumInstancesInactive(config)) {
                         return;


### PR DESCRIPTION
When a GCE cloud is created, but doesn't have any instance configurations yet, the periodic checker (default 10min) prints an NPE
```
2026-04-17 10:34:55.736+0000 [id=147]   SEVERE  h.i.i.InstallUncaughtExceptionHandler$DefaultUncaughtExceptionHandler#uncaughtException: A thread (GCE minimum instances checker thread/147) died unexpectedly due to an uncaught exception. This may leave your server corrupted and usually indicates a software bug.
java.lang.NullPointerException: Cannot invoke "java.util.List.forEach(java.util.function.Consumer)" because the return value of "com.google.jenkins.plugins.computeengine.ComputeEngineCloud.getConfigurations()" is null
        at PluginClassLoader for google-compute-engine//com.google.jenkins.plugins.computeengine.MinimumInstanceChecker.lambda$performCheck$1(MinimumInstanceChecker.java:264)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)
        at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
        at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
        at PluginClassLoader for google-compute-engine//com.google.jenkins.plugins.computeengine.MinimumInstanceChecker.performCheck(MinimumInstanceChecker.java:264)
```

This is not going to be noticed by users — as they would have at least 1 instance configuration. (unless the GCE cloud was test, or stale missed to delete)


### Testing done

After the fix no more errors. No other test required.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

