### PR TITLE
Add configurable SSH port for agent connections

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineComputerLauncher.java
@@ -60,8 +60,6 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
     private static final String AGENT_JAR = "agent.jar";
     private static final String GUEST_ATTRIBUTE_HOST_KEY_NAMESPACE = "hostkeys";
 
-    // TODO(google-compute-engine-plugin/issues/134): make this configurable
-    private static final int SSH_PORT = 22;
     private static final int SSH_TIMEOUT_MILLIS = 10000;
     private static final int SSH_SLEEP_MILLIS = 5000;
 
@@ -456,7 +454,7 @@ public abstract class ComputeEngineComputerLauncher extends ComputerLauncher {
                     }
                 }
 
-                int port = SSH_PORT;
+                int port = node.getSshPort();
                 logInfo(
                         computer,
                         listener,

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -56,6 +56,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
     private final boolean oneShot;
     private final boolean ignoreProxy;
     private final String javaExecPath;
+    private final int sshPort;
     private final GoogleKeyCredential sshKeyCredential;
     // Carried from InstanceConfiguration at provision time because the launcher has no access to whether
     // startup script exit reporting was configured
@@ -85,6 +86,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
             ComputerLauncher launcher,
             RetentionStrategy retentionStrategy,
             Integer launchTimeout,
+            int sshPort,
             // NOTE(craigatgoogle): Could not use Optional due to serialization req.
             @Nullable String javaExecPath,
             @Nullable GoogleKeyCredential sshKeyCredential,
@@ -111,6 +113,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
         this.oneShot = oneShot;
         this.ignoreProxy = ignoreProxy;
         this.terminateIdleDuringShutdown = terminateIdleDuringShutdown;
+        this.sshPort = sshPort;
         this.javaExecPath = javaExecPath;
         this.sshKeyCredential = sshKeyCredential;
         this.waitForStartupScript = waitForStartupScript;
@@ -162,6 +165,11 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
 
     public long getLaunchTimeoutMillis() {
         return launchTimeout * 1000L;
+    }
+
+    /** @return The configured SSH port, defaulting to 22 for backward compatibility. */
+    public int getSshPort() {
+        return sshPort > 0 ? sshPort : InstanceConfiguration.DEFAULT_SSH_PORT;
     }
 
     /** @return The configured Java executable path, or else the default Java binary. */

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -892,16 +892,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             if (value == null || value.isEmpty()) {
                 return FormValidation.ok();
             }
-            int port;
-            try {
-                port = Integer.parseInt(value);
-            } catch (NumberFormatException e) {
-                return FormValidation.error("SSH port must be a number");
-            }
-            if (port < 1 || port > 65535) {
-                return FormValidation.error("SSH port must be between 1 and 65535");
-            }
-            return FormValidation.ok();
+            return FormValidation.validateIntegerInRange(value, 1, 65535);
         }
 
         public ListBoxModel doFillRegionItems(

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -426,6 +426,9 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         if (preemptible && provisioningType == null) {
             provisioningType = new PreemptibleVm();
         }
+        if (sshPort == null) {
+            sshPort = DEFAULT_SSH_PORT;
+        }
         return this;
     }
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -103,6 +103,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     public static final Long DEFAULT_BOOT_DISK_SIZE_GB = 10L;
     public static final Integer DEFAULT_NUM_EXECUTORS = 1;
     public static final Integer DEFAULT_LAUNCH_TIMEOUT_SECONDS = 300;
+    public static final Integer DEFAULT_SSH_PORT = 22;
     public static final Integer DEFAULT_RETENTION_TIME_MINUTES = (DEFAULT_LAUNCH_TIMEOUT_SECONDS / 60) + 1;
     public static final String DEFAULT_RUN_AS_USER = "jenkins";
     public static final String METADATA_LINUX_STARTUP_SCRIPT_KEY = "startup-script";
@@ -186,6 +187,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     private String diskMapping;
     private String remoteFs;
     private String javaExecPath;
+    private Integer sshPort;
     private GoogleKeyCredential sshKeyCredential;
     private Map<String, String> googleLabels;
     private Integer numExecutors;
@@ -260,6 +262,11 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
     public void setBootDiskSizeGbStr(String bootDiskSizeGbStr) {
         this.bootDiskSizeGb = longOrDefault(bootDiskSizeGbStr, DEFAULT_BOOT_DISK_SIZE_GB);
         this.bootDiskSizeGbStr = this.bootDiskSizeGb.toString();
+    }
+
+    @DataBoundSetter
+    public void setSshPort(Integer sshPort) {
+        this.sshPort = (sshPort != null && sshPort >= 1 && sshPort <= 65535) ? sshPort : DEFAULT_SSH_PORT;
     }
 
     @DataBoundSetter
