### PR TITLE
Fix launch timeout being applied 1000x longer than configured

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -464,7 +464,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                     .labelString(labels)
                     .launcher(launcher)
                     .retentionStrategy(new ComputeEngineRetentionStrategy(retentionTimeMinutes, oneShot))
-                    .launchTimeout(getLaunchTimeoutMillis())
+                    .launchTimeout(launchTimeoutSeconds)
                     .sshPort(sshPort)
                     .javaExecPath(javaExecPath)
                     .sshKeyCredential(sshKeyCredential)

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
 import com.google.api.services.compute.model.AcceleratorType;
@@ -38,6 +39,7 @@ import com.google.api.services.compute.model.InstanceTemplate;
 import com.google.api.services.compute.model.MachineType;
 import com.google.api.services.compute.model.Metadata;
 import com.google.api.services.compute.model.Network;
+import com.google.api.services.compute.model.Operation;
 import com.google.api.services.compute.model.Region;
 import com.google.api.services.compute.model.Subnetwork;
 import com.google.api.services.compute.model.Zone;
@@ -683,5 +685,22 @@ public class InstanceConfigurationTest {
         assertFalse(config.isExhausted(ZONE));
         config.markExhausted(ZONE);
         assertTrue(config.isExhausted(ZONE));
+    }
+
+    @Test
+    public void testProvisionedNodeLaunchTimeoutIsInSeconds() throws Exception {
+        Mockito.when(cloud.getClient()).thenReturn(computeClient);
+        Mockito.when(computeClient.insertInstance(anyString(), any(Optional.class), any()))
+                .thenReturn(new Operation());
+        var config = instanceConfigurationBuilder().cloud(cloud).build();
+
+        ComputeEngineInstance node = config.provision();
+
+        // launchTimeoutSeconds must be carried into the node as seconds; passing millis here
+        // made getLaunchTimeoutMillis() multiply by 1000 twice (300s became ~3.5 days)
+        assertEquals(
+                Long.parseLong(LAUNCH_TIMEOUT_SECONDS_STR),
+                node.getLaunchTimeout().longValue());
+        assertEquals(Long.parseLong(LAUNCH_TIMEOUT_SECONDS_STR) * 1000L, node.getLaunchTimeoutMillis());
     }
 }


### PR DESCRIPTION
A configured launch timeout of 300 seconds actually waits ~3.5 days. `InstanceConfiguration.provision()` passes `getLaunchTimeoutMillis()` (seconds × 1000) into the node builder, but `ComputeEngineInstance.launchTimeout` is documented and consumed as **seconds** — its own `getLaunchTimeoutMillis()` multiplies by 1000 again. Every wait that uses `node.getLaunchTimeoutMillis()` (insert-operation wait, startup-script wait, SSH wait) runs with a timeout 1000× larger than configured.

In production we found 16 `Computer.threadPoolForRemoting` threads wedged for a week inside `ComputeClient.waitForOperationCompletion`, polling long-expired GCE operations (404 on every poll), with their nodes stuck offline in "connecting" state and the backing VMs kept alive indefinitely by `CleanLostNodesWork` label refreshes:

```
Computer.threadPoolForRemoting [#64] TIMED_WAITING
  com.google.cloud.graphite.platforms.plugin.client.ComputeClient.waitForOperationCompletion(ComputeClient.java:669)
  com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.launch(ComputeEngineComputerLauncher.java:195)
  hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:298)
```

The fix passes `launchTimeoutSeconds` to the builder, matching the field's documented unit.

Resolves #560

### Testing done

- New unit test `InstanceConfigurationTest#testProvisionedNodeLaunchTimeoutIsInSeconds` provisions a node from a configuration with a 100-second launch timeout and asserts the node reports 100 s / 100 000 ms. It fails before the fix (`expected:<100> but was:<100000>`) and passes after.
- Full `InstanceConfigurationTest` class passes (28/28).
- Verified in a production Jenkins instance (public OpenROAD CI): with the corrected timeout the launcher gives up after the configured 300 s and `terminateNode()` cleans up, instead of wedging threads for days.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
