### PR TITLE
Remove agents that fail to connect within the launch timeout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -279,7 +279,7 @@ Instance configurations define what kind of VM to launch for a given set of Jenk
 
 | *Launch Timeout*
 | `launchTimeoutSecondsStr`
-| Seconds to wait for an agent to connect before giving up. Default: 300.
+| Seconds to wait for an agent to connect before giving up. Agents that never come online within this time are removed from Jenkins (and any corresponding VM is deleted). Default: 300.
 
 | *Use Internal IP*
 | `useInternalAddress`
@@ -754,7 +754,7 @@ The *Instance Cap* on the cloud limits total concurrent VMs across all instance 
 [[retention-and-termination]]
 ==== Retention and Termination
 
-Idle agents are terminated after the configured *Node Retention Time* (default: 6 minutes). The *Launch Timeout* (default: 300 seconds) controls how long the plugin waits for a new agent to connect before giving up.
+Idle agents are terminated after the configured *Node Retention Time* (default: 6 minutes). The *Launch Timeout* (default: 300 seconds) controls how long the plugin waits for a new agent to connect before giving up. Agents that never come online within the launch timeout are removed from Jenkins, and any corresponding GCP VM is deleted if still present.
 
 If *Terminate idle agents during shutdown* is enabled, idle agents are deleted when the Jenkins controller stops.
 

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineCloud.java
@@ -377,9 +377,22 @@ public class ComputeEngineCloud extends AbstractCloudImpl {
                                     System.currentTimeMillis() - startTime, node.getNodeName()));
                 } else {
                     log.log(Level.WARNING, String.format("No computer for node %s found", node.getNodeName()));
+                    node.terminateNeverOnline("no computer found");
                 }
             } catch (TimeoutException e) {
                 log.log(Level.WARNING, String.format("Timeout waiting for node %s to connect", node.getNodeName()), e);
+                node.terminateNeverOnline("connect timeout");
+            } catch (InterruptedException e) {
+                // Interruption says nothing about whether the VM will come online; leave cleanup of a
+                // node that never connects to the retention strategy.
+                log.log(
+                        Level.WARNING,
+                        String.format("Interrupted waiting for node %s to connect", node.getNodeName()),
+                        e);
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                log.log(Level.WARNING, String.format("Error waiting for node %s to connect", node.getNodeName()), e);
+                node.terminateNeverOnline("connect error");
             }
             return null;
         });

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstance.java
@@ -63,6 +63,9 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
     private final boolean waitForStartupScript;
     private Integer launchTimeout; // Seconds
     private Boolean connected;
+    /** Wall-clock time when this node was provisioned; used for never-online cleanup. */
+    private final long provisionedAtMillis;
+
     private transient ComputeEngineCloud cloud;
 
     @Builder
@@ -103,7 +106,8 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
                 launcher,
                 retentionStrategy,
                 Collections.emptyList());
-        this.launchTimeout = launchTimeout;
+        this.launchTimeout =
+                launchTimeout != null ? launchTimeout : InstanceConfiguration.DEFAULT_LAUNCH_TIMEOUT_SECONDS;
         this.zone = zone;
         this.cloudName = cloudName;
         this.sshUser = sshUser;
@@ -118,6 +122,7 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
         this.sshKeyCredential = sshKeyCredential;
         this.waitForStartupScript = waitForStartupScript;
         this.cloud = cloud;
+        this.provisionedAtMillis = System.currentTimeMillis();
     }
 
     @Override