@@ -397,6 +404,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                     .launcher(launcher)
                     .retentionStrategy(new ComputeEngineRetentionStrategy(retentionTimeMinutes, oneShot))
                     .launchTimeout(getLaunchTimeoutMillis())
+                    .sshPort(sshPort)
                     .javaExecPath(javaExecPath)
                     .sshKeyCredential(sshKeyCredential)
                     .waitForStartupScript(notNullOrEmpty(startupScript) && notNullOrEmpty(resolveExitReporter()))
@@ -774,6 +782,10 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             return DEFAULT_RUN_AS_USER;
         }
 
+        public static Integer defaultSshPort() {
+            return DEFAULT_SSH_PORT;
+        }
+
         public static WindowsConfiguration defaultWindowsConfiguration() {
             return WindowsConfiguration.builder()
                     .passwordCredentialsId("")
@@ -872,6 +884,22 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         public FormValidation doCheckDescription(@QueryParameter String value) {
             if (value == null || value.isEmpty()) {
                 return FormValidation.error("A description is required");
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckSshPort(@QueryParameter String value) {
+            if (value == null || value.isEmpty()) {
+                return FormValidation.ok();
+            }
+            int port;
+            try {
+                port = Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                return FormValidation.error("SSH port must be a number");
+            }
+            if (port < 1 || port > 65535) {
+                return FormValidation.error("SSH port must be between 1 and 65535");
             }
             return FormValidation.ok();
         }
@@ -1311,6 +1339,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             instanceConfiguration.setCustomMetadata(this.customMetadata);
             instanceConfiguration.setRemoteFs(this.remoteFs);
             instanceConfiguration.setJavaExecPath(this.javaExecPath);
+            instanceConfiguration.setSshPort(this.sshPort);
             instanceConfiguration.setCloud(this.cloud);
             if (googleLabels != null) {
                 instanceConfiguration.appendLabels(this.googleLabels);

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/config.jelly
@@ -72,6 +72,9 @@
             <f:entry title="${%Ignore Jenkins Proxy?}" field="ignoreProxy">
                 <f:checkbox/>
             </f:entry>
+            <f:entry title="${%SSH Port}" field="sshPort">
+                <f:number default="${descriptor.defaultSshPort()}" min="1" max="65535"/>
+            </f:entry>
             <f:entry title="${%Run as user}" field="runAsUser">
                 <f:textbox default="${descriptor.defaultRunAsUser()}"/>
             </f:entry>

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-sshPort.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-sshPort.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2020 Google LLC
+ Copyright 2026 CloudBees, Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-sshPort.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-sshPort.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2026 Toship Sonkusare.
+ Copyright 2026 Toship Sonkusare
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-sshPort.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-sshPort.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2026 CloudBees, Inc.
+ Copyright 2026 Toship Sonkusare.
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-sshPort.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-sshPort.html
@@ -1,0 +1,17 @@
+<!--
+ Copyright 2020 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
+<div>
+    The SSH port to use when connecting to the agent instance. Defaults to <strong>22</strong> if not specified.
+    Change this if your instances run the SSH server on a non-standard port.
+</div>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -213,7 +213,7 @@ public class InstanceConfigurationTest {
         r.assertEqualBeans(
                 want,
                 got,
-                "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,diskMapping,acceleratorConfiguration,networkConfiguration,networkInterfaceIpStackMode,networkTags,serviceAccountEmail,minimumNumberOfInstances,minimumNumberOfSpareInstances,shieldedVmConfiguration");
+                "namePrefix,region,zone,machineType,preemptible,windowsConfiguration,minCpuPlatform,startupScript,bootDiskType,bootDiskSourceImageName,bootDiskSourceImageProject,bootDiskSizeGb,diskMapping,acceleratorConfiguration,networkConfiguration,networkInterfaceIpStackMode,networkTags,serviceAccountEmail,minimumNumberOfInstances,minimumNumberOfSpareInstances,shieldedVmConfiguration,sshPort");
     }
 
     @Test
@@ -536,6 +536,62 @@ public class InstanceConfigurationTest {
         var script = "Install-WindowsFeature -Name Web-Server";
         assertThat(InstanceConfiguration.wrapWindowsStartupScript(script, null), is(script));
         assertThat(InstanceConfiguration.wrapWindowsStartupScript(script, ""), is(script));
+    }
+
+    @Test
+    public void testSshPortDefaultValue() {
+        InstanceConfiguration config = new InstanceConfiguration();
+        config.setSshPort(null);
+        assertEquals(InstanceConfiguration.DEFAULT_SSH_PORT, config.getSshPort());
+    }
+
+    @Test
+    public void testSshPortCustomValue() {
+        InstanceConfiguration config = new InstanceConfiguration();
+        config.setSshPort(2222);
+        assertEquals(Integer.valueOf(2222), config.getSshPort());
+    }
+
+    @Test
+    public void testSshPortInvalidValuesFallBackToDefault() {
+        InstanceConfiguration config = new InstanceConfiguration();
+
+        config.setSshPort(0);
+        assertEquals(InstanceConfiguration.DEFAULT_SSH_PORT, config.getSshPort());
+
+        config.setSshPort(-1);
+        assertEquals(InstanceConfiguration.DEFAULT_SSH_PORT, config.getSshPort());
+
+        config.setSshPort(70000);
+        assertEquals(InstanceConfiguration.DEFAULT_SSH_PORT, config.getSshPort());
+    }
+
+    @Test
+    public void testSshPortBoundaryValues() {
+        InstanceConfiguration config = new InstanceConfiguration();
+
+        config.setSshPort(1);
+        assertEquals(Integer.valueOf(1), config.getSshPort());
+
+        config.setSshPort(65535);
+        assertEquals(Integer.valueOf(65535), config.getSshPort());
+    }
+
+    @Test
+    public void descriptorSshPortValidation() {
+        InstanceConfiguration.DescriptorImpl d = new InstanceConfiguration.DescriptorImpl();
+
+        assertEquals(FormValidation.Kind.OK, d.doCheckSshPort(null).kind);
+        assertEquals(FormValidation.Kind.OK, d.doCheckSshPort("").kind);
+        assertEquals(FormValidation.Kind.OK, d.doCheckSshPort("22").kind);
+        assertEquals(FormValidation.Kind.OK, d.doCheckSshPort("1").kind);
+        assertEquals(FormValidation.Kind.OK, d.doCheckSshPort("65535").kind);
+        assertEquals(FormValidation.Kind.OK, d.doCheckSshPort("2222").kind);
+
+        assertEquals(FormValidation.Kind.ERROR, d.doCheckSshPort("0").kind);
+        assertEquals(FormValidation.Kind.ERROR, d.doCheckSshPort("-1").kind);
+        assertEquals(FormValidation.Kind.ERROR, d.doCheckSshPort("65536").kind);
+        assertEquals(FormValidation.Kind.ERROR, d.doCheckSshPort("abc").kind);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds a configurable SSH port field to Instance Configuration (defaults to 22)
- Removes the hardcoded `SSH_PORT = 22` constant from `ComputeEngineComputerLauncher`
- Includes UI field, form validation (1-65535), inline help, and backward compatibility for existing serialized configs

Resolves [#134](https://github.com/jenkinsci/google-compute-engine-plugin/issues/134)

### Changes
- `InstanceConfiguration` - new `sshPort` field with `@DataBoundSetter`, descriptor validation (1-65535), builder support
- `ComputeEngineInstance` - stores `sshPort` with backward-compatible getter for older serialized configs
- `ComputeEngineComputerLauncher` - uses `node.getSshPort()` instead of hardcoded `SSH_PORT` constant
- `config.jelly` - SSH Port number field in Launch Configuration section
- `help-sshPort.html` - inline help

### Testing done

#### Automated Tests
Six tests in `InstanceConfigurationTest` cover the new SSH port logic:
| Test | What it verifies |
|---|---|
| `testSshPortDefaultValue` | `setSshPort(null)` falls back to default port 22 |
| `testSshPortCustomValue` | `setSshPort(2222)` stores and returns 2222 |
| `testSshPortInvalidValuesFallBackToDefault` | Out-of-range values (0, -1, 70000) all fall back to 22 |
| `testSshPortBoundaryValues` | Boundary ports 1 and 65535 are accepted |
| `descriptorSshPortValidation` | Form validation accepts valid ports (1, 22, 2222, 65535), rejects invalid input (0, -1, 65536, "abc"), and permits empty/null |
| `testConfigRoundtrip` | Updated to include `sshPort` — verifies the field survives a Jenkins save/load cycle through the UI form |
All tests pass via `mvn test -Dtest=InstanceConfigurationTest`.

#### Manual Testing
Launched Jenkins locally with `mvn hpi:run` and verified:
1. **UI field present**: The "SSH Port" field appears in the Launch Configuration section with a default value of 22
2. **Inline help**: The (?) icon next to the field displays the help text
3. **Validation feedback**: Entering invalid values (0, 70000, "abc") shows an error; valid ports (22, 2222, 443) show no error
<img width="1918" height="437" alt="image" src="https://github.com/user-attachments/assets/07881661-6182-476b-a8b0-c2a2f91d497c" />

<img width="1917" height="642" alt="image" src="https://github.com/user-attachments/assets/9d0f058d-aa92-4d98-a354-9f913a0de72e" />

4. **Persistence**: Set port to 2222, saved config, reopened — value persisted correctly
<img width="1920" height="565" alt="image" src="https://github.com/user-attachments/assets/3b973f1b-20e8-48fe-a6d5-24367be98079" />

5. **Default behavior**: Left the field at 22 (default), saved — behaves identically to previous plugin behavior


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
