### PR TITLE
Set `images.list` maxResults to 10k and make it configurable - default was 500

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -76,6 +76,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
 import jenkins.model.Jenkins;
+import jenkins.util.SystemProperties;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -117,6 +118,19 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             Invoke-RestMethod -Method PUT -Body "$($args[0])" `
               -Headers @{'Metadata-Flavor'='Google'} `
               -Uri "http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/startup-script/status\"""";
+    /**
+     * Upper bound on images returned from {@code images.list} when populating the
+     * boot-disk image dropdown. Avoids GCE's default server-side cap of 500 while
+     * staying well under the kind of payload size that would overwhelm Jetty or
+     * the browser for pathological projects.
+     * <p>
+     * Configurable via system property
+     * {@code com.google.jenkins.plugins.computeengine.InstanceConfiguration.listImagesMaxResults}.
+     * Default: {@code 10000}.
+     */
+    public static final int LIST_IMAGES_MAX_RESULTS =
+            SystemProperties.getInteger(InstanceConfiguration.class.getName() + ".listImagesMaxResults", 10_000);
+
     public static final List<String> KNOWN_IMAGE_PROJECTS = List.of(
             "centos-cloud",
             "coreos-cloud",
@@ -1059,8 +1073,8 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             items.add("");
             try {
                 var clientV2 = ClientUtil.createComputeClientV2(projectId, credentialsId);
-                List<Image> images = clientV2.listImages(projectId, Integer.MAX_VALUE);
-                log.info("listImages(maxResults=" + Integer.MAX_VALUE + ") returned " + images.size()
+                List<Image> images = clientV2.listImages(projectId, LIST_IMAGES_MAX_RESULTS);
+                log.fine(() -> "listImages(maxResults=" + LIST_IMAGES_MAX_RESULTS + ") returned " + images.size()
                         + " images for project " + projectId);
                 for (Image i : images) {
                     items.add(i.getName(), i.getSelfLink());

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -65,6 +65,7 @@ import hudson.util.ComboBoxModel;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1057,13 +1058,14 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
             ListBoxModel items = new ListBoxModel();
             items.add("");
             try {
-                ComputeClient compute = computeClient(context, credentialsId);
-                List<Image> images = compute.listImages(projectId);
-
+                var clientV2 = ClientUtil.createComputeClientV2(projectId, credentialsId);
+                List<Image> images = clientV2.listImages(projectId, Integer.MAX_VALUE);
+                log.info("listImages(maxResults=" + Integer.MAX_VALUE + ") returned " + images.size()
+                        + " images for project " + projectId);
                 for (Image i : images) {
                     items.add(i.getName(), i.getSelfLink());
                 }
-            } catch (IOException ioe) {
+            } catch (IOException | GeneralSecurityException e) {
                 items.clear();
                 items.add("Error retrieving images for project");
             } catch (IllegalArgumentException iae) {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/client/ComputeClientV2.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/client/ComputeClientV2.java
@@ -1,10 +1,12 @@
 package com.google.jenkins.plugins.computeengine.client;
 
 import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.Image;
 import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.InstancesScopedList;
 import com.google.api.services.compute.model.InstancesSetLabelsRequest;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -80,5 +82,19 @@ public class ComputeClientV2 {
                 .filter(Objects::nonNull)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Lists images in {@code imageProject} with an explicit {@code maxResults}, bypassing the
+     * archived gcp-plugin-core-java {@code ComputeClient#listImages} which silently truncates
+     * at the server default of 500.
+     *
+     * @see <a href="https://docs.cloud.google.com/compute/docs/reference/rest/v1/images/list#query-parameters">
+     *     images.list query parameters</a>
+     */
+    public List<Image> listImages(String imageProject, long maxResults) throws IOException {
+        var resp = compute.images().list(imageProject).setMaxResults(maxResults).execute();
+        List<Image> items = resp.getItems();
+        return items == null ? Collections.emptyList() : items;
     }
 }


### PR DESCRIPTION
Whenever a GCP project had more than 500 images, the list was truncated to 500 - due to GCP server side default is 500.
https://docs.cloud.google.com/compute/docs/reference/rest/v1/images/list#query-parameters

> The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)

This PR fixes by - `setMaxResults` to higher value (`Integer.MAX_VALUE`) when `images().list()`

**Testing**

Reproduced the issue, with a project having 828 images.
|Before|After|
|---|---|
|Log line: `2026-05-08 08:35:29.516+0000 [id=97]    INFO    c.g.j.p.c.InstanceConfiguration$DescriptorImpl#doFillBootDiskSourceImageNameItems: listImages() returned 500 images for project tiger-team-testing`|Log line: `2026-05-08 08:32:21.842+0000 [id=144]   INFO    c.g.j.p.c.InstanceConfiguration$DescriptorImpl#doFillBootDiskSourceImageNameItems: listImages(maxResults=2147483647) returned 828 images for project tiger-team-testing`|
| only up to 500 images <img width="1370" height="453" alt="image" src="https://github.com/user-attachments/assets/650344c0-0105-4624-aa28-959230a34a80" />|no missing images even beyond 500<img width="1150" height="1058" alt="image" src="https://github.com/user-attachments/assets/52e8d224-db53-422f-8ae9-a7a05c4c8af8" />|

* manual build running in jenkins works ✔️
* ran a couple of integration tests, works ✔️ 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed