### PR TITLE
Fix IllegalArgumentException in markExhausted for template-based instance configurations

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -497,10 +497,22 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
         log.info(String.format(
                 "Marking zone [%s] exhausted for machine type [%s] in config [%s] until %s; "
                         + "the next provisioning cycle will skip this zone and try the next candidate zone",
-                zone,
-                nameFromSelfLink(machineType),
-                description,
-                Instant.now().plus(ZONE_EXHAUSTION_COOLDOWN_DURATION)));
+                zone, machineTypeDisplayName(), description, Instant.now().plus(ZONE_EXHAUSTION_COOLDOWN_DURATION)));
+    }
+
+    /**
+     * Human-readable machine type for log messages. Template-based configurations leave {@code machineType}
+     * unset (it is only used when no template is configured), so fall back to the template name there;
+     * {@code ClientUtil.nameFromSelfLink} rejects empty input.
+     */
+    private String machineTypeDisplayName() {
+        if (!Strings.isNullOrEmpty(machineType)) {
+            return nameFromSelfLink(machineType);
+        }
+        if (!Strings.isNullOrEmpty(template)) {
+            return "template " + nameFromSelfLink(template);
+        }
+        return "unknown";
     }
 
     boolean isExhausted(String zone) {

--- a/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/InstanceConfigurationTest.java
@@ -675,6 +675,20 @@ public class InstanceConfigurationTest {
     }
 
     @Test
+    public void testMarkExhaustedDoesNotThrowForTemplateBasedConfiguration() {
+        // Template-based configurations leave machineType empty; markExhausted's log message
+        // used to call nameFromSelfLink(machineType) and threw IllegalArgumentException
+        var config = instanceConfigurationBuilder()
+                .machineType("")
+                .template(TEMPLATE_NAME)
+                .build();
+
+        config.markExhausted(ZONE);
+
+        assertTrue(config.isExhausted(ZONE));
+    }
+
+    @Test
     @LocalData
     public void testZoneExhaustionStateTransientFieldInitializedAfterLoad() {
         var cloud = (ComputeEngineCloud) r.jenkins.clouds.getByName("gce-unit-tests");


### PR DESCRIPTION
When a GCE capacity error (`ZONE_RESOURCE_POOL_EXHAUSTED`) hits an **instance-template-based** configuration, `markExhausted()` throws while formatting its log message:

```
java.lang.IllegalArgumentException
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:127)
    at com.google.cloud.graphite.platforms.plugin.client.util.ClientUtil.nameFromSelfLink(ClientUtil.java:84)
    at com.google.jenkins.plugins.computeengine.InstanceConfiguration.markExhausted(InstanceConfiguration.java:501)
    at com.google.jenkins.plugins.computeengine.ComputeEngineComputerLauncher.launch(ComputeEngineComputerLauncher.java:209)
    at hudson.slaves.SlaveComputer.lambda$_connect$0(SlaveComputer.java:298)
```

Template-based configurations leave `machineType` empty (it is only read when no template is set), and `nameFromSelfLink("")` rejects empty input. Consequences (hit in production during a real us-central1-a stockout):

- the exception escapes `launch()` before `terminateNode()` runs, so the dead node is relaunched in a loop by the retention strategy and Jenkins shows "Unexpected error in launching an agent. This is probably a bug in Jenkins" on every cycle;
- the zone is never marked exhausted, so the #555 fallback-zone feature never engages and the provisioner keeps hammering the stocked-out zone.

The fix guards the log message: use `machineType` when set, fall back to the template name for template-based configurations.

Resolves #561

### Testing done

- New unit test `InstanceConfigurationTest#testMarkExhaustedDoesNotThrowForTemplateBasedConfiguration` builds a configuration with an empty machine type and a template, calls `markExhausted`, and asserts the zone is marked. It fails before the fix (`IllegalArgumentException`) and passes after.
- Full `InstanceConfigurationTest` class passes (28/28).
- Verified in a production Jenkins instance (public OpenROAD CI): with `machineType` populated as a workaround, `markExhausted` succeeds and the fallback-zone logic provisioned correctly in another zone during a subsequent real stockout.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