@@ -161,6 +166,40 @@ public class ComputeEngineInstance extends AbstractCloudSlave {
 
     public void onConnected() {
         this.connected = true;
+    }
+
+    /** Initializes fields that may be missing after deserialization. */
+    protected Object readResolve() {
+        if (launchTimeout == null) {
+            launchTimeout = InstanceConfiguration.DEFAULT_LAUNCH_TIMEOUT_SECONDS;
+        }
+        return super.readResolve();
+    }
+
+    /** @return true if this agent has successfully come online at least once. */
+    boolean hasEverConnected() {
+        return Boolean.TRUE.equals(connected);
+    }
+
+    /**
+     * @return true if this node has been waiting longer than the configured launch timeout without
+     *     coming online. Returns false when provision time is unknown (e.g. pre-upgrade deserialize).
+     */
+    boolean isPastLaunchTimeout(long nowMillis) {
+        if (provisionedAtMillis <= 0) {
+            return false;
+        }
+        return nowMillis - provisionedAtMillis > getLaunchTimeoutMillis();
+    }
+
+    /** Terminates this node (and any corresponding GCP VM) after it failed to ever come online. */
+    void terminateNeverOnline(String reason) {
+        LOGGER.log(Level.WARNING, "Terminating never-online node {0} ({1})", new Object[] {getNodeName(), reason});
+        try {
+            terminate();
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to terminate never-online node " + getNodeName(), e);
+        }
     }
 
     public long getLaunchTimeoutMillis() {

--- a/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineRetentionStrategy.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/ComputeEngineRetentionStrategy.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
+import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.ExecutorListener;
 import hudson.model.Job;
@@ -56,10 +57,31 @@ public class ComputeEngineRetentionStrategy extends RetentionStrategy<ComputeEng
 
     @Override
     public long check(ComputeEngineComputer c) {
+        ComputeEngineInstance node = c.getNode();
+        if (shouldTerminateNeverOnline(node)) {
+            node.terminateNeverOnline("launch timeout");
+            return 1;
+        }
         if (MinimumInstanceChecker.shouldPreserve(c)) {
             return 1;
         }
         return delegate.check(c);
+    }
+
+    /**
+     * Agents that never came online do not count toward the min pool and should be removed once past
+     * the launch timeout. Skips agents whose age is unknown or that are already online.
+     */
+    static boolean shouldTerminateNeverOnline(ComputeEngineInstance node) {
+        return shouldTerminateNeverOnline(node, System.currentTimeMillis());
+    }
+
+    static boolean shouldTerminateNeverOnline(ComputeEngineInstance node, long nowMillis) {
+        if (node == null || node.hasEverConnected() || !node.isPastLaunchTimeout(nowMillis)) {
+            return false;
+        }
+        Computer computer = node.toComputer();
+        return computer == null || !computer.isOnline();
     }
 
     @Override

--- a/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
+++ b/src/main/java/com/google/jenkins/plugins/computeengine/InstanceConfiguration.java
@@ -464,7 +464,7 @@ public class InstanceConfiguration implements Describable<InstanceConfiguration>
                     .labelString(labels)
                     .launcher(launcher)
                     .retentionStrategy(new ComputeEngineRetentionStrategy(retentionTimeMinutes, oneShot))
-                    .launchTimeout(getLaunchTimeoutMillis())
+                    .launchTimeout(launchTimeoutSeconds)
                     .sshPort(sshPort)
                     .javaExecPath(javaExecPath)
                     .sshKeyCredential(sshKeyCredential)

--- a/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-launchTimeoutSecondsStr.html
+++ b/src/main/resources/com/google/jenkins/plugins/computeengine/InstanceConfiguration/help-launchTimeoutSecondsStr.html
@@ -13,4 +13,6 @@
 -->
 <div>
     The number of <strong>seconds</strong> a new node has to provision and come online.
+    If the agent never connects within this time, it is removed from Jenkins and any
+    corresponding GCP VM is deleted.
 </div>

--- a/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstanceNeverOnlineTest.java
+++ b/src/test/java/com/google/jenkins/plugins/computeengine/ComputeEngineInstanceNeverOnlineTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.jenkins.plugins.computeengine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import hudson.model.Computer;
+import hudson.model.Node;
+import hudson.model.TaskListener;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.RetentionStrategy;
+import hudson.slaves.SlaveComputer;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class ComputeEngineInstanceNeverOnlineTest {
+
+    private static final int LAUNCH_TIMEOUT_SECONDS = 30;
+    private static final long TIMEOUT_MILLIS = LAUNCH_TIMEOUT_SECONDS * 1000L;
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void launchTimeoutSecondsMatchConfigMillis() throws Exception {
+        InstanceConfiguration config = InstanceConfigurationTest.instanceConfigurationBuilder()
+                .launchTimeoutSecondsStr(String.valueOf(LAUNCH_TIMEOUT_SECONDS))
+                .build();
+        ComputeEngineInstance node = createNode(LAUNCH_TIMEOUT_SECONDS);
+
+        assertEquals(config.getLaunchTimeoutMillis(), node.getLaunchTimeoutMillis());
+        assertEquals(TIMEOUT_MILLIS, node.getLaunchTimeoutMillis());
+        assertEquals(Integer.valueOf(LAUNCH_TIMEOUT_SECONDS), node.getLaunchTimeout());
+    }
+
+    @Test
+    public void hasEverConnected_falseUntilOnConnected() throws Exception {
+        ComputeEngineInstance node = createNode(LAUNCH_TIMEOUT_SECONDS);
+        assertFalse(node.hasEverConnected());
+
+        node.onConnected();
+        assertTrue(node.hasEverConnected());
+    }
+
+    @Test
+    public void isPastLaunchTimeout_respectsAge() throws Exception {
+        ComputeEngineInstance node = createNode(LAUNCH_TIMEOUT_SECONDS);
+        long provisionedAt = node.getProvisionedAtMillis();
+
+        assertFalse(node.isPastLaunchTimeout(provisionedAt + node.getLaunchTimeoutMillis()));
+        assertTrue(node.isPastLaunchTimeout(provisionedAt + node.getLaunchTimeoutMillis() + 1));
+    }
+
+    @Test
+    public void isPastLaunchTimeout_unknownAgeIsNotPastTimeout() throws Exception {
+        // Nodes serialized before this field existed deserialize with provisionedAtMillis == 0.
+        ComputeEngineInstance node = createNode(LAUNCH_TIMEOUT_SECONDS);
+        setProvisionedAtMillis(node, 0);
+
+        assertFalse(node.isPastLaunchTimeout(System.currentTimeMillis()));
+    }
+
+    @Test
+    public void terminateNeverOnline_removesJenkinsNode() throws Exception {
+        ComputeEngineInstance node = createNode(LAUNCH_TIMEOUT_SECONDS);
+        r.jenkins.addNode(node);
+
+        node.terminateNeverOnline("test");
+
+        assertNull("never-online node should be removed from Jenkins", r.jenkins.getNode(node.getNodeName()));
+    }
+
+    @Test
+    public void shouldTerminateNeverOnline_onlyWhenNeverConnectedAndPastTimeout() throws Exception {
+        ComputeEngineInstance node = createNode(LAUNCH_TIMEOUT_SECONDS);
+        long provisionedAt = node.getProvisionedAtMillis();
+        long pastTimeout = provisionedAt + node.getLaunchTimeoutMillis() + 1;
+
+        assertFalse(ComputeEngineRetentionStrategy.shouldTerminateNeverOnline(null, pastTimeout));
+        assertFalse(ComputeEngineRetentionStrategy.shouldTerminateNeverOnline(
+                node, provisionedAt + node.getLaunchTimeoutMillis()));
+        assertTrue(ComputeEngineRetentionStrategy.shouldTerminateNeverOnline(node, pastTimeout));
+
+        node.onConnected();
+        assertFalse(ComputeEngineRetentionStrategy.shouldTerminateNeverOnline(node, pastTimeout));
+    }
+
+    @Test
+    public void shouldTerminateNeverOnline_skipsWhenComputerAlreadyOnline() throws Exception {
+        ComputeEngineInstance node = spy(createNode(LAUNCH_TIMEOUT_SECONDS));
+        long pastTimeout = node.getProvisionedAtMillis() + node.getLaunchTimeoutMillis() + 1;
+
+        Computer online = mock(Computer.class);
+        when(online.isOnline()).thenReturn(true);
+        doReturn(online).when(node).toComputer();
+
+        assertFalse(ComputeEngineRetentionStrategy.shouldTerminateNeverOnline(node, pastTimeout));
+    }
+
+    private static void setProvisionedAtMillis(ComputeEngineInstance node, long value) throws Exception {
+        Field field = ComputeEngineInstance.class.getDeclaredField("provisionedAtMillis");
+        field.setAccessible(true);
+        field.set(node, value);
+    }
+
+    private static ComputeEngineInstance createNode(int launchTimeoutSeconds) throws Exception {
+        return ComputeEngineInstance.builder()
+                .cloudName("test-cloud")
+                .name("never-online-" + System.nanoTime())
+                .zone("us-west1-a")
+                .nodeDescription("test")
+                .sshUser("jenkins")
+                .remoteFS("/tmp")
+                .windowsConfig(null)
+                .sshConfig(null)
+                .createSnapshot(false)
+                .oneShot(false)
+                .ignoreProxy(false)
+                .terminateIdleDuringShutdown(false)
+                .numExecutors(1)
+                .mode(Node.Mode.NORMAL)
+                .labelString("test")
+                .launcher(new NoOpLauncher())
+                .retentionStrategy(RetentionStrategy.NOOP)
+                .launchTimeout(launchTimeoutSeconds)
+                .sshPort(22)
+                .javaExecPath(null)
+                .sshKeyCredential(null)
+                .waitForStartupScript(false)
+                .cloud(null)
+                .build();
+    }
+
+    private static final class NoOpLauncher extends ComputerLauncher {
+        @Override
+        public void launch(SlaveComputer computer, TaskListener listener) throws IOException, InterruptedException {
+            // never connects
+        }
+    }
+}


### PR DESCRIPTION
If an agent fails to connect within the configured launch timeout it is removed from the agent list. Fixes #564 

### Testing done
In addition to the unit tests this was tested manually by spawning agents with a gpu until the bug described in #564 is encountered, then confirming that the agents were now removed from the list in jenkins.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
